### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
     hostname: database
     restart: always
     user: postgres
+    ports:
+      - "5433:5432"
     volumes:
       - /pgdata
 


### PR DESCRIPTION
Exposing port 5433:5432 to allow host connections to the container's database.  5433 is used in case there's an existing database running on the host machine.


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-15-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-compliance-enforcement-15-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)