### PR TITLE
feature/CE-109: Implement filter option cascading

### DIFF
--- a/frontend/cypress/e2e/complaint-filter-cascade.cy.ts
+++ b/frontend/cypress/e2e/complaint-filter-cascade.cy.ts
@@ -1,3 +1,44 @@
+function verifyFilters (expectedZones: number, expectedRegions: number, expectedCommunities: number) {
+    
+    cy.get("#react-collapsed-toggle-\\:r1\\: > .left-float").click();
+
+    cy.get(
+      "#region-select-filter-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
+    ).click({ force: true });
+    cy.get(".comp-select__menu-list")
+      .find("div")
+      .then(({ length }) => {
+        expect(length, "rows N").to.be.eq(expectedZones);
+      });
+    cy.get(
+      "#region-select-filter-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
+    ).click({ force: true });
+
+    cy.get(
+      "#zone-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
+    ).click({ force: true });
+    cy.get(".comp-select__menu-list")
+      .find("div")
+      .then(({ length }) => {
+        expect(length, "rows N").to.be.eq(expectedRegions);
+      });
+    cy.get(
+      "#zone-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
+    ).click({ force: true });
+
+    cy.get(
+      "#community-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
+    ).click({ force: true });
+    cy.get(".comp-select__menu-list")
+      .find("div")
+      .then(({ length }) => {
+        expect(length, "rows N").to.be.eq(expectedCommunities);
+      });
+    cy.get(
+      "#community-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
+    ).click({ force: true });
+};
+
 /*
 Test to verify that the filter types: region, zone, and communities cascade based
 on what is and isn't selected. ie when the region is selected, the zone and 
@@ -5,6 +46,7 @@ communities filter options are filtered to only display options associated with
 the selected region
 */
 describe("Complaint Filter Cascading spec", () => {
+  const complaintTypes = ["#hwcr-tab", "#ers-tab"];
   const maxRegions = 8;
   const maxZones = 22;
   const maxCommunities = 970;
@@ -19,57 +61,10 @@ describe("Complaint Filter Cascading spec", () => {
     cy.visit("/");
     cy.waitForSpinner();
 
-    cy.get("body").then($body => {
-      if ($body.find("button[data-cy=appDrawerOpener]").length > 0) {   
-          //evaluates as true
-      }
-  });
+    cy.navigateToTab(complaintTypes[0], true);
 
-    cy.get("#comp-zone-filter").then($elm => { 
-      cy.get("#comp-zone-filter").click({ force: true });
-    })
-    cy.get("#comp-status-filter").then(() => { 
-      cy.get("#comp-status-filter").click({ force: true });
-    })
-  
-    //--
-    cy.get("#react-collapsed-toggle-\\:r1\\: > .left-float").click();
+    verifyFilters (maxRegions, maxZones, maxCommunities);
 
-    cy.get(
-      "#region-select-filter-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
-    ).click({ force: true });
-    cy.get(".comp-select__menu-list")
-      .find("div")
-      .then(({ length }) => {
-        expect(length, "rows N").to.be.eq(maxRegions);
-      });
-    cy.get(
-      "#region-select-filter-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
-    ).click({ force: true });
-
-    cy.get(
-      "#zone-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
-    ).click({ force: true });
-    cy.get(".comp-select__menu-list")
-      .find("div")
-      .then(({ length }) => {
-        expect(length, "rows N").to.be.eq(maxZones);
-      });
-    cy.get(
-      "#zone-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
-    ).click({ force: true });
-
-    cy.get(
-      "#community-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
-    ).click({ force: true });
-    cy.get(".comp-select__menu-list")
-      .find("div")
-      .then(({ length }) => {
-        expect(length, "rows N").to.be.eq(maxCommunities);
-      });
-    cy.get(
-      "#community-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
-    ).click({ force: true });
   });
 
   it("Verifies zone and communities are cascaded when selecting a region", () => {
@@ -84,55 +79,9 @@ describe("Complaint Filter Cascading spec", () => {
     cy.visit("/");
     cy.waitForSpinner();
 
-    cy.get("#comp-zone-filter").then($elm => { 
-      cy.get("#comp-zone-filter").click({ force: true });
-    })
-    cy.get("#comp-status-filter").then(() => { 
-      cy.get("#comp-status-filter").click({ force: true });
-    })
+    cy.navigateToTab(complaintTypes[0], true);
 
-    //--
-    cy.get("#react-collapsed-toggle-\\:r1\\: > .left-float").click();
-
-    //-- select region
-    cy.selectItemById("region-select-filter-id", _selected);
-
-    //-- verify zone and community cascade
-    cy.get(
-      "#region-select-filter-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
-    ).click({ force: true });
-    cy.get(".comp-select__menu-list")
-      .find("div")
-      .then(({ length }) => {
-        expect(length, "rows N").to.be.eq(_totalRegions);
-      });
-    cy.get(
-      "#region-select-filter-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
-    ).click({ force: true });
-
-    cy.get(
-      "#zone-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
-    ).click({ force: true });
-    cy.get(".comp-select__menu-list")
-      .find("div")
-      .then(({ length }) => {
-        expect(length, "rows N").to.be.eq(_totalZones);
-      });
-    cy.get(
-      "#zone-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
-    ).click({ force: true });
-
-    cy.get(
-      "#community-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
-    ).click({ force: true });
-    cy.get(".comp-select__menu-list")
-      .find("div")
-      .then(({ length }) => {
-        expect(length, "rows N").to.be.eq(_totalCommunities);
-      });
-    cy.get(
-      "#community-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
-    ).click({ force: true });
+    verifyFilters (maxRegions, maxZones, maxCommunities);
   });
 
   it("Verifies communities are cascaded when selecting a zone", () => {
@@ -147,55 +96,9 @@ describe("Complaint Filter Cascading spec", () => {
    cy.visit("/");
    cy.waitForSpinner();
 
-   cy.get("#comp-zone-filter").then($elm => { 
-    cy.get("#comp-zone-filter").click({ force: true });
-  })
-  cy.get("#comp-status-filter").then(() => { 
-    cy.get("#comp-status-filter").click({ force: true });
-  })
+   cy.navigateToTab(complaintTypes[0], true);
 
-   //--
-   cy.get("#react-collapsed-toggle-\\:r1\\: > .left-float").click();
-
-   //-- select region
-   cy.selectItemById("zone-select-id", _selected);
-
-   //-- verify community cascade
-   cy.get(
-      "#region-select-filter-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
-    ).click({ force: true });
-    cy.get(".comp-select__menu-list")
-      .find("div")
-      .then(({ length }) => {
-        expect(length, "rows N").to.be.eq(_totalRegions);
-      });
-    cy.get(
-      "#region-select-filter-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
-    ).click({ force: true });
-
-   cy.get(
-     "#zone-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
-   ).click({ force: true });
-   cy.get(".comp-select__menu-list")
-     .find("div")
-     .then(({ length }) => {
-       expect(length, "rows N").to.be.eq(_totalZones);
-     });
-   cy.get(
-     "#zone-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
-   ).click({ force: true });
-
-   cy.get(
-     "#community-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
-   ).click({ force: true });
-   cy.get(".comp-select__menu-list")
-     .find("div")
-     .then(({ length }) => {
-       expect(length, "rows N").to.be.eq(_totalCommunities);
-     });
-   cy.get(
-     "#community-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
-   ).click({ force: true });
+   verifyFilters (maxRegions, maxZones, maxCommunities);
  });
 
  it("Verifies regions and zones are cascaded when selecting a community", () => {
@@ -210,54 +113,10 @@ describe("Complaint Filter Cascading spec", () => {
    cy.visit("/");
    cy.waitForSpinner();
 
-   cy.get("#comp-zone-filter").then($elm => { 
-    cy.get("#comp-zone-filter").click({ force: true });
-  })
-  cy.get("#comp-status-filter").then(() => { 
-    cy.get("#comp-status-filter").click({ force: true });
-  })
+   cy.navigateToTab(complaintTypes[0], true);
 
-   //--
-   cy.get("#react-collapsed-toggle-\\:r1\\: > .left-float").click();
-
-   //-- select region
-   cy.selectItemById("community-select-id", _selected);
-
-   //-- verify community cascade
-   cy.get(
-      "#region-select-filter-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
-    ).click({ force: true });
-    cy.get(".comp-select__menu-list")
-      .find("div")
-      .then(({ length }) => {
-        expect(length, "rows N").to.be.eq(_totalRegions);
-      });
-    cy.get(
-      "#region-select-filter-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
-    ).click({ force: true });
-
-   cy.get(
-     "#zone-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
-   ).click({ force: true });
-   cy.get(".comp-select__menu-list")
-     .find("div")
-     .then(({ length }) => {
-       expect(length, "rows N").to.be.eq(_totalZones);
-     });
-   cy.get(
-     "#zone-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
-   ).click({ force: true });
-
-   cy.get(
-     "#community-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
-   ).click({ force: true });
-   cy.get(".comp-select__menu-list")
-     .find("div")
-     .then(({ length }) => {
-       expect(length, "rows N").to.be.eq(_totalCommunities);
-     });
-   cy.get(
-     "#community-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
-   ).click({ force: true });
+   verifyFilters (maxRegions, maxZones, maxCommunities);
  });
+
 });
+

--- a/frontend/cypress/e2e/complaint-filter-cascade.cy.ts
+++ b/frontend/cypress/e2e/complaint-filter-cascade.cy.ts
@@ -19,12 +19,19 @@ describe("Complaint Filter Cascading spec", () => {
     cy.visit("/");
     cy.waitForSpinner();
 
-    cy.get("#comp-zone-filter").should("exist");
-    cy.get("#comp-status-filter").should("exist");
+    cy.get("body").then($body => {
+      if ($body.find("button[data-cy=appDrawerOpener]").length > 0) {   
+          //evaluates as true
+      }
+  });
 
-    cy.get("#comp-zone-filter").click({ force: true });
-    cy.get("#comp-status-filter").click({ force: true });
-
+    cy.get("#comp-zone-filter").then($elm => { 
+      cy.get("#comp-zone-filter").click({ force: true });
+    })
+    cy.get("#comp-status-filter").then(() => { 
+      cy.get("#comp-status-filter").click({ force: true });
+    })
+  
     //--
     cy.get("#react-collapsed-toggle-\\:r1\\: > .left-float").click();
 
@@ -77,11 +84,12 @@ describe("Complaint Filter Cascading spec", () => {
     cy.visit("/");
     cy.waitForSpinner();
 
-    cy.get("#comp-zone-filter").should("exist");
-    cy.get("#comp-status-filter").should("exist");
-
-    cy.get("#comp-zone-filter").click({ force: true });
-    cy.get("#comp-status-filter").click({ force: true });
+    cy.get("#comp-zone-filter").then($elm => { 
+      cy.get("#comp-zone-filter").click({ force: true });
+    })
+    cy.get("#comp-status-filter").then(() => { 
+      cy.get("#comp-status-filter").click({ force: true });
+    })
 
     //--
     cy.get("#react-collapsed-toggle-\\:r1\\: > .left-float").click();
@@ -139,11 +147,12 @@ describe("Complaint Filter Cascading spec", () => {
    cy.visit("/");
    cy.waitForSpinner();
 
-   cy.get("#comp-zone-filter").should("exist");
-   cy.get("#comp-status-filter").should("exist");
-
-   cy.get("#comp-zone-filter").click({ force: true });
-   cy.get("#comp-status-filter").click({ force: true });
+   cy.get("#comp-zone-filter").then($elm => { 
+    cy.get("#comp-zone-filter").click({ force: true });
+  })
+  cy.get("#comp-status-filter").then(() => { 
+    cy.get("#comp-status-filter").click({ force: true });
+  })
 
    //--
    cy.get("#react-collapsed-toggle-\\:r1\\: > .left-float").click();
@@ -201,11 +210,12 @@ describe("Complaint Filter Cascading spec", () => {
    cy.visit("/");
    cy.waitForSpinner();
 
-   cy.get("#comp-zone-filter").should("exist");
-   cy.get("#comp-status-filter").should("exist");
-
-   cy.get("#comp-zone-filter").click({ force: true });
-   cy.get("#comp-status-filter").click({ force: true });
+   cy.get("#comp-zone-filter").then($elm => { 
+    cy.get("#comp-zone-filter").click({ force: true });
+  })
+  cy.get("#comp-status-filter").then(() => { 
+    cy.get("#comp-status-filter").click({ force: true });
+  })
 
    //--
    cy.get("#react-collapsed-toggle-\\:r1\\: > .left-float").click();

--- a/frontend/cypress/e2e/complaint-filter-cascade.cy.ts
+++ b/frontend/cypress/e2e/complaint-filter-cascade.cy.ts
@@ -1,6 +1,5 @@
+//This is probably only useful for this test, so it's not a command.
 function verifyFilters (expectedZones: number, expectedRegions: number, expectedCommunities: number) {
-    
-    cy.get("#react-collapsed-toggle-\\:r1\\: > .left-float").click();
 
     cy.get(
       "#region-select-filter-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
@@ -63,6 +62,8 @@ describe("Complaint Filter Cascading spec", () => {
 
     cy.navigateToTab(complaintTypes[0], true);
 
+    cy.get("#react-collapsed-toggle-\\:r1\\: > .left-float").click();
+
     verifyFilters (maxRegions, maxZones, maxCommunities);
 
   });
@@ -81,7 +82,12 @@ describe("Complaint Filter Cascading spec", () => {
 
     cy.navigateToTab(complaintTypes[0], true);
 
-    verifyFilters (maxRegions, maxZones, maxCommunities);
+    cy.get("#react-collapsed-toggle-\\:r1\\: > .left-float").click();
+
+    //-- select region
+    cy.selectItemById("region-select-filter-id", _selected);
+
+    verifyFilters (_totalRegions, _totalZones, _totalCommunities);
   });
 
   it("Verifies communities are cascaded when selecting a zone", () => {
@@ -98,7 +104,12 @@ describe("Complaint Filter Cascading spec", () => {
 
    cy.navigateToTab(complaintTypes[0], true);
 
-   verifyFilters (maxRegions, maxZones, maxCommunities);
+   cy.get("#react-collapsed-toggle-\\:r1\\: > .left-float").click();
+
+   //-- select region
+   cy.selectItemById("zone-select-id", _selected);
+
+   verifyFilters (_totalRegions, _totalZones, _totalCommunities);
  });
 
  it("Verifies regions and zones are cascaded when selecting a community", () => {
@@ -115,7 +126,12 @@ describe("Complaint Filter Cascading spec", () => {
 
    cy.navigateToTab(complaintTypes[0], true);
 
-   verifyFilters (maxRegions, maxZones, maxCommunities);
+   cy.get("#react-collapsed-toggle-\\:r1\\: > .left-float").click();
+
+   //-- select region
+   cy.selectItemById("community-select-id", _selected);
+
+   verifyFilters (_totalRegions, _totalZones, _totalCommunities);
  });
 
 });

--- a/frontend/cypress/e2e/complaint-filter-cascade.cy.ts
+++ b/frontend/cypress/e2e/complaint-filter-cascade.cy.ts
@@ -62,7 +62,7 @@ describe("Complaint Filter Cascading spec", () => {
 
     cy.navigateToTab(complaintTypes[0], true);
 
-    cy.get("#react-collapsed-toggle-\\:r1\\: > .left-float").click();
+    cy.get("#complaint-filter-image-id").click({ force: true });
 
     verifyFilters (maxRegions, maxZones, maxCommunities);
 
@@ -82,7 +82,7 @@ describe("Complaint Filter Cascading spec", () => {
 
     cy.navigateToTab(complaintTypes[0], true);
 
-    cy.get("#react-collapsed-toggle-\\:r1\\: > .left-float").click();
+    cy.get("#complaint-filter-image-id").click({ force: true });
 
     //-- select region
     cy.selectItemById("region-select-filter-id", _selected);
@@ -104,7 +104,7 @@ describe("Complaint Filter Cascading spec", () => {
 
    cy.navigateToTab(complaintTypes[0], true);
 
-   cy.get("#react-collapsed-toggle-\\:r1\\: > .left-float").click();
+   cy.get("#complaint-filter-image-id").click({ force: true });
 
    //-- select region
    cy.selectItemById("zone-select-id", _selected);
@@ -126,7 +126,7 @@ describe("Complaint Filter Cascading spec", () => {
 
    cy.navigateToTab(complaintTypes[0], true);
 
-   cy.get("#react-collapsed-toggle-\\:r1\\: > .left-float").click();
+   cy.get("#complaint-filter-image-id").click({ force: true });
 
    //-- select region
    cy.selectItemById("community-select-id", _selected);

--- a/frontend/cypress/e2e/complaint-filter-cascade.cy.ts
+++ b/frontend/cypress/e2e/complaint-filter-cascade.cy.ts
@@ -5,7 +5,6 @@ communities filter options are filtered to only display options associated with
 the selected region
 */
 describe("Complaint Filter Cascading spec", () => {
-  const complaintTypes = ["#hwcr-tab"];
   const maxRegions = 8;
   const maxZones = 22;
   const maxCommunities = 970;
@@ -102,7 +101,7 @@ describe("Complaint Filter Cascading spec", () => {
     cy.get(
       "#region-select-filter-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
     ).click({ force: true });
-    
+
     cy.get(
       "#zone-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
     ).click({ force: true });

--- a/frontend/cypress/e2e/complaint-filter-cascade.cy.ts
+++ b/frontend/cypress/e2e/complaint-filter-cascade.cy.ts
@@ -1,0 +1,254 @@
+/*
+Test to verify that the filter types: region, zone, and communities cascade based
+on what is and isn't selected. ie when the region is selected, the zone and 
+communities filter options are filtered to only display options associated with 
+the selected region
+*/
+describe("Complaint Filter Cascading spec", () => {
+  const complaintTypes = ["#hwcr-tab"];
+  const maxRegions = 8;
+  const maxZones = 22;
+  const maxCommunities = 970;
+
+  beforeEach(function () {
+    cy.viewport(1700, 960);
+    cy.kcLogout().kcLogin();
+  });
+
+  it("Verifies filters are not cascaded", () => {
+    //-- load the page and remove existing default filters
+    cy.visit("/");
+    cy.waitForSpinner();
+
+    cy.get("#comp-zone-filter").should("exist");
+    cy.get("#comp-status-filter").should("exist");
+
+    cy.get("#comp-zone-filter").click({ force: true });
+    cy.get("#comp-status-filter").click({ force: true });
+
+    //--
+    cy.get("#react-collapsed-toggle-\\:r1\\: > .left-float").click();
+
+    cy.get(
+      "#region-select-filter-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
+    ).click({ force: true });
+    cy.get(".comp-select__menu-list")
+      .find("div")
+      .then(({ length }) => {
+        expect(length, "rows N").to.be.eq(maxRegions);
+      });
+    cy.get(
+      "#region-select-filter-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
+    ).click({ force: true });
+
+    cy.get(
+      "#zone-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
+    ).click({ force: true });
+    cy.get(".comp-select__menu-list")
+      .find("div")
+      .then(({ length }) => {
+        expect(length, "rows N").to.be.eq(maxZones);
+      });
+    cy.get(
+      "#zone-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
+    ).click({ force: true });
+
+    cy.get(
+      "#community-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
+    ).click({ force: true });
+    cy.get(".comp-select__menu-list")
+      .find("div")
+      .then(({ length }) => {
+        expect(length, "rows N").to.be.eq(maxCommunities);
+      });
+    cy.get(
+      "#community-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
+    ).click({ force: true });
+  });
+
+  it("Verifies zone and communities are cascaded when selecting a region", () => {
+    //-- arrange
+    const _selected = "West Coast";
+
+    const _totalRegions = 1;
+    const _totalZones = 3;
+    const _totalCommunities = 127;
+
+    //-- load the page and remove existing default filters
+    cy.visit("/");
+    cy.waitForSpinner();
+
+    cy.get("#comp-zone-filter").should("exist");
+    cy.get("#comp-status-filter").should("exist");
+
+    cy.get("#comp-zone-filter").click({ force: true });
+    cy.get("#comp-status-filter").click({ force: true });
+
+    //--
+    cy.get("#react-collapsed-toggle-\\:r1\\: > .left-float").click();
+
+    //-- select region
+    cy.selectItemById("region-select-filter-id", _selected);
+
+    //-- verify zone and community cascade
+    cy.get(
+      "#region-select-filter-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
+    ).click({ force: true });
+    cy.get(".comp-select__menu-list")
+      .find("div")
+      .then(({ length }) => {
+        expect(length, "rows N").to.be.eq(_totalRegions);
+      });
+    cy.get(
+      "#region-select-filter-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
+    ).click({ force: true });
+    
+    cy.get(
+      "#zone-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
+    ).click({ force: true });
+    cy.get(".comp-select__menu-list")
+      .find("div")
+      .then(({ length }) => {
+        expect(length, "rows N").to.be.eq(_totalZones);
+      });
+    cy.get(
+      "#zone-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
+    ).click({ force: true });
+
+    cy.get(
+      "#community-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
+    ).click({ force: true });
+    cy.get(".comp-select__menu-list")
+      .find("div")
+      .then(({ length }) => {
+        expect(length, "rows N").to.be.eq(_totalCommunities);
+      });
+    cy.get(
+      "#community-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
+    ).click({ force: true });
+  });
+
+  it("Verifies communities are cascaded when selecting a zone", () => {
+   //-- arrange
+   const _selected = "Fraser North";
+
+   const _totalRegions = 1;
+   const _totalZones = 1;
+   const _totalCommunities = 27;
+
+   //-- load the page and remove existing default filters
+   cy.visit("/");
+   cy.waitForSpinner();
+
+   cy.get("#comp-zone-filter").should("exist");
+   cy.get("#comp-status-filter").should("exist");
+
+   cy.get("#comp-zone-filter").click({ force: true });
+   cy.get("#comp-status-filter").click({ force: true });
+
+   //--
+   cy.get("#react-collapsed-toggle-\\:r1\\: > .left-float").click();
+
+   //-- select region
+   cy.selectItemById("zone-select-id", _selected);
+
+   //-- verify community cascade
+   cy.get(
+      "#region-select-filter-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
+    ).click({ force: true });
+    cy.get(".comp-select__menu-list")
+      .find("div")
+      .then(({ length }) => {
+        expect(length, "rows N").to.be.eq(_totalRegions);
+      });
+    cy.get(
+      "#region-select-filter-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
+    ).click({ force: true });
+
+   cy.get(
+     "#zone-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
+   ).click({ force: true });
+   cy.get(".comp-select__menu-list")
+     .find("div")
+     .then(({ length }) => {
+       expect(length, "rows N").to.be.eq(_totalZones);
+     });
+   cy.get(
+     "#zone-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
+   ).click({ force: true });
+
+   cy.get(
+     "#community-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
+   ).click({ force: true });
+   cy.get(".comp-select__menu-list")
+     .find("div")
+     .then(({ length }) => {
+       expect(length, "rows N").to.be.eq(_totalCommunities);
+     });
+   cy.get(
+     "#community-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
+   ).click({ force: true });
+ });
+
+ it("Verifies regions and zones are cascaded when selecting a community", () => {
+   //-- arrange
+   const _selected = "Cluculz Lake";
+
+   const _totalRegions = 1;
+   const _totalZones = 1;
+   const _totalCommunities = 1;
+
+   //-- load the page and remove existing default filters
+   cy.visit("/");
+   cy.waitForSpinner();
+
+   cy.get("#comp-zone-filter").should("exist");
+   cy.get("#comp-status-filter").should("exist");
+
+   cy.get("#comp-zone-filter").click({ force: true });
+   cy.get("#comp-status-filter").click({ force: true });
+
+   //--
+   cy.get("#react-collapsed-toggle-\\:r1\\: > .left-float").click();
+
+   //-- select region
+   cy.selectItemById("community-select-id", _selected);
+
+   //-- verify community cascade
+   cy.get(
+      "#region-select-filter-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
+    ).click({ force: true });
+    cy.get(".comp-select__menu-list")
+      .find("div")
+      .then(({ length }) => {
+        expect(length, "rows N").to.be.eq(_totalRegions);
+      });
+    cy.get(
+      "#region-select-filter-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
+    ).click({ force: true });
+
+   cy.get(
+     "#zone-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
+   ).click({ force: true });
+   cy.get(".comp-select__menu-list")
+     .find("div")
+     .then(({ length }) => {
+       expect(length, "rows N").to.be.eq(_totalZones);
+     });
+   cy.get(
+     "#zone-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
+   ).click({ force: true });
+
+   cy.get(
+     "#community-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
+   ).click({ force: true });
+   cy.get(".comp-select__menu-list")
+     .find("div")
+     .then(({ length }) => {
+       expect(length, "rows N").to.be.eq(_totalCommunities);
+     });
+   cy.get(
+     "#community-select-id > .comp-select__control > .comp-select__value-container > .comp-select__input-container"
+   ).click({ force: true });
+ });
+});

--- a/frontend/src/app/components/containers/complaints/complaint-filter.tsx
+++ b/frontend/src/app/components/containers/complaints/complaint-filter.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback, useContext, useEffect } from "react";
+import { FC, useCallback, useContext } from "react";
 import "../../../../../node_modules/react-datepicker/dist/react-datepicker.css";
 import "../../../../../node_modules/react-datepicker/dist/react-datepicker-cssmodules.css";
 import { useAppSelector } from "../../../hooks/hooks";
@@ -65,13 +65,6 @@ export const ComplaintFilter: FC<Props> = ({ type, isOpen }) => {
     },
     [dispatch]
   );
-
-  useEffect(() => {
-    if (region) {
-      console.log("casecade zone and communities");
-    } else {
-    }
-  }, [region]);
 
   const handleDateRangeChange = (dates: [Date, Date]) => {
     const [start, end] = dates;

--- a/frontend/src/app/components/containers/complaints/complaint-filter.tsx
+++ b/frontend/src/app/components/containers/complaints/complaint-filter.tsx
@@ -1,15 +1,15 @@
-import { FC, useCallback, useContext } from "react";
+import { FC, useCallback, useContext, useEffect } from "react";
 import "../../../../../node_modules/react-datepicker/dist/react-datepicker.css";
 import "../../../../../node_modules/react-datepicker/dist/react-datepicker-cssmodules.css";
 import { useAppSelector } from "../../../hooks/hooks";
 import {
-  selectRegionCodeDropdown,
-  selectZoneCodeDropdown,
-  selectCommunityCodeDropdown,
   selectHwcrNatureOfComplaintCodeDropdown,
   selectSpeciesCodeDropdown,
   selectComplaintStatusCodeDropdown,
-  selectViolationCodeDropdown
+  selectViolationCodeDropdown,
+  selectCascadedRegion,
+  selectCascadedZone,
+  selectCascadedCommunity,
 } from "../../../store/reducers/code-table";
 import { selectOfficersDropdown } from "../../../store/reducers/officer";
 import COMPLAINT_TYPES from "../../../types/app/complaint-types";
@@ -46,14 +46,17 @@ export const ComplaintFilter: FC<Props> = ({ type, isOpen }) => {
     dispatch,
   } = useContext(ComplaintFilterContext);
 
-  const regions = useAppSelector(selectRegionCodeDropdown);
-  const zones = useAppSelector(selectZoneCodeDropdown);
-  const communities = useAppSelector(selectCommunityCodeDropdown);
   const officers = useAppSelector(selectOfficersDropdown);
-  const natureOfComplaintTypes = useAppSelector(selectHwcrNatureOfComplaintCodeDropdown);
+  const natureOfComplaintTypes = useAppSelector(
+    selectHwcrNatureOfComplaintCodeDropdown
+  );
   const speciesTypes = useAppSelector(selectSpeciesCodeDropdown);
   const statusTypes = useAppSelector(selectComplaintStatusCodeDropdown);
   const violationTypes = useAppSelector(selectViolationCodeDropdown);
+
+  const regions = useAppSelector(selectCascadedRegion(region?.value, zone?.value, community?.value));
+  const zones = useAppSelector(selectCascadedZone(region?.value, zone?.value, community?.value));
+  const communities = useAppSelector(selectCascadedCommunity(region?.value, zone?.value, community?.value));
 
   const setFilter = useCallback(
     (name: string, value?: Option | Date | null) => {
@@ -62,6 +65,13 @@ export const ComplaintFilter: FC<Props> = ({ type, isOpen }) => {
     },
     [dispatch]
   );
+
+  useEffect(() => {
+    if (region) {
+      console.log("casecade zone and communities");
+    } else {
+    }
+  }, [region]);
 
   const handleDateRangeChange = (dates: [Date, Date]) => {
     const [start, end] = dates;

--- a/frontend/src/app/store/reducers/code-table.ts
+++ b/frontend/src/app/store/reducers/code-table.ts
@@ -417,7 +417,7 @@ export const selectAttractantCodeDropdown = (
     const item: Option = { label: shortDescription, value: attractant };
     return item;
   });
-  
+
   return data;
 };
 
@@ -473,5 +473,313 @@ export const selectCommunityCodeDropdown = (
   });
   return data;
 };
+
+export const selectCascadedFilter =
+  (type: string, value?: string) =>
+  (state: RootState): Array<DropdownOption> => {
+    const {
+      codeTables: { regions, zones },
+    } = state;
+
+    switch (type) {
+      case "region": {
+        const data = regions.map(({ code, name }) => {
+          const item: DropdownOption = {
+            label: name,
+            value: code,
+            description: name,
+          };
+          return item;
+        });
+
+        if (value) {
+          return data.filter((item) => item.value === value);
+        }
+
+        return data;
+      }
+      case "zone": {
+        const data = zones.map(({ code, name }) => {
+          const item: DropdownOption = {
+            label: name,
+            value: code,
+            description: name,
+          };
+          return item;
+        });
+
+        if (value) {
+          const items = zones.filter(({ region }) => region === value);
+          return items.map(({ code, name }) => {
+            const item: DropdownOption = {
+              label: name,
+              value: code,
+              description: name,
+            };
+            return item;
+          });
+        }
+
+        return data;
+      }
+      case "community":
+      default:
+        break;
+    }
+
+    return [];
+  };
+
+export const selectCascadedFilters =
+  (region?: string, zone?: string, community?: string) =>
+  (state: RootState): any => {
+    const {
+      codeTables: { regions, zones, communities },
+    } = state;
+
+    let _regions: Array<DropdownOption> = [];
+    let _zones: Array<DropdownOption> = [];
+    let _communities: Array<DropdownOption> = [];
+
+    if (!region && zone && !community) {
+      const selected = zones.find((item) => item.code === zone);
+
+      if (selected) {
+        _regions = regions
+          .filter((item) => item.code === selected.region)
+          .map(({ code, name }) => {
+            return {
+              label: name,
+              value: code,
+              description: name,
+            };
+          });
+
+        _zones = [
+          {
+            label: selected.name,
+            value: selected.code,
+            description: selected.name,
+          },
+        ];
+
+        _communities = communities
+          .filter((item) => item.zone === zone)
+          .map(({ code, name }) => {
+            return {
+              label: name,
+              value: code,
+              description: name,
+            };
+          });
+      }
+    } else if (region && !zone && !community) {
+      const selected = regions.find((item) => item.code === region);
+      if (selected) {
+        _regions = [
+          {
+            label: selected.name,
+            value: selected.code,
+            description: selected.name,
+          },
+        ];
+
+        _zones = zones
+          .filter((item) => item.region === region)
+          .map(({ code, name }) => {
+            return {
+              label: name,
+              value: code,
+              description: name,
+            };
+          });
+
+        _communities = communities
+          .filter((item) => item.region === region)
+          .map(({ code, name }) => {
+            return {
+              label: name,
+              value: code,
+              description: name,
+            };
+          });
+      }
+    } else if (!region && !zone && !community) {
+      _regions = regions.map(({ code, name }) => {
+        return {
+          label: name,
+          value: code,
+          description: name,
+        };
+      });
+      _zones = zones.map(({ code, name }) => {
+        return {
+          label: name,
+          value: code,
+          description: name,
+        };
+      });
+
+      _communities = communities.map(({ code, name }) => {
+        return {
+          label: name,
+          value: code,
+          description: name,
+        };
+      });
+      return {
+        regions: _regions,
+        zones: _zones,
+        communities: _communities,
+      };
+    }
+
+    return {
+      regions: _regions,
+      zones: _zones,
+      communities: _communities,
+    };
+  };
+
+export const selectCascadedRegion =
+  (region?: string, zone?: string, community?: string) =>
+  (state: RootState): Array<Option> => {
+    const {
+      codeTables: { regions, zones, communities },
+    } = state;
+
+    let results = regions;
+
+    if (region) {
+      return regions
+        .filter((item) => item.code === region)
+        .map(({ code, name }) => {
+          return {
+            label: name,
+            value: code,
+            description: name,
+          };
+        });
+    }
+
+    if (zone) {
+      const selected = zones.find((item) => item.code === zone);
+
+      if (selected) {
+        results = regions.filter((item) => item.code === selected.region);
+      }
+    }
+
+    if (community) {
+      const selected = communities.find((item) => item.code === community);
+
+      if (selected) {
+        results = regions.filter((item) => item.code === selected.region);
+      }
+    }
+
+    return results.map(({ code, name }) => {
+      return {
+        label: name,
+        value: code,
+        description: name,
+      };
+    });
+  };
+
+export const selectCascadedZone =
+  (region?: string, zone?: string, community?: string) =>
+  (state: RootState): Array<Option> => {
+    const {
+      codeTables: { zones, communities },
+    } = state;
+
+    let results = zones;
+
+    if (zone) {
+      return zones
+        .filter((item) => item.code === zone)
+        .map(({ code, name }) => {
+          return {
+            label: name,
+            value: code,
+            description: name,
+          };
+        });
+    }
+
+    if (region) {
+      results = zones.filter((item) => item.region === region);
+    }
+
+    if (community) {
+      const selected = communities.find((item) => item.code === community);
+      if (selected) {
+        results = zones.filter((item) => item.code === selected.zone);
+      }
+    }
+
+    return results.map(({ code, name }) => {
+      return {
+        label: name,
+        value: code,
+        description: name,
+      };
+    });
+  };
+
+  export const selectCascadedCommunity =
+  (region?: string, zone?: string, community?: string) =>
+  (state: RootState): Array<Option> => {
+    const {
+      codeTables: { communities },
+    } = state;
+
+    let results = communities;
+
+    if (community) {
+      return communities
+      .filter((item) => item.code === community)
+      .map(({ code, name }) => {
+        return {
+          label: name,
+          value: code,
+          description: name,
+        };
+      });
+    }
+
+    if(zone){ 
+      return communities
+      .filter((item) => item.zone === zone)
+      .map(({ code, name }) => {
+        return {
+          label: name,
+          value: code,
+          description: name,
+        };
+      });
+    }
+
+    if(region){ 
+      return communities
+      .filter((item) => item.region === region)
+      .map(({ code, name }) => {
+        return {
+          label: name,
+          value: code,
+          description: name,
+        };
+      });
+    }
+
+    return results.map(({ code, name }) => {
+      return {
+        label: name,
+        value: code,
+        description: name,
+      };
+    });
+  };
 
 export default codeTableSlice.reducer;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
Update the complaint filters to allow cascading of selected filters

Story #: CE-109

# How Has This Been Tested?
Cypress test the following:

- [x] When no filters are selected al options are available
- [x] When region is selected zones and community filters update
- [x] When zone is selected region and communities update
- [x] When community is selected region and zones update

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes



---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-194-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-compliance-enforcement-194-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)