### PR TITLE
Compenf 608 refresh assignee list bug

### DIFF
--- a/frontend/src/app/components/containers/complaints/details/complaint-header.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-header.tsx
@@ -32,6 +32,7 @@ export const ComplaintHeader: FC<{ id: string; complaintType: string }> = ({
   } = useAppSelector(selectComplaintHeader(complaintType));
 
   const dispatch = useAppDispatch();
+  const assignText = officerAssigned === 'Not Assigned' ? 'Assign' : 'Reassign';
 
   const applyStatusClass = (state: string): string => {
 
@@ -68,8 +69,8 @@ export const ComplaintHeader: FC<{ id: string; complaintType: string }> = ({
         modalSize: "md",
         modalType: AssignOfficer,
         data: {
-          title: "Update status?",
-          description: "Status",
+          title: "Assign Complaint",
+          description: "Suggested Officers",
           complaint_identifier: id,
           complaint_type: complaintType,
           zone: zone
@@ -117,7 +118,7 @@ export const ComplaintHeader: FC<{ id: string; complaintType: string }> = ({
             <div className="comp-box-species-type">{species}</div>
           )}
           <div className="comp-box-actions">
-            <Button id="details_screen_assign_button" title="Assign to Officer" variant="outline-primary" onClick={openAsignOfficerModal}><span>Assign</span><BsPersonPlus/></Button>
+            <Button id="details_screen_assign_button" title="Assign to Officer" variant="outline-primary" onClick={openAsignOfficerModal}><span>{assignText}</span><BsPersonPlus/></Button>
             <Button id="details_screen_update_status_button" title="Update Status" variant="outline-primary"  onClick={openStatusChangeModal}>Update Status</Button>
           </div>
         </div>

--- a/frontend/src/app/components/modal/instances/assign-officer-modal.tsx
+++ b/frontend/src/app/components/modal/instances/assign-officer-modal.tsx
@@ -39,6 +39,7 @@ export const AssignOfficerModal: FC<AssignOfficerModalProps> = ({ close, submit,
   // assigns the selected officer to a complaint
   const handleSubmit = () => {
     setNewAssignee(selectedAssignee);
+
     if (selectedAssignee !== "") {
       dispatch(updateComplaintAssignee(userid, selectedAssignee as UUID, complaint_identifier, complaint_type));
       submit();
@@ -80,7 +81,7 @@ export const AssignOfficerModal: FC<AssignOfficerModalProps> = ({ close, submit,
           <Modal.Title style={{ fontSize: '20px' }}>{title}</Modal.Title>
         </Modal.Header>
       )}
-      <Modal.Body className="">
+      <Modal.Body>
       <div className="assign_officer_modal_profile_card">
         <div className="assign_officer_modal_profile_card_column">
           <div className="assign_officer_modal_profile_card_profile-picture">

--- a/frontend/src/app/components/modal/instances/assign-officer-modal.tsx
+++ b/frontend/src/app/components/modal/instances/assign-officer-modal.tsx
@@ -100,7 +100,7 @@ export const AssignOfficerModal: FC<AssignOfficerModalProps> = ({ close, submit,
       <div className="assign_officer_modal_subtitle">
         Suggested Officers
       </div>
-      {officersJson.map((val, key) => {
+      {officersJson?.map((val, key) => {
 
         const firstName = val.first_name;
         const lastName = val.last_name;

--- a/frontend/src/app/components/modal/modal.tsx
+++ b/frontend/src/app/components/modal/modal.tsx
@@ -12,6 +12,7 @@ import {
   selectModalType,
 } from "../../store/reducers/app";
 import { MODAL_COMPONENTS } from "./model-components";
+import { setOfficersInZone } from "../../store/reducers/assign-officers";
 
 export const ModalComponent: FC = () => {
   const dispatch = useAppDispatch();
@@ -33,6 +34,7 @@ export const ModalComponent: FC = () => {
   };
 
   const handleCloseModal = () => {
+    dispatch(setOfficersInZone({}));
     if(closingCallback){
       closingCallback()
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

When opening the "Assign Officers" modal, the previous list of officers no longer flashes before being refreshed with the officers in the zone of the selected complaint.

The "Assign" button on the details pages will now be labelled as "Reassign" if there's already an officer assigned.

# How Has This Been Tested?

- [x] Verified that the previous list of officers is cleared before opening the "assign officer" modal again
- [x] Verified that the "Assign" button on the details screen displays the text "Reassign" if the complaint is already assigned
- [x] Verified that the button label on the details screen updates when an officer is assigned



---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-71-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-compliance-enforcement-71-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)