### PR TITLE
Removed auth guard on health check endpoint

### DIFF
--- a/backend/src/app.controller.spec.ts
+++ b/backend/src/app.controller.spec.ts
@@ -22,12 +22,5 @@ describe('AppController', () => {
       expect(appController.getHello()).toBe('Hello Backend!');
     });
 
-    it('should ensure the JwtRoleGuard is applied to the app class', async () => {
-      const guards = Reflect.getMetadata('__guards__', AppController);
-      const guard = new (guards[0]);
-    
-      expect(guard).toBeInstanceOf(JwtRoleGuard);
-    });
-
   });
 });

--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -6,13 +6,9 @@ import {
 import { AppService } from './app.service';
 import { ApiTags } from '@nestjs/swagger';
 import { Public } from './auth/decorators/public.decorator';
-import { Roles } from './auth/decorators/roles.decorator';
-import { Role } from './enum/role.enum';
-import { JwtRoleGuard } from './auth/jwtrole.guard';
 
 @Controller()
 @ApiTags('Health Check')
-@UseGuards(JwtRoleGuard)
 export class AppController {
   constructor(private readonly appService: AppService) {}
 
@@ -24,13 +20,6 @@ export class AppController {
 
   @Get()
   getHelloPrivate(): string {
-    return this.appService.getHello();
-  }
-
-  @Get()
-  @Public()
-  @Roles(Role.COS_OFFICER)
-  getHelloAuth(): string {
     return this.appService.getHello();
   }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Removed the auth guard on the healthcheck endpoint.  Without this change, the healtcheck api will return a 401 error, and the lineness and readyness OpenShift probes will fail, which will result in the pods not starting up.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)



---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-19-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-compliance-enforcement-19-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-19-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-compliance-enforcement-19-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)