### PR TITLE
COMPENF-961-Use complaint's zone, not the filtered zone when displaying the assig…

### DIFF
--- a/frontend/src/app/components/containers/complaints/complaint-ellipsis-popover.tsx
+++ b/frontend/src/app/components/containers/complaints/complaint-ellipsis-popover.tsx
@@ -8,6 +8,7 @@ import { ComplaintFilterContext } from "../../../providers/complaint-filter-prov
 type Props = {
   complaint_identifier: string;
   complaint_type: string;
+  complaint_zone: string;
   sortColumn: string,
   sortOrder: string,
   assigned_ind: boolean;
@@ -21,6 +22,7 @@ type Props = {
 export const ComplaintEllipsisPopover: FC<Props> = ({
   complaint_identifier,
   complaint_type,
+  complaint_zone,
   assigned_ind,
   sortColumn,
   sortOrder
@@ -31,7 +33,6 @@ export const ComplaintEllipsisPopover: FC<Props> = ({
 
   const { state: filters } = useContext(ComplaintFilterContext);
   const {
-    zone,
     species: speciesCodeFilter,
     natureOfComplaint: natureOfComplaintFilter,
     status: complaintStatusFilter,
@@ -96,7 +97,7 @@ export const ComplaintEllipsisPopover: FC<Props> = ({
           description: "",
           complaint_identifier: complaint_identifier,
           complaint_type: complaint_type,
-          zone: zone,
+          zone: complaint_zone,
         },
       })
     );

--- a/frontend/src/app/components/containers/complaints/list-items/allegation-complaint-list-item.tsx
+++ b/frontend/src/app/components/containers/complaints/list-items/allegation-complaint-list-item.tsx
@@ -139,6 +139,7 @@ export const AllegationComplaintListItem: FC<Props> = ({
       <ComplaintEllipsisPopover
         complaint_identifier={id}
         complaint_type={type}
+        complaint_zone={cos_geo_org_unit.zone_code}
         assigned_ind={assigned_ind}
         sortColumn={sortKey}
         sortOrder={sortDirection}

--- a/frontend/src/app/components/containers/complaints/list-items/wildlife-complaint-list-item.tsx
+++ b/frontend/src/app/components/containers/complaints/list-items/wildlife-complaint-list-item.tsx
@@ -129,6 +129,7 @@ export const WildlifeComplaintListItem: FC<Props> = ({
       <ComplaintEllipsisPopover
         complaint_identifier={id}
         complaint_type={type}
+        complaint_zone={cos_geo_org_unit.zone_code}
         assigned_ind={assigned_ind}
         sortColumn={sortKey}
         sortOrder={sortDirection}


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->

# Description

Assign Officer Modal now uses the complaint's zone on both the list and details view of the complaint.  Previously, on the list view, the selected filter was being used to determine the complaint's zone.

Fixes # (issue)

# How Has This Been Tested?

Verified that the list of officers in the assign-complaint modal matched the officer's in the complaint's zone.


## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-148-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-compliance-enforcement-148-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)