### PR TITLE
Compenf-768-edit complaint location

### DIFF
--- a/backend/src/v1/attractant_hwcr_xref/attractant_hwcr_xref.service.ts
+++ b/backend/src/v1/attractant_hwcr_xref/attractant_hwcr_xref.service.ts
@@ -91,7 +91,7 @@ export class AttractantHwcrXrefService {
           queryRunner.manager.update(AttractantHwcrXref, updateAttractantHwcrXrefDto.attractant_hwcr_xref_guid, updateAttractantHwcrXrefDto);
         }
       }
-      queryRunner.commitTransaction();
+      await queryRunner.commitTransaction();
     } 
     catch (err) {
       this.logger.error(err);
@@ -100,7 +100,7 @@ export class AttractantHwcrXrefService {
     } 
     finally
     {
-      //await queryRunner.release();
+      await queryRunner.release();
     }
     return ;
   }

--- a/frontend/src/app/common/validation-input.tsx
+++ b/frontend/src/app/common/validation-input.tsx
@@ -10,6 +10,7 @@ interface ValidationInputProps {
     type: string,
     step?: string,
     maxLength?: number,
+    value?: string,
   }
 
   export const ValidationInput: FC<ValidationInputProps> = ({
@@ -21,6 +22,7 @@ interface ValidationInputProps {
     type,
     step,
     maxLength,
+    value
   }) => {
     const errClass = (errMsg === "" ? "" : "error-message");
     const calulatedClass = (errMsg === "" ? className : className + " error-border");
@@ -31,6 +33,7 @@ interface ValidationInputProps {
                     id={id}
                     className={calulatedClass}
                     defaultValue={defaultValue}
+                    value={value}
                     onChange={e => onChange(e.target.value)}
                     step={step}
                     maxLength={maxLength}

--- a/frontend/src/app/common/validation-input.tsx
+++ b/frontend/src/app/common/validation-input.tsx
@@ -12,6 +12,7 @@ interface ValidationInputProps {
     maxLength?: number,
     value?: string,
   }
+  
 
   export const ValidationInput: FC<ValidationInputProps> = ({
     className,
@@ -24,6 +25,12 @@ interface ValidationInputProps {
     maxLength,
     value
   }) => {
+
+    const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+      const newValue = event.target.value;
+      onChange(newValue); // Call the parent's onChange function
+    };
+    
     const errClass = (errMsg === "" ? "" : "error-message");
     const calulatedClass = (errMsg === "" ? className : className + " error-border");
     return (<div>
@@ -34,7 +41,7 @@ interface ValidationInputProps {
                     className={calulatedClass}
                     defaultValue={defaultValue}
                     value={value}
-                    onChange={e => onChange(e.target.value)}
+                    onChange={handleInputChange}
                     step={step}
                     maxLength={maxLength}
                   />

--- a/frontend/src/app/components/common/bc-geocoder-autocomplete.tsx
+++ b/frontend/src/app/components/common/bc-geocoder-autocomplete.tsx
@@ -3,9 +3,8 @@ import CreatableSelect from "react-select/creatable";
 import { useAppDispatch, useAppSelector } from "../../hooks/hooks";
 import {
   getComplaintLocationByAddress,
-  selectGeocodedComplaintLocation,
+  selectComplaintLocation,
 } from "../../store/reducers/complaints";
-import finalPropsSelectorFactory from "react-redux/es/connect/selectorFactory";
 
 interface Props {
   value?: string;
@@ -41,7 +40,7 @@ export const BCGeocoderAutocomplete: FC<Props> = ({
   };
 
   const dispatch = useAppDispatch();
-  const complaintLocation = useAppSelector(selectGeocodedComplaintLocation);
+  const complaintLocation = useAppSelector(selectComplaintLocation);
 
   useEffect(() => {
     const fetchAddresses = async (inputValue: string) => {

--- a/frontend/src/app/components/common/bc-geocoder-autocomplete.tsx
+++ b/frontend/src/app/components/common/bc-geocoder-autocomplete.tsx
@@ -3,7 +3,7 @@ import CreatableSelect from "react-select/creatable";
 import { useAppDispatch, useAppSelector } from "../../hooks/hooks";
 import {
   getComplaintLocationByAddress,
-  selectComplaintLocation,
+  selectGeocodedComplaintLocation,
 } from "../../store/reducers/complaints";
 import finalPropsSelectorFactory from "react-redux/es/connect/selectorFactory";
 
@@ -43,7 +43,7 @@ export const BCGeocoderAutocomplete: FC<Props> = ({
   };
 
   const dispatch = useAppDispatch();
-  const complaintLocation = useAppSelector(selectComplaintLocation);
+  const complaintLocation = useAppSelector(selectGeocodedComplaintLocation);
 
   useEffect(() => {
     const fetchAddresses = async (inputValue: string) => {

--- a/frontend/src/app/components/containers/complaints/complaint-details.tsx
+++ b/frontend/src/app/components/containers/complaints/complaint-details.tsx
@@ -533,11 +533,13 @@ function handleViolationTypeChange(selectedOption: Option | null) {
       }
   }
 
-  function handleGeoPointXChange(value: string) {
+  function handleGeoPointChange(lat: string, lng: string) {
+    let hwcrComplaint: HwcrComplaint = cloneDeep(updateComplaint) as HwcrComplaint;
+    let allegationComplaint: AllegationComplaint = cloneDeep(updateComplaint) as AllegationComplaint;
 
-      if(value !== "")
+      if(lng !== "")
       {
-        if(+value > bcBoundaries.maxLongitude || +value < bcBoundaries.minLongitude)
+        if(+lng > bcBoundaries.maxLongitude || +lng < bcBoundaries.minLongitude)
         {
           setGeoPointXMsg("Value must be between " + bcBoundaries.minLongitude + " and " + bcBoundaries.maxLongitude + " degrees");
         }
@@ -546,14 +548,15 @@ function handleViolationTypeChange(selectedOption: Option | null) {
           setGeoPointXMsg("");
           if(complaintType === COMPLAINT_TYPES.HWCR)
           {
-            let hwcrComplaint: HwcrComplaint = cloneDeep(updateComplaint) as HwcrComplaint;
-            hwcrComplaint.complaint_identifier.location_geometry_point.coordinates[Coordinates.Longitude] = +value;
+            hwcrComplaint.complaint_identifier.location_geometry_point.coordinates[Coordinates.Longitude] = +lng;
+            hwcrComplaint.complaint_identifier.location_geometry_point.coordinates[Coordinates.Latitude] = +lat;
             setUpdateComplaint(hwcrComplaint);
           }
           else if(complaintType === COMPLAINT_TYPES.ERS)
           {
             let allegationComplaint: AllegationComplaint = cloneDeep(updateComplaint) as AllegationComplaint;
-            allegationComplaint.complaint_identifier.location_geometry_point.coordinates[Coordinates.Longitude] = +value;
+            allegationComplaint.complaint_identifier.location_geometry_point.coordinates[Coordinates.Longitude] = +lng;
+            allegationComplaint.complaint_identifier.location_geometry_point.coordinates[Coordinates.Latitude] = +lat;
             setUpdateComplaint(allegationComplaint);
           }
         }
@@ -563,16 +566,52 @@ function handleViolationTypeChange(selectedOption: Option | null) {
         setGeoPointXMsg("");
         if(complaintType === COMPLAINT_TYPES.HWCR)
         {
-          let hwcrComplaint: HwcrComplaint = cloneDeep(updateComplaint) as HwcrComplaint;
           hwcrComplaint.complaint_identifier.location_geometry_point.coordinates[Coordinates.Longitude] = 0;
           setUpdateComplaint(hwcrComplaint);
         }
         else if(complaintType === COMPLAINT_TYPES.ERS)
         {
-          let allegationComplaint: AllegationComplaint = cloneDeep(updateComplaint) as AllegationComplaint;
           allegationComplaint.complaint_identifier.location_geometry_point.coordinates[Coordinates.Longitude] = 0;
           setUpdateComplaint(allegationComplaint);
         }
+      }
+
+      if(lat !== "")
+      {
+        if(+lat > bcBoundaries.maxLatitude || +lat < bcBoundaries.minLatitude)
+        {
+          setGeoPointYMsg("Value must be between " + bcBoundaries.minLatitude + " and " + bcBoundaries.maxLatitude + " degrees");
+        }
+        else
+        {
+          setGeoPointYMsg("");
+          if(complaintType === COMPLAINT_TYPES.HWCR)
+          {
+            hwcrComplaint.complaint_identifier.location_geometry_point.coordinates[Coordinates.Latitude] = +lat;
+            hwcrComplaint.complaint_identifier.location_geometry_point.coordinates[Coordinates.Longitude] = +lng;
+            setUpdateComplaint(hwcrComplaint);
+          }
+          if(complaintType === COMPLAINT_TYPES.ERS)
+          {
+            allegationComplaint.complaint_identifier.location_geometry_point.coordinates[Coordinates.Latitude] = +lat;
+            allegationComplaint.complaint_identifier.location_geometry_point.coordinates[Coordinates.Longitude] = +lng;
+            setUpdateComplaint(allegationComplaint);
+          }
+        }
+      }
+      else
+      {
+          setGeoPointYMsg("");
+          if(complaintType === COMPLAINT_TYPES.HWCR)
+          {
+            hwcrComplaint.complaint_identifier.location_geometry_point.coordinates[Coordinates.Latitude] = 0;
+            setUpdateComplaint(hwcrComplaint);
+          }
+          else if(complaintType === COMPLAINT_TYPES.ERS)
+          {
+            allegationComplaint.complaint_identifier.location_geometry_point.coordinates[Coordinates.Latitude] = 0;
+            setUpdateComplaint(allegationComplaint);
+          }
       }
   }
 
@@ -801,8 +840,8 @@ function handleViolationTypeChange(selectedOption: Option | null) {
           complaintDescErrorMsg={complaintDescErrorMsg} handleComplaintDescChange={handleComplaintDescChange}
           attractantsErrorMsg={attractantsErrorMsg} handleAttractantsChange={handleAttractantsChange}
           communityErrorMsg={communityErrorMsg} handleCommunityChange={handleCommunityChange}
-          geoPointXMsg={geoPointXMsg} handleGeoPointXChange={handleGeoPointXChange}
-          geoPointYMsg={geoPointYMsg} handleGeoPointYChange={handleGeoPointYChange}
+          geoPointXMsg={geoPointXMsg} handleGeoPointChange={handleGeoPointChange}
+          geoPointYMsg={geoPointYMsg}
           emailMsg={emailMsg} handleEmailChange={handleEmailChange}
           primaryPhoneMsg={primaryPhoneMsg} handlePrimaryPhoneChange={handlePrimaryPhoneChange}
           secondaryPhoneMsg={secondaryPhoneMsg} handleSecondaryPhoneChange={handleSecondaryPhoneChange}

--- a/frontend/src/app/components/containers/complaints/complaint-details.tsx
+++ b/frontend/src/app/components/containers/complaints/complaint-details.tsx
@@ -422,10 +422,9 @@ export const ComplaintDetails: FC = () => {
   }
 
   function handleGeoPointXChange(value: string) {
-
     if(complaintType === COMPLAINT_TYPES.HWCR)
     {
-      if(value !== "")
+      if(value !== "" && value !== "-")
       {
         if(+value > bcBoundaries.maxLongitude || +value < bcBoundaries.minLongitude)
         {
@@ -450,10 +449,10 @@ export const ComplaintDetails: FC = () => {
   }
 
   function handleGeoPointYChange(value: string) {
-
+   
     if(complaintType === COMPLAINT_TYPES.HWCR)
     {
-      if(value !== "")
+      if(value !== "" && value !== "-")
       {
         if(+value > bcBoundaries.maxLatitude || +value < bcBoundaries.minLatitude)
         {

--- a/frontend/src/app/components/containers/complaints/complaint-details.tsx
+++ b/frontend/src/app/components/containers/complaints/complaint-details.tsx
@@ -4,7 +4,6 @@ import { useParams } from "react-router-dom";
 
 import { CallDetails, CallerInformation, ComplaintHeader } from "./details";
 import {
-  getAllegationComplaintByComplaintIdentifier,
   getAllegationComplaintByComplaintIdentifierSetUpdate,
   getWildlifeComplaintByComplaintIdentifierSetUpdate,
   selectComplaint,
@@ -609,48 +608,6 @@ function handleViolationTypeChange(selectedOption: Option | null) {
           }
           else if(complaintType === COMPLAINT_TYPES.ERS)
           {
-            allegationComplaint.complaint_identifier.location_geometry_point.coordinates[Coordinates.Latitude] = 0;
-            setUpdateComplaint(allegationComplaint);
-          }
-      }
-  }
-
-  function handleGeoPointYChange(value: string) {
-      if(value !== "")
-      {
-        if(+value > bcBoundaries.maxLatitude || +value < bcBoundaries.minLatitude)
-        {
-          setGeoPointYMsg("Value must be between " + bcBoundaries.minLatitude + " and " + bcBoundaries.maxLatitude + " degrees");
-        }
-        else
-        {
-          setGeoPointYMsg("");
-          if(complaintType === COMPLAINT_TYPES.HWCR)
-          {
-            let hwcrComplaint: HwcrComplaint = cloneDeep(updateComplaint) as HwcrComplaint;
-            hwcrComplaint.complaint_identifier.location_geometry_point.coordinates[Coordinates.Latitude] = +value;
-            setUpdateComplaint(hwcrComplaint);
-          }
-          if(complaintType === COMPLAINT_TYPES.ERS)
-          {
-            let allegationComplaint: AllegationComplaint = cloneDeep(updateComplaint) as AllegationComplaint;
-            allegationComplaint.complaint_identifier.location_geometry_point.coordinates[Coordinates.Latitude] = +value;
-            setUpdateComplaint(allegationComplaint);
-          }
-        }
-      }
-      else
-      {
-          setGeoPointYMsg("");
-          if(complaintType === COMPLAINT_TYPES.HWCR)
-          {
-            let hwcrComplaint: HwcrComplaint = cloneDeep(updateComplaint) as HwcrComplaint;
-            hwcrComplaint.complaint_identifier.location_geometry_point.coordinates[Coordinates.Latitude] = 0;
-            setUpdateComplaint(hwcrComplaint);
-          }
-          else if(complaintType === COMPLAINT_TYPES.ERS)
-          {
-            let allegationComplaint: AllegationComplaint = cloneDeep(updateComplaint) as AllegationComplaint;
             allegationComplaint.complaint_identifier.location_geometry_point.coordinates[Coordinates.Latitude] = 0;
             setUpdateComplaint(allegationComplaint);
           }

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
@@ -60,9 +60,8 @@ interface ComplaintDetailsProps {
   communityErrorMsg: string,
   handleCommunityChange: Function,
   geoPointXMsg: string,
-  handleGeoPointXChange: Function,
+  handleGeoPointChange: Function,
   geoPointYMsg: string,
-  handleGeoPointYChange: Function,
   emailMsg: string,
   handleEmailChange: Function,
   primaryPhoneMsg: string,
@@ -100,9 +99,8 @@ export const ComplaintDetailsEdit: FC<ComplaintDetailsProps> = ({
   communityErrorMsg,
   handleCommunityChange,
   geoPointXMsg,
-  handleGeoPointXChange,
+  handleGeoPointChange,
   geoPointYMsg,
-  handleGeoPointYChange,
   emailMsg,
   handleEmailChange,
   primaryPhoneMsg,
@@ -240,22 +238,21 @@ export const ComplaintDetailsEdit: FC<ComplaintDetailsProps> = ({
   const [latitude, setLatitude] = useState<number>(+yCoordinate);
   const [longitude, setLongitude] = useState<number>(+xCoordinate);
 
-  const handleMarkerMove = (lat: number, lng: number) => {
-    updateCoordinates(lat,lng);
-    updateValidation(lat,lng);
+  const handleMarkerMove = async (lat: number, lng: number) => {
+    await updateCoordinates(lat,lng);
+    await updateValidation(lat,lng);
 
 
   };
 
-  function updateCoordinates(lat: number,lng: number) {
+  async function updateCoordinates(lat: number,lng: number) {
     setLatitude(lat);
     setLongitude(lng);
 
   }
 
-  function updateValidation(lat: number,lng: number) {
-    handleGeoPointXChange(lng);
-    handleGeoPointYChange(lat);
+  async function updateValidation(lat: number,lng: number) {
+    handleGeoPointChange(lat,lng);
   }
 
   function handleIncidentDateTimeChange(date: Date) {

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from "react";
+import { FC, useState } from "react";
 import { useAppSelector } from "../../../../hooks/hooks";
 import {
   formatDate,
@@ -31,7 +31,6 @@ import Option from "../../../../types/app/option";
 import COMPLAINT_TYPES from "../../../../types/app/complaint-types";
 import { ComplaintSuspectWitness } from "../../../../types/complaints/details/complaint-suspect-witness-details";
 import { selectOfficersByZone } from "../../../../store/reducers/officer";
-import { BCGeocoderAutocomplete } from "../../../common/bc-geocoder-autocomplete";
 import { ComplaintLocation } from "./complaint-location";
 import { ValidationSelect } from "../../../../common/validation-select";
 import { HwcrComplaint } from "../../../../types/complaints/hwcr-complaint";

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
@@ -231,6 +231,14 @@ export const ComplaintDetailsEdit: FC<ComplaintDetailsProps> = ({
     (option) => option.value === (violationObserved ? "Yes" : "No")
   );
 
+  const [latitude, setLatitude] = useState<number>(0);
+  const [longitude, setLongitude] = useState<number>(0);
+
+  const handleMarkerMove = (lat: number, lng: number) => {
+    setLatitude(lat);
+    setLongitude(lng);
+  };
+
   function handleIncidentDateTimeChange(date: Date) {
 
     if(complaintType === COMPLAINT_TYPES.HWCR)
@@ -518,6 +526,7 @@ export const ComplaintDetailsEdit: FC<ComplaintDetailsProps> = ({
                     type="number"
                     id="comp-details-edit-x-coordinate-input"
                     className="comp-form-control"
+                    value={`${longitude}`}
                     defaultValue={xCoordinate}
                     onChange={handleGeoPointXChange}
                     errMsg={geoPointXMsg}
@@ -535,6 +544,7 @@ export const ComplaintDetailsEdit: FC<ComplaintDetailsProps> = ({
                     type="number"
                     id="comp-details-edit-y-coordinate-input"
                     className="comp-form-control"
+                    value={`${latitude}`}
                     defaultValue={yCoordinate}
                     onChange={handleGeoPointYChange}
                     errMsg={geoPointYMsg}
@@ -608,7 +618,7 @@ export const ComplaintDetailsEdit: FC<ComplaintDetailsProps> = ({
           </div>
         </div>
       </div>
-      <ComplaintLocation complaintType={complaintType} draggable={true}/>
+      <ComplaintLocation complaintType={complaintType} draggable={true} onMarkerMove={handleMarkerMove}/>
       {/* edit caller info block */}
       <div className="comp-complaint-details-block">
         <h6>Caller Information</h6>

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from "react";
+import { FC, useEffect, useState } from "react";
 import { useAppSelector } from "../../../../hooks/hooks";
 import {
   formatDate,
@@ -231,13 +231,26 @@ export const ComplaintDetailsEdit: FC<ComplaintDetailsProps> = ({
     (option) => option.value === (violationObserved ? "Yes" : "No")
   );
 
-  const [latitude, setLatitude] = useState<number>(0);
-  const [longitude, setLongitude] = useState<number>(0);
+  const [latitude, setLatitude] = useState<number>(+yCoordinate);
+  const [longitude, setLongitude] = useState<number>(+xCoordinate);
 
   const handleMarkerMove = (lat: number, lng: number) => {
+    updateCoordinates(lat,lng);
+    updateValidation(lat,lng);
+
+
+  };
+
+  function updateCoordinates(lat: number,lng: number) {
     setLatitude(lat);
     setLongitude(lng);
-  };
+
+  }
+
+  function updateValidation(lat: number,lng: number) {
+    handleGeoPointXChange(lng);
+    handleGeoPointYChange(lat);
+  }
 
   function handleIncidentDateTimeChange(date: Date) {
 
@@ -248,6 +261,16 @@ export const ComplaintDetailsEdit: FC<ComplaintDetailsProps> = ({
         hwcrComplaint.complaint_identifier.incident_datetime = date.toDateString();
         setUpdateComplaint(hwcrComplaint);
     }
+  }
+
+  const handleLongitudeChange = (newValue: string) => {
+    setLongitude(+newValue);
+    updateValidation(latitude,longitude);
+  }
+
+  const handleLatitudeChange = (newValue: string) => {
+    setLatitude(+newValue);
+    updateValidation(latitude,longitude);
   }
 
   return (
@@ -527,8 +550,8 @@ export const ComplaintDetailsEdit: FC<ComplaintDetailsProps> = ({
                     id="comp-details-edit-x-coordinate-input"
                     className="comp-form-control"
                     value={`${longitude}`}
-                    defaultValue={xCoordinate}
-                    onChange={handleGeoPointXChange}
+                    defaultValue={`${longitude}`}
+                    onChange={handleLongitudeChange}
                     errMsg={geoPointXMsg}
                     step="any"
                   />
@@ -545,8 +568,8 @@ export const ComplaintDetailsEdit: FC<ComplaintDetailsProps> = ({
                     id="comp-details-edit-y-coordinate-input"
                     className="comp-form-control"
                     value={`${latitude}`}
-                    defaultValue={yCoordinate}
-                    onChange={handleGeoPointYChange}
+                    defaultValue={`${latitude}`}
+                    onChange={handleLatitudeChange}
                     errMsg={geoPointYMsg}
                     step="any"
                   />

--- a/frontend/src/app/components/containers/complaints/details/complaint-location.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-location.tsx
@@ -2,7 +2,7 @@ import { FC } from "react";
 import { useAppSelector } from "../../../../hooks/hooks";
 import {
   selectComplaintDeails,
-  selectGeocodedComplaintLocation,
+  selectComplaintLocation,
 } from "../../../../store/reducers/complaints";
 import LeafletMapWithPoint from "../../../mapping/leaflet-map-with-point";
 import { ComplaintDetails } from "../../../../types/complaints/details/complaint-details";
@@ -24,7 +24,7 @@ export const ComplaintLocation: FC<Props> = ({ complaintType, draggable, onMarke
   const { coordinates } = useAppSelector(
     selectComplaintDeails(complaintType)
   ) as ComplaintDetails;
-  const complaintLocation = useAppSelector(selectGeocodedComplaintLocation);
+  const complaintLocation = useAppSelector(selectComplaintLocation);
 
   // the lat and long of the marker we need to display on the map
   // Initialized to 0.  This will either be populated using the optionally supplied coordinates
@@ -40,17 +40,6 @@ export const ComplaintLocation: FC<Props> = ({ complaintType, draggable, onMarke
     lng = (complaintLocation?.features[0]?.geometry?.coordinates[Coordinates.Longitude] !== undefined ? complaintLocation?.features[0]?.geometry?.coordinates[Coordinates.Longitude] : 0);
   }
 
-  if (!lat && !lng) {
-    return (
-      <div className="comp-complaint-details-location-block">
-        <h6>Complaint Location</h6>
-        <div className="comp-complaint-location">
-          Unable to determine location based on address and community
-          information.
-        </div>
-      </div>
-    );
-  } else {
     return (
       <div className="comp-complaint-details-location-block">
         <h6>Complaint Location</h6>
@@ -63,5 +52,5 @@ export const ComplaintLocation: FC<Props> = ({ complaintType, draggable, onMarke
         </div>
       </div>
     );
-  }
+  
 };

--- a/frontend/src/app/components/containers/complaints/details/complaint-location.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-location.tsx
@@ -2,7 +2,7 @@ import { FC } from "react";
 import { useAppSelector } from "../../../../hooks/hooks";
 import {
   selectComplaintDeails,
-  selectComplaintLocation,
+  selectGeocodedComplaintLocation,
 } from "../../../../store/reducers/complaints";
 import LeafletMapWithPoint from "../../../mapping/leaflet-map-with-point";
 import { ComplaintDetails } from "../../../../types/complaints/details/complaint-details";
@@ -12,22 +12,23 @@ import { Coordinates } from "../../../../types/app/coordinate-type";
 type Props = {
   complaintType: string;
   draggable: boolean;
+  onMarkerMove?: (lat: number, lng: number) => void;
 };
 
 /**
  * Component that displays a map with a marker representing the complaint location
  *
  */
-export const ComplaintLocation: FC<Props> = ({ complaintType, draggable }) => {
+export const ComplaintLocation: FC<Props> = ({ complaintType, draggable, onMarkerMove }) => {
   
-  const { location, coordinates } = useAppSelector(
+  const { coordinates } = useAppSelector(
     selectComplaintDeails(complaintType)
   ) as ComplaintDetails;
-  const complaintLocation = useAppSelector(selectComplaintLocation);
+  const complaintLocation = useAppSelector(selectGeocodedComplaintLocation);
 
   // the lat and long of the marker we need to display on the map
   // Initialized to 0.  This will either be populated using the optionally supplied coordinates
-  // or they'll be derived using the complaint's location and/or communit.
+  // or they'll be derived using the complaint's location and/or community.
   let lat = 0;
   let lng = 0;
 
@@ -57,6 +58,7 @@ export const ComplaintLocation: FC<Props> = ({ complaintType, draggable }) => {
           <LeafletMapWithPoint
             coordinates={{ lat: lat, lng: lng }}
             draggable={draggable}
+            onMarkerMove={onMarkerMove}
           />
         </div>
       </div>

--- a/frontend/src/app/components/mapping/leaflet-map-with-point.tsx
+++ b/frontend/src/app/components/mapping/leaflet-map-with-point.tsx
@@ -27,7 +27,7 @@ const LeafletMapWithPoint: FC<Props> = ({ coordinates, draggable, onMarkerMove }
 
   const handleMarkerDragEnd = (e: L.LeafletEvent) => {
     const marker = e.target;
-    if (marker && marker.getLatLng) {
+    if (marker?.getLatLng) {
       const newPosition = marker.getLatLng();
       
       if (onMarkerMove) {

--- a/frontend/src/app/store/reducers/app.ts
+++ b/frontend/src/app/store/reducers/app.ts
@@ -263,7 +263,7 @@ export const getConfigurations = (): AppThunk => async (dispatch) => {
       );
     }
   } catch (error) {
-    //-- handle errors
+    console.log(error);
   } finally {
     dispatch(toggleLoading(false));
   }

--- a/frontend/src/app/store/reducers/complaints.ts
+++ b/frontend/src/app/store/reducers/complaints.ts
@@ -95,9 +95,9 @@ export const complaintSlice = createSlice({
       const { payload: complaint } = action;
       return { ...state, complaint };
     },
-    setComplaintLocation: (state, action) => {
-      const { payload: complaintLocation } = action;
-      return { ...state, complaintLocation };
+    setGeocodedComplaintLocation: (state, action) => {
+      const { payload: geocodedComplaintLocation } = action;
+      return { ...state, geocodedComplaintLocation };
     },
     setZoneAtAGlance: (state, action) => {
       const { payload: statistics } = action;
@@ -169,7 +169,7 @@ export const {
   setTotalCount,
   setComplaintsOnMap,
   setComplaint,
-  setComplaintLocation,
+  setGeocodedComplaintLocation,
   setZoneAtAGlance,
   updateWildlifeComplaintByRow,
   updateAllegationComplaintByRow,
@@ -323,7 +323,7 @@ export const getWildlifeComplaintByComplaintIdentifier =
           location_summary_text,
           cos_geo_org_unit: { area_name },
         } = ceComplaint;
-        dispatch(getComplaintLocation(area_name, location_summary_text));
+        dispatch(getGeocodedComplaintLocation(area_name, location_summary_text));
       }
 
       dispatch(setComplaint({ ...response }));
@@ -352,7 +352,7 @@ export const getWildlifeComplaintByComplaintIdentifierSetUpdate =
           location_summary_text,
           cos_geo_org_unit: { area_name },
         } = ceComplaint;
-        await dispatch(getComplaintLocation(area_name, location_summary_text));
+        await dispatch(getGeocodedComplaintLocation(area_name, location_summary_text));
       }
       setUpdateComplaint(response);
 
@@ -384,7 +384,7 @@ export const getAllegationComplaintByComplaintIdentifier =
           cos_geo_org_unit: { area_name },
         } = ceComplaint;
 
-        dispatch(getComplaintLocation(area_name, location_summary_text));
+        dispatch(getGeocodedComplaintLocation(area_name, location_summary_text));
       }
 
       dispatch(setComplaint({ ...response }));
@@ -417,6 +417,7 @@ export const getZoneAtAGlanceStats =
     }
   };
 
+// used by the autocomplete
 export const getComplaintLocationByAddress =
   (address: string): AppThunk =>
   async (dispatch) => {
@@ -425,27 +426,14 @@ export const getComplaintLocationByAddress =
         `${config.API_BASE_URL}/bc-geo-coder/address?addressString=${address}`
       );
       const response = await get<Feature>(dispatch, parameters);
-      dispatch(setComplaintLocation(response));
+      dispatch(setGeocodedComplaintLocation(response));
     } catch (error) {
       //-- handle the error message
     }
   };
 
-export const getComplaintLocationByAddressAsync =
-  (address: string): AppThunk =>
-  async (dispatch) => {
-    try {
-      const parameters = generateApiParameters(
-        `${config.API_BASE_URL}/bc-geo-coder/address?addressString=${address}`
-      );
-      const response = await get<Feature>(dispatch, parameters);
-      return response.features[0].geometry;
-    } catch (error) {
-      //-- handle the error message
-    }
-  };
-
-export const getComplaintLocation =
+  // Used to get the complaint location by area and address
+  export const getGeocodedComplaintLocation =
   (area: string, address?: string): AppThunk =>
   async (dispatch) => {
     try {
@@ -461,7 +449,7 @@ export const getComplaintLocation =
         );
       }
       const response = await get<Feature>(dispatch, parameters);
-      dispatch(setComplaintLocation(response));
+      dispatch(setGeocodedComplaintLocation(response));
     } catch (error) {
       //-- handle the error message
     }
@@ -572,7 +560,7 @@ export const selectComplaint = (
   return complaint;
 };
 
-export const selectComplaintLocation = (
+export const selectGeocodedComplaintLocation = (
   state: RootState
 ): Feature | null | undefined => {
   const {

--- a/frontend/src/app/store/reducers/complaints.ts
+++ b/frontend/src/app/store/reducers/complaints.ts
@@ -422,6 +422,8 @@ export const getComplaintLocationByAddress =
   (address: string): AppThunk =>
   async (dispatch) => {
     try {
+      dispatch(toggleLoading(true));
+
       const parameters = generateApiParameters(
         `${config.API_BASE_URL}/bc-geo-coder/address?addressString=${address}`
       );
@@ -429,6 +431,8 @@ export const getComplaintLocationByAddress =
       dispatch(setGeocodedComplaintLocation(response));
     } catch (error) {
       //-- handle the error message
+    } finally {
+      dispatch(toggleLoading(false));
     }
   };
 
@@ -437,6 +441,7 @@ export const getComplaintLocationByAddress =
   (area: string, address?: string): AppThunk =>
   async (dispatch) => {
     try {
+      dispatch(toggleLoading(true));
       let parameters;
 
       if (address && area) {
@@ -452,6 +457,8 @@ export const getComplaintLocationByAddress =
       dispatch(setGeocodedComplaintLocation(response));
     } catch (error) {
       //-- handle the error message
+    } finally {
+      dispatch(toggleLoading(false));
     }
   };
 

--- a/frontend/src/app/store/reducers/complaints.ts
+++ b/frontend/src/app/store/reducers/complaints.ts
@@ -414,7 +414,7 @@ export const getAllegationComplaintByComplaintIdentifier =
           location_summary_text,
           cos_geo_org_unit: { area_name },
         } = ceComplaint;
-        await dispatch(getComplaintLocation(area_name, location_summary_text));
+        await dispatch(getGeocodedComplaintLocation(area_name, location_summary_text));
       }
       setUpdateComplaint(response);
 

--- a/frontend/src/app/store/reducers/complaints.ts
+++ b/frontend/src/app/store/reducers/complaints.ts
@@ -95,9 +95,9 @@ export const complaintSlice = createSlice({
       const { payload: complaint } = action;
       return { ...state, complaint };
     },
-    setGeocodedComplaintLocation: (state, action) => {
-      const { payload: geocodedComplaintLocation } = action;
-      return { ...state, geocodedComplaintLocation };
+    setComplaintLocation: (state, action) => {
+      const { payload: complaintLocation } = action;
+      return { ...state, complaintLocation };
     },
     setZoneAtAGlance: (state, action) => {
       const { payload: statistics } = action;
@@ -169,7 +169,7 @@ export const {
   setTotalCount,
   setComplaintsOnMap,
   setComplaint,
-  setGeocodedComplaintLocation,
+  setComplaintLocation,
   setZoneAtAGlance,
   updateWildlifeComplaintByRow,
   updateAllegationComplaintByRow,
@@ -323,7 +323,7 @@ export const getWildlifeComplaintByComplaintIdentifier =
           location_summary_text,
           cos_geo_org_unit: { area_name },
         } = ceComplaint;
-        dispatch(getGeocodedComplaintLocation(area_name, location_summary_text));
+        dispatch(getComplaintLocation(area_name, location_summary_text));
       }
 
       dispatch(setComplaint({ ...response }));
@@ -352,7 +352,7 @@ export const getWildlifeComplaintByComplaintIdentifierSetUpdate =
           location_summary_text,
           cos_geo_org_unit: { area_name },
         } = ceComplaint;
-        await dispatch(getGeocodedComplaintLocation(area_name, location_summary_text));
+        await dispatch(getComplaintLocation(area_name, location_summary_text));
       }
       setUpdateComplaint(response);
 
@@ -384,7 +384,7 @@ export const getAllegationComplaintByComplaintIdentifier =
           cos_geo_org_unit: { area_name },
         } = ceComplaint;
 
-        dispatch(getGeocodedComplaintLocation(area_name, location_summary_text));
+        dispatch(getComplaintLocation(area_name, location_summary_text));
       }
 
       dispatch(setComplaint({ ...response }));
@@ -414,7 +414,7 @@ export const getAllegationComplaintByComplaintIdentifier =
           location_summary_text,
           cos_geo_org_unit: { area_name },
         } = ceComplaint;
-        await dispatch(getGeocodedComplaintLocation(area_name, location_summary_text));
+        await dispatch(getComplaintLocation(area_name, location_summary_text));
       }
       setUpdateComplaint(response);
 
@@ -459,7 +459,7 @@ export const getComplaintLocationByAddress =
         `${config.API_BASE_URL}/bc-geo-coder/address?addressString=${address}`
       );
       const response = await get<Feature>(dispatch, parameters);
-      dispatch(setGeocodedComplaintLocation(response));
+      dispatch(setComplaintLocation(response));
     } catch (error) {
       //-- handle the error message
     } finally {
@@ -468,7 +468,7 @@ export const getComplaintLocationByAddress =
   };
 
   // Used to get the complaint location by area and address
-  export const getGeocodedComplaintLocation =
+  export const getComplaintLocation =
   (area: string, address?: string): AppThunk =>
   async (dispatch) => {
     try {
@@ -485,7 +485,7 @@ export const getComplaintLocationByAddress =
         );
       }
       const response = await get<Feature>(dispatch, parameters);
-      dispatch(setGeocodedComplaintLocation(response));
+      dispatch(setComplaintLocation(response));
     } catch (error) {
       //-- handle the error message
     } finally {
@@ -627,7 +627,7 @@ export const selectComplaint = (
   return complaint;
 };
 
-export const selectGeocodedComplaintLocation = (
+export const selectComplaintLocation = (
   state: RootState
 ): Feature | null | undefined => {
   const {

--- a/frontend/src/assets/sass/maps.scss
+++ b/frontend/src/assets/sass/maps.scss
@@ -7,4 +7,5 @@
 
 .map-container {
     border-radius: 4px;
+    z-index: 1;
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

As an officer or Admin Staff, I want to be able to select the location of the complaint from a map while editing a complaint to ensure that the location information captured for that complaint is as accurate as possible.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] When editing an HWCR or EC complaint, user has the option to select the location from a map 
- [x] User is able to move pan and zoom around a map view 
- [x] User is able to click the map to select a location
- [x] Coordinate fields automatically get overwritten by the selected point's coordinates
- [x] Confirmation of changes appear to the user prior to saving


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-130-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-compliance-enforcement-130-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)