### PR TITLE
COMPENF-859: Default zone fix

### DIFF
--- a/frontend/cypress/e2e/change-complaint-assignee.cy.ts
+++ b/frontend/cypress/e2e/change-complaint-assignee.cy.ts
@@ -16,8 +16,8 @@ describe('Complaint Assign Popover spec', { scrollBehavior: false }, () => {
     it('Changes assignee of complaint',  () => {
       cy.visit("/");
 
-      //I hate having this but I can't find a way to make sure the filters are there.
-      cy.wait(7000);
+      //Need to make sure the filters are loaded before switching tabs.
+      cy.waitForSpinner();
 
       cy.get(complaintTypes[index]).click({ force: true });
 

--- a/frontend/cypress/e2e/change-complaint-assignee.cy.ts
+++ b/frontend/cypress/e2e/change-complaint-assignee.cy.ts
@@ -15,6 +15,10 @@ describe('Complaint Assign Popover spec', { scrollBehavior: false }, () => {
   
     it('Changes assignee of complaint',  () => {
       cy.visit("/");
+
+      //I hate having this but I can't find a way to make sure the filters are there.
+      cy.wait(7000);
+
       cy.get(complaintTypes[index]).click({ force: true });
 
       cy.waitForSpinner();

--- a/frontend/cypress/e2e/change-complaint-status.cy.ts
+++ b/frontend/cypress/e2e/change-complaint-status.cy.ts
@@ -16,8 +16,8 @@ describe('Complaint Assign and Status Popover spec', { scrollBehavior: false }, 
     it('Changes status of open complaint to closed and back to open', () => {
       cy.visit("/");
 
-      //I hate having this but I can't find a way to make sure the filters are there.
-      cy.wait(7000);
+      //Need to make sure the filters are loaded before switching tabs.
+      cy.waitForSpinner();
       
       cy.get(complaintTypes[index]).click({ force: true });
 

--- a/frontend/cypress/e2e/change-complaint-status.cy.ts
+++ b/frontend/cypress/e2e/change-complaint-status.cy.ts
@@ -15,6 +15,10 @@ describe('Complaint Assign and Status Popover spec', { scrollBehavior: false }, 
   
     it('Changes status of open complaint to closed and back to open', () => {
       cy.visit("/");
+
+      //I hate having this but I can't find a way to make sure the filters are there.
+      cy.wait(7000);
+      
       cy.get(complaintTypes[index]).click({ force: true });
 
       cy.waitForSpinner();

--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -158,7 +158,7 @@ Cypress.Commands.add(
     //-- navigate to application root
     cy.visit("/");
 
-    //I hate having this but I can't find a way to make sure the filters are there.
+    //Need to make sure the filters are loaded before switching tabs.
     cy.waitForSpinner();
 
     //-- click on HWCR tab

--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -158,12 +158,22 @@ Cypress.Commands.add(
     //-- navigate to application root
     cy.visit("/");
 
+    //I hate having this but I can't find a way to make sure the filters are there.
+    cy.wait(2000);
+
     //-- click on HWCR tab
     cy.get(`#${complaintType.toLowerCase()}-tab`).click({ force: true });
 
-    cy.waitForSpinner();
-
+    // This doesn't always appear... commenting it out for now.  I don't think it's required.
+    //cy.waitForSpinner();
+    cy.get("#comp-zone-filter").should('exist');
+    
     cy.get("#comp-zone-filter").click({ force: true }); //clear zone filter so this complaint is in the list view
+    
+    cy.get("#comp-status-filter").should('exist');
+
+    cy.get("#comp-status-filter").click({ force: true }); //clear status filter so this complaint is in the list view
+
 
     // This doesn't always appear... commenting it out for now.  I don't think it's required.
     // cy.waitForSpinner();

--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -159,7 +159,7 @@ Cypress.Commands.add(
     cy.visit("/");
 
     //I hate having this but I can't find a way to make sure the filters are there.
-    cy.wait(7000);
+    cy.waitForSpinner();
 
     //-- click on HWCR tab
     cy.get(`#${complaintType.toLowerCase()}-tab`).click({ force: true });

--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -159,7 +159,7 @@ Cypress.Commands.add(
     cy.visit("/");
 
     //I hate having this but I can't find a way to make sure the filters are there.
-    cy.wait(2000);
+    cy.wait(5000);
 
     //-- click on HWCR tab
     cy.get(`#${complaintType.toLowerCase()}-tab`).click({ force: true });

--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -159,21 +159,21 @@ Cypress.Commands.add(
     cy.visit("/");
 
     //I hate having this but I can't find a way to make sure the filters are there.
-    cy.wait(5000);
+    cy.wait(7000);
 
     //-- click on HWCR tab
     cy.get(`#${complaintType.toLowerCase()}-tab`).click({ force: true });
 
     // This doesn't always appear... commenting it out for now.  I don't think it's required.
     //cy.waitForSpinner();
-    cy.get("#comp-zone-filter").should('exist');
     
-    cy.get("#comp-zone-filter").click({ force: true }); //clear zone filter so this complaint is in the list view
+    cy.get("#comp-zone-filter").should('exist').click({ force: true }); //clear zone filter so this complaint is in the list view
+    cy.get("#comp-zone-filter").should('not.exist');
     
-    cy.get("#comp-status-filter").should('exist');
 
-    cy.get("#comp-status-filter").click({ force: true }); //clear status filter so this complaint is in the list view
 
+    cy.get("#comp-status-filter").should('exist').click({ force: true }); //clear status filter so this complaint is in the list view
+    cy.get("#comp-status-filter").should('not.exist');
 
     // This doesn't always appear... commenting it out for now.  I don't think it's required.
     // cy.waitForSpinner();

--- a/frontend/src/app/components/containers/complaints/complaint-list.tsx
+++ b/frontend/src/app/components/containers/complaints/complaint-list.tsx
@@ -5,7 +5,7 @@ import {
   getComplaints,
   selectComplaintsByType,
   setComplaints,
-  selectTotalComplaintsByType
+  selectTotalComplaintsByType,
 } from "../../../store/reducers/complaints";
 import { Table } from "react-bootstrap";
 import { SORT_TYPES } from "../../../constants/sort-direction";
@@ -14,7 +14,10 @@ import { ComplaintFilters } from "../../../types/complaints/complaint-filters/co
 import { ComplaintRequestPayload } from "../../../types/complaints/complaint-filters/complaint-reauest-payload";
 import { WildlifeComplaintListHeader } from "./headers/wildlife-complaint-list-header";
 import { AllegationComplaintListHeader } from "./headers/allegation-complaint-list-header";
-import { selectDefaultPageSize } from "../../../store/reducers/app";
+import {
+  selectDefaultPageSize,
+  selectDefaultZone,
+} from "../../../store/reducers/app";
 import { WildlifeComplaintListItem } from "./list-items/wildlife-complaint-list-item";
 import { HwcrComplaint } from "../../../types/complaints/hwcr-complaint";
 import { useNavigate } from "react-router-dom";
@@ -43,7 +46,6 @@ export const ComplaintList: FC<Props> = ({ type }) => {
 
   const [page, setPage] = useState<number>(1);
   const [pageSize, setPageSize] = useState<number>(defaultPageSize); // Default to 10 results per page
-
 
   const generateComplaintRequestPayload = (
     complaintType: string,
@@ -94,14 +96,19 @@ export const ComplaintList: FC<Props> = ({ type }) => {
     }
   };
 
+  const defaultZone = useAppSelector(selectDefaultZone);
+
   useEffect(() => {
-    const payload = generateComplaintRequestPayload(
-      type,
-      filters,
-      page,
-      pageSize
-    );
-    dispatch(getComplaints(type, payload));
+    if (defaultZone) {
+      const payload = generateComplaintRequestPayload(
+        type,
+        filters,
+        page,
+        pageSize
+      );
+
+      dispatch(getComplaints(type, payload));
+    }
   }, [filters, sortKey, sortDirection, page, pageSize]);
 
   useEffect(() => {

--- a/frontend/src/app/components/containers/complaints/complaints.tsx
+++ b/frontend/src/app/components/containers/complaints/complaints.tsx
@@ -17,10 +17,15 @@ import {
 import {
   resetFilters,
   ComplaintFilterPayload,
-  updateFilter
+  updateFilter,
 } from "../../../store/reducers/complaint-filters";
-import { selectDefaultZone, getOfficerDefaultZone, profileZoneDescription, profileZone } from '../../../store/reducers/app';
-import { DropdownOption } from '../../../types/code-tables/option';
+import {
+  selectDefaultZone,
+  getOfficerDefaultZone,
+  profileZoneDescription,
+  profileZone,
+} from "../../../store/reducers/app";
+import { DropdownOption } from "../../../types/code-tables/option";
 import { ComplaintMap } from "./complaint-map";
 import { COMPLAINT_VIEW_TYPES } from "../../../constants/complaint-view-type";
 import { selectTotalComplaintsOnMapByType } from "../../../store/reducers/complaint-locations";
@@ -33,7 +38,9 @@ type Props = {
 export const Complaints: FC<Props> = ({ defaultComplaintType }) => {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
-  const { dispatch: filterDispatch } = useContext(ComplaintFilterContext); //-- make sure to keep this dispatch renamed
+  const { dispatch: filterDispatch } = useContext(
+    ComplaintFilterContext
+  ); //-- make sure to keep this dispatch renamed
   const [complaintType, setComplaintType] = useState(defaultComplaintType);
 
   const [viewType, setViewType] = useState<"map" | "list">("list");
@@ -50,24 +57,6 @@ export const Complaints: FC<Props> = ({ defaultComplaintType }) => {
   const { getToggleProps } = useCollapse({ isExpanded });
 
   const defaultZone = useAppSelector(selectDefaultZone);
-  const zone_name = useAppSelector(profileZone);
-  const zone_descrption = useAppSelector(profileZoneDescription);
-
-  useEffect(() => {
-    if (defaultZone) {
-      setFilter("zone", { value: zone_name, label: zone_descrption });
-    } else {
-      dispatch(getOfficerDefaultZone);
-    }
-  }, [zone_name, zone_descrption]);
-
-  const setFilter = useCallback(
-    (name: string, value?: DropdownOption | Date | null) => {
-      let payload: ComplaintFilterPayload = { filter: name, value };
-      filterDispatch(updateFilter(payload));
-    },
-    []
-  );
 
   const complaintTypes: Array<{ name: string; id: string; code: string }> =
     Object.keys(COMPLAINT_TYPES).map((item) => {
@@ -79,19 +68,17 @@ export const Complaints: FC<Props> = ({ defaultComplaintType }) => {
     });
 
   // renders the complaint count on the list and map views, for the selected complaint type
-  const renderComplaintTotal = (selectedComplaintType: string): string | undefined => {
-    
+  const renderComplaintTotal = (
+    selectedComplaintType: string
+  ): string | undefined => {
     if (COMPLAINT_VIEW_TYPES.MAP === viewType) {
       if (complaintType === selectedComplaintType) {
         return `(${totalComplaintsOnMap})`;
       }
-    } else 
-    if (complaintType === selectedComplaintType) {
+    } else if (complaintType === selectedComplaintType) {
       return `(${totalComplaints})`;
     }
   };
-
-  
 
   const handleComplaintTabChange = (complaintType: string) => {
     setComplaintType(complaintType);
@@ -107,10 +94,7 @@ export const Complaints: FC<Props> = ({ defaultComplaintType }) => {
     filterDispatch(resetFilters(payload));
   };
 
-  const handleCreateClick = (
-    e: any,
-  ) => {
-
+  const handleCreateClick = (e: any) => {
     navigate(`/complaint/createComplaint`);
   };
 
@@ -148,39 +132,44 @@ export const Complaints: FC<Props> = ({ defaultComplaintType }) => {
           })}
 
           {/* <!-- dynamic tabs end --> */}
-		  
-          <Nav.Item className="ms-auto"
-          >
+
+          <Nav.Item className="ms-auto">
             <div hidden onClick={() => handleCreateClick(COMPLAINT_TYPES.ERS)}>
-            <div
-              className="complaint-create-image-container"
-              id="complaint-create-image-id"
-            >
-              <i className="bi bi-filter filter-image-spacing"></i>
-            </div>
-            <div className="left-float">Create</div>
-            <div className="clear-left-float"></div>
+              <div
+                className="complaint-create-image-container"
+                id="complaint-create-image-id"
+              >
+                <i className="bi bi-filter filter-image-spacing"></i>
+              </div>
+              <div className="left-float">Create</div>
+              <div className="clear-left-float"></div>
             </div>
           </Nav.Item>
-		  
+
           <Nav.Item
             className="ms-auto"
             {...getToggleProps({
-                onClick: () => {
-                  const filterElem = document.querySelector("#collapsible-complaints-list-filter-id");
-                  const rect = filterElem?.getBoundingClientRect();
-                  const bottom = rect?.bottom;
+              onClick: () => {
+                const filterElem = document.querySelector(
+                  "#collapsible-complaints-list-filter-id"
+                );
+                const rect = filterElem?.getBoundingClientRect();
+                const bottom = rect?.bottom;
 
-                  if({isExpanded}.isExpanded && bottom !== undefined && bottom < 140) //page has been scrolled while filter is open... need to close it!
-                  {
-                    setExpanded((prevExpanded) => !prevExpanded);
-                  }
-                  window.scrollTo({
-                    top: 0,
-                    behavior: "smooth",
-                    });
+                if (
+                  { isExpanded }.isExpanded &&
+                  bottom !== undefined &&
+                  bottom < 140
+                ) {
+                  //page has been scrolled while filter is open... need to close it!
                   setExpanded((prevExpanded) => !prevExpanded);
-                },
+                }
+                window.scrollTo({
+                  top: 0,
+                  behavior: "smooth",
+                });
+                setExpanded((prevExpanded) => !prevExpanded);
+              },
             })}
           >
             <div
@@ -212,8 +201,10 @@ export const Complaints: FC<Props> = ({ defaultComplaintType }) => {
 };
 
 export const ComplaintsWrapper: FC<Props> = ({ defaultComplaintType }) => {
+  const defaultZone = useAppSelector(selectDefaultZone);
+
   return (
-    <ComplaintFilterProvider>
+    <ComplaintFilterProvider zone={defaultZone}>
       <Complaints defaultComplaintType={defaultComplaintType} />
     </ComplaintFilterProvider>
   );

--- a/frontend/src/app/components/containers/complaints/complaints.tsx
+++ b/frontend/src/app/components/containers/complaints/complaints.tsx
@@ -1,10 +1,10 @@
-import { FC, useState, useContext, useEffect, useCallback } from "react";
+import { FC, useState, useContext } from "react";
 import { Nav, Navbar } from "react-bootstrap";
 import { useCollapse } from "react-collapsed";
 import COMPLAINT_TYPES, {
   complaintTypeToName,
 } from "../../../types/app/complaint-types";
-import { useAppDispatch, useAppSelector } from "../../../hooks/hooks";
+import { useAppSelector } from "../../../hooks/hooks";
 import { selectTotalComplaintsByType } from "../../../store/reducers/complaints";
 import { ComplaintFilter } from "./complaint-filter";
 import { ComplaintList } from "./complaint-list";
@@ -16,16 +16,11 @@ import {
 } from "../../../providers/complaint-filter-provider";
 import {
   resetFilters,
-  ComplaintFilterPayload,
-  updateFilter,
+  ComplaintFilterPayload
 } from "../../../store/reducers/complaint-filters";
 import {
-  selectDefaultZone,
-  getOfficerDefaultZone,
-  profileZoneDescription,
-  profileZone,
+  selectDefaultZone
 } from "../../../store/reducers/app";
-import { DropdownOption } from "../../../types/code-tables/option";
 import { ComplaintMap } from "./complaint-map";
 import { COMPLAINT_VIEW_TYPES } from "../../../constants/complaint-view-type";
 import { selectTotalComplaintsOnMapByType } from "../../../store/reducers/complaint-locations";
@@ -36,7 +31,6 @@ type Props = {
 };
 
 export const Complaints: FC<Props> = ({ defaultComplaintType }) => {
-  const dispatch = useAppDispatch();
   const navigate = useNavigate();
   const { dispatch: filterDispatch } = useContext(
     ComplaintFilterContext

--- a/frontend/src/app/providers/complaint-filter-provider.tsx
+++ b/frontend/src/app/providers/complaint-filter-provider.tsx
@@ -1,6 +1,7 @@
 import React, { FC, createContext, useReducer } from "react";
 import complaintFilterReducer from "../store/reducers/complaint-filters";
 import { ComplaintFilters } from "../types/complaints/complaint-filters/complaint-filters";
+import { ComplaintFilterPayload } from '../store/reducers/complaint-filters';
 
 interface ComplaintFilterContextType {
   state: ComplaintFilters;
@@ -9,9 +10,10 @@ interface ComplaintFilterContextType {
 
 type ProviderProps = {
   children: React.ReactNode;
+  zone: any
 };
 
-const initialState: ComplaintFilters = {
+let initialState: ComplaintFilters = {
   region: null,
   zone: null,
   community: null,
@@ -22,14 +24,19 @@ const initialState: ComplaintFilters = {
   species: null,
   natureOfComplaint: null,
   violationType: null,
+  filters: [],
 };
 
 const ComplaintFilterContext = createContext<ComplaintFilterContextType>({
   state: initialState,
-  dispatch: () => {},
+  dispatch: () => {}
 });
 
-const ComplaintFilterProvider: FC<ProviderProps> = ({ children }) => {
+const ComplaintFilterProvider: FC<ProviderProps> = ({ children, zone }) => {
+  if(zone){
+    initialState = {...initialState, zone}
+  }
+
   const [state, dispatch] = useReducer(complaintFilterReducer, initialState);
 
   const value = React.useMemo(

--- a/frontend/src/app/providers/complaint-filter-provider.tsx
+++ b/frontend/src/app/providers/complaint-filter-provider.tsx
@@ -1,7 +1,6 @@
 import React, { FC, createContext, useReducer } from "react";
 import complaintFilterReducer from "../store/reducers/complaint-filters";
 import { ComplaintFilters } from "../types/complaints/complaint-filters/complaint-filters";
-import { ComplaintFilterPayload } from '../store/reducers/complaint-filters';
 
 interface ComplaintFilterContextType {
   state: ComplaintFilters;

--- a/frontend/src/app/types/complaints/complaint-filters/complaint-filters.ts
+++ b/frontend/src/app/types/complaints/complaint-filters/complaint-filters.ts
@@ -15,4 +15,6 @@ export type ComplaintFilters = {
    natureOfComplaint: DropdownOption | null;
  
    violationType: DropdownOption | null;
+
+   filters: Array<any>
  };


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Fixes the behaviour of the default zone filter. Initially the default zone is not being correctly applied, the update to the complaint filter provider applies the default zone as part of initial state opposed to setting the filter on load which has been causing the complaints list to be requested without the default zone being applied

Fixes # COMPENF-859

# How Has This Been Tested?
Existing tests handle this update


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-154-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-compliance-enforcement-154-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)