### PR TITLE
COMPENF-626 - Remove previous complaint

### DIFF
--- a/frontend/src/app/components/containers/complaints/complaint-details.tsx
+++ b/frontend/src/app/components/containers/complaints/complaint-details.tsx
@@ -7,6 +7,7 @@ import {
   getAllegationComplaintByComplaintIdentifier,
   getWildlifeComplaintByComplaintIdentifier,
   selectComplaint,
+  setComplaint,
 } from "../../../store/reducers/complaints";
 import COMPLAINT_TYPES from "../../../types/app/complaint-types";
 import { SuspectWitnessDetails } from "./details/suspect-witness-details";
@@ -24,6 +25,14 @@ export const ComplaintDetails: FC = () => {
   const dispatch = useAppDispatch();
   const complaint = useAppSelector(selectComplaint);
   const [readOnly, setReadOnly] = useState(true);
+
+  useEffect(() => {
+    //-- when the component unmounts clear the complaint from redux
+    return () => {
+      dispatch(setComplaint(null))
+    };
+  }, []);
+
 
   const editButtonClick = () => {
     setReadOnly(false);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

When a new complaint is viewed after viewing a previous complaint, the previous complaint remains causing a flash of data when viewing a new complaint. This fix updates the complaint details to remove the complaint when the complaint-details component is unmounted.

Fixes # COMPENF-626

# How Has This Been Tested?
Existing tests will cover this 

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
