### PR TITLE
COMPENF-996-Should not have Plural Human Wildlife Conflicts on Single Complaints

### DIFF
--- a/frontend/cypress/e2e/complaint-list.cy.ts
+++ b/frontend/cypress/e2e/complaint-list.cy.ts
@@ -12,6 +12,20 @@ describe('Complaint List Functionality', () => {
   
     Cypress._.times(complaintTypes.length, ((index) => {
   
+      it('Verifies that the complaint tabs have specific text', () => {
+        cy.visit("/");
+        cy.waitForSpinner();
+        
+        cy.get(complaintTypes[index]).click({ force: true });
+
+        if ("#hwcr-tab".includes(complaintTypes[index])) {
+          cy.get("#hwcr-tab").should("contain.text","Human Wildlife Conflicts");
+        } else {
+          cy.get("#ers-tab").should("contain.text","Enforcement");
+        }
+
+      });
+
       it('Verifies the complaint tabs, filter and table header are sticky', {scrollBehavior: false}, () => {
         cy.visit("/");
         cy.waitForSpinner();

--- a/frontend/cypress/e2e/complaints-on-map-view.cy.ts
+++ b/frontend/cypress/e2e/complaints-on-map-view.cy.ts
@@ -124,6 +124,12 @@ describe("Complaints on map tests", () => {
 
       cy.get(".leaflet-popup").should("exist");
 
+      if ("#hwcr-tab".includes(complaintTypes[index])) {
+        cy.get("div.hwcr-conflict-type").should("exist");
+        cy.get("div.hwcr-conflict-type").should("have.text","Human Wildlife Conflict");
+        cy.get("div.hwcr-conflict-type").should("not.have.text","Human Wildlife Conflicts");
+      }
+
       // click the "view details" button to navigate to the complaint
       cy.get("#view-complaint-details-button-id").click({ force: true });
 

--- a/frontend/cypress/e2e/hwcr-details.cy.ts
+++ b/frontend/cypress/e2e/hwcr-details.cy.ts
@@ -64,7 +64,12 @@ describe("COMPENF-35 Display HWCR Details", () => {
     cy.get(
       'div[id="comp-details-location"]'
     ).contains(callDetails.location);
-    
+
+    //-- verify that the conflict type is singular, not plural
+    cy.get("div.hwcr-conflict-type").should("exist");
+    cy.get("div.hwcr-conflict-type").should("have.text","Human Wildlife Conflict");
+    cy.get("div.hwcr-conflict-type").should("not.have.text","Human Wildlife Conflicts");
+
     cy.get(
       'p[id="comp-details-location-description"]'
     ).should('have.value', '');

--- a/frontend/src/app/components/containers/complaints/details/complaint-header.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-header.tsx
@@ -115,7 +115,7 @@ export const ComplaintHeader: FC<ComplaintHeaderProps> = ({
                   : "allegation-conflict-type"
               }`}
             >
-              {complaintTypeToName(complaintType)}
+              {complaintTypeToName(complaintType,true)}
             </div>
           { readOnly && species && complaintType !== COMPLAINT_TYPES.ERS && (
             <div className="comp-box-species-type">{species}</div>

--- a/frontend/src/app/components/mapping/complaint-summary-popup.tsx
+++ b/frontend/src/app/components/mapping/complaint-summary-popup.tsx
@@ -76,7 +76,7 @@ export const ComplaintSummaryPopup: FC<Props> = ({
             <div className="comp-complaint-info">
               <div className="map-comp-summary-popup-subheading">
                 <div className={`comp-box-conflict-type ${renderHWCRSection ? 'hwcr-conflict-type' : 'allegation-conflict-type'}`}>
-                  {complaintTypeToName(complaintType)}
+                  {complaintTypeToName(complaintType,true)}
                 </div>
                 {renderHWCRSection ? (
                   <div className="comp-box-species-type">{species}</div>

--- a/frontend/src/app/types/app/complaint-types.ts
+++ b/frontend/src/app/types/app/complaint-types.ts
@@ -3,12 +3,12 @@ export const COMPLAINT_TYPES = {
   ERS: "ERS",
 };
 
-export const complaintTypeToName = (complaintType: string | undefined | null) => {
+export const complaintTypeToName = (complaintType: string | undefined | null, singular?: boolean) => {
   switch (complaintType) {
     case COMPLAINT_TYPES.ERS:
       return "Enforcement";
     case COMPLAINT_TYPES.HWCR:
-      return "Human Wildlife Conflicts";
+      return singular ? "Human Wildlife Conflict" : "Human Wildlife Conflicts";
     default:
       return "";
   }


### PR DESCRIPTION
Should not have Plural Human Wildlife Conflicts on Single Complaints


Fixes # (issue)

[COMPENF-996](https://apps.nrs.gov.bc.ca/int/jira/browse/COMPENF-996)

# How Has This Been Tested?

- [x] The complaint type "Human Wildlife Complaints" should be singular on the details and map pop.
- [x] The complaint type "Human Wildlife Complaints" should be pluralized on other screens.


## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-151-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-compliance-enforcement-151-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-151-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-compliance-enforcement-151-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)