### PR TITLE
Cancel Tokens

### DIFF
--- a/frontend/src/app/store/reducers/allegation-complaint.ts
+++ b/frontend/src/app/store/reducers/allegation-complaint.ts
@@ -1,7 +1,7 @@
 import { PayloadAction, createSlice } from "@reduxjs/toolkit";
 import { RootState, AppThunk } from "../store";
 import config from "../../../config";
-import axios from "axios";
+import axios, { CancelTokenSource } from "axios";
 import { AllegationComplaint } from "../../types/complaints/allegation-complaint";
 import { AllegationComplaintState } from "../../types/complaints/allegation-complaints-state";
 import { Complaint } from "../../types/complaints/complaint";
@@ -11,6 +11,8 @@ const initialState: AllegationComplaintState = {
   allegationComplaints: [],
 };
 
+let cancelTokenSource: CancelTokenSource | null = null;
+
 export const allegationComplaintSlice = createSlice({
   name: "allegationComplaints",
   initialState,
@@ -18,12 +20,20 @@ export const allegationComplaintSlice = createSlice({
   reducers: {
     setAllegationComplaints: (state, action) => {
       const { payload } = action;
-      const allegationComplaints:AllegationComplaint[] = payload.allegationComplaints;
-      return { ...state, allegationComplaints};
+      const allegationComplaints: AllegationComplaint[] =
+        payload.allegationComplaints;
+      return { ...state, allegationComplaints };
     },
-    updateAllegationComplaintRow: (state, action: PayloadAction<AllegationComplaint>) => {
+    updateAllegationComplaintRow: (
+      state,
+      action: PayloadAction<AllegationComplaint>
+    ) => {
       const updatedComplaint = action.payload;
-      const index = state.allegationComplaints.findIndex(row => row.allegation_complaint_guid === updatedComplaint.allegation_complaint_guid);
+      const index = state.allegationComplaints.findIndex(
+        (row) =>
+          row.allegation_complaint_guid ===
+          updatedComplaint.allegation_complaint_guid
+      );
       if (index !== -1) {
         state.allegationComplaints[index] = updatedComplaint;
       }
@@ -35,51 +45,98 @@ export const allegationComplaintSlice = createSlice({
 });
 
 // export the actions/reducers
-export const { setAllegationComplaints, updateAllegationComplaintRow } = allegationComplaintSlice.actions;
+export const { setAllegationComplaints, updateAllegationComplaintRow } =
+  allegationComplaintSlice.actions;
 
 // The function below is called a thunk and allows us to perform async logic. It
 // can be dispatched like a regular action: `dispatch(incrementAsync(10))`. This
 // will call the thunk with the `dispatch` function as the first argument. Async
 // code can then be executed and other actions can be dispatched
-export const getAllegationComplaints = (sortColumn: string, sortOrder: string, regionCodeFilter?:Option | null, zoneCodeFilter?:Option | null, areaCodeFilter?:Option | null, officerFilter?:Option | null, violationFilter?: Option | null, startDateFilter?: Date | undefined, endDateFilter?: Date | undefined, statusFilter?: Option | null): AppThunk => async (dispatch) => {
-  const token = localStorage.getItem("user");
-  if (token) {
-    axios.defaults.headers.common.Authorization = `Bearer ${token}`;
-    const response = await axios.get(`${config.API_BASE_URL}/v1/allegation-complaint/search`, { params: { sortColumn: sortColumn, sortOrder: sortOrder, region: regionCodeFilter?.value, zone: zoneCodeFilter?.value, community: areaCodeFilter?.value, 
-      officerAssigned: officerFilter?.value, violationCode: violationFilter?.value, incidentReportedStart: startDateFilter, incidentReportedEnd: endDateFilter, status: statusFilter?.value}});
-    dispatch(
-      setAllegationComplaints({
-        allegationComplaints: response.data
-      }),
-    );
-  }
-};
+export const getAllegationComplaints =
+  (
+    sortColumn: string,
+    sortOrder: string,
+    regionCodeFilter?: Option | null,
+    zoneCodeFilter?: Option | null,
+    areaCodeFilter?: Option | null,
+    officerFilter?: Option | null,
+    violationFilter?: Option | null,
+    startDateFilter?: Date | undefined,
+    endDateFilter?: Date | undefined,
+    statusFilter?: Option | null
+  ): AppThunk =>
+  async (dispatch) => {
+    try {
+      if (cancelTokenSource) {
+        cancelTokenSource.cancel("Request canceled due to new request");
+      }
+
+      cancelTokenSource = axios.CancelToken.source();
+      const token = localStorage.getItem("user");
+      if (token) {
+        axios.defaults.headers.common.Authorization = `Bearer ${token}`;
+        const response = await axios.get(
+          `${config.API_BASE_URL}/v1/allegation-complaint/search`,
+          {
+            cancelToken: cancelTokenSource.token,
+            params: {
+              sortColumn: sortColumn,
+              sortOrder: sortOrder,
+              region: regionCodeFilter?.value,
+              zone: zoneCodeFilter?.value,
+              community: areaCodeFilter?.value,
+              officerAssigned: officerFilter?.value,
+              violationCode: violationFilter?.value,
+              incidentReportedStart: startDateFilter,
+              incidentReportedEnd: endDateFilter,
+              status: statusFilter?.value,
+            },
+          }
+        );
+        dispatch(
+          setAllegationComplaints({
+            allegationComplaints: response.data,
+          })
+        );
+      }
+    } catch (error) {
+      console.log(`Unable to retrieve Allegation complaints: ${error}`);
+    }
+  };
 
 // Update the complaint status and dispatch this change so that the affected row is updated in the state
-export const updateAllegationComplaintStatus = (complaint_identifier: string, newStatus: string ): AppThunk => { 
+export const updateAllegationComplaintStatus = (
+  complaint_identifier: string,
+  newStatus: string
+): AppThunk => {
   return async (dispatch) => {
     const token = localStorage.getItem("user");
     if (token) {
       axios.defaults.headers.common.Authorization = `Bearer ${token}`;
-      const complaintResponse = await axios.get<Complaint>(`${config.API_BASE_URL}/v1/complaint/${complaint_identifier}`);
-      
+      const complaintResponse = await axios.get<Complaint>(
+        `${config.API_BASE_URL}/v1/complaint/${complaint_identifier}`
+      );
+
       // first update the complaint status
       let updatedComplaint = complaintResponse.data;
       updatedComplaint.complaint_status_code.complaint_status_code = newStatus;
-      await axios.patch(`${config.API_BASE_URL}/v1/complaint/${complaint_identifier}`, {"complaint_status_code": `${newStatus}`});
-      
-      // now get that allegation complaint row and update the state
-      const response = await axios.get(`${config.API_BASE_URL}/v1/allegation-complaint/by-complaint-identifier/${complaint_identifier}`);
-      dispatch(
-        updateAllegationComplaintRow(response.data)
+      await axios.patch(
+        `${config.API_BASE_URL}/v1/complaint/${complaint_identifier}`,
+        { complaint_status_code: `${newStatus}` }
       );
+
+      // now get that allegation complaint row and update the state
+      const response = await axios.get(
+        `${config.API_BASE_URL}/v1/allegation-complaint/by-complaint-identifier/${complaint_identifier}`
+      );
+      dispatch(updateAllegationComplaintRow(response.data));
     }
-  }
+  };
 };
 
-export const allegationComplaints = (state: RootState) => { 
+export const allegationComplaints = (state: RootState) => {
   const { allegationComplaints } = state.allegationComplaint;
   return allegationComplaints;
-}
+};
 
 export default allegationComplaintSlice.reducer;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

axios requests to retrieve all complaints can now be cancelled by a subsequent request.  This prevents the case where long running request may mistakenly overwrite a more recent request.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Navigate to and from the HWCR complaints list, ensure that the default filters are applied each time.
- [ ] Navigate to and from the Allegation complaints list, ensure that the default filters are applied each time.


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
