### PR TITLE
Attractants are now populated on edit screen

### DIFF
--- a/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
@@ -158,7 +158,7 @@ export const ComplaintDetailsEdit: FC<ComplaintHeaderProps> = ({
       (referredByAgencyCode === undefined ? "" : referredByAgencyCode)
   );
   const selectedAttractants = attractantCodes.filter((option) =>
-    attractants?.some((attractant) => attractant.description === option.value)
+    attractants?.some((attractant) => attractant.code === option.value)
   );
   const selectedViolationTypeCode = violationTypeCodes.find(
     (option) => option.value === violationType

--- a/frontend/src/app/store/reducers/complaints.ts
+++ b/frontend/src/app/store/reducers/complaints.ts
@@ -303,9 +303,9 @@ export const selectComplaintDeails =
             const attractants = attractant_hwcr_xref.map(
               ({
                 attractant_hwcr_xref_guid: key,
-                attractant_code: { short_description: description },
+                attractant_code: {attractant_code: code, short_description: description },
               }: any): ComplaintDetailsAttractant => {
-                return { key, description };
+                return { key, code, description };
               }
             );
 

--- a/frontend/src/app/store/reducers/hwcr-complaints.ts
+++ b/frontend/src/app/store/reducers/hwcr-complaints.ts
@@ -184,9 +184,9 @@ export const selectComplaintDetails = (state: RootState): ComplaintDetails => {
   const attractants = attractant_hwcr_xref.map(
     ({
       attractant_hwcr_xref_guid: key,
-      attractant_code: { short_description: description },
+      attractant_code: { attractant_code: code, short_description: description },
     }: any): ComplaintDetailsAttractant => {
-      return { key, description };
+      return { key, code, description };
     }
   );
 

--- a/frontend/src/app/types/complaints/details/complaint-attactant.ts
+++ b/frontend/src/app/types/complaints/details/complaint-attactant.ts
@@ -1,4 +1,5 @@
 export interface ComplaintDetailsAttractant { 
     key: string,
+    code: string,
     description: string
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Attractants are now populated on HWCR complaints.
# How Has This Been Tested?

Found a complaint with multiple attractants (23-000083), and verified that they are displayed on both the view and edit screen.

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-90-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-compliance-enforcement-90-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)