### PR TITLE
bug/CE-232 - fixed modal state persistance 

### DIFF
--- a/frontend/src/app/store/reducers.ts
+++ b/frontend/src/app/store/reducers.ts
@@ -1,3 +1,5 @@
+import { persistReducer } from "redux-persist";
+import storage from "redux-persist/lib/storage";
 import { combineReducers } from "@reduxjs/toolkit";
 
 import officers from "./reducers/officer";
@@ -7,8 +9,14 @@ import offices from "./reducers/office";
 import codeTables from "./reducers/code-table";
 import complaintLocations from "./reducers/complaint-locations";
 
+const appPersistConfig = {
+	key: "app",
+	storage: storage,
+	whitelist: ["profile", "alerts", "notifications", "configurations"],
+};
+
 export const rootReducer = combineReducers({
-  app,
+  app: persistReducer(appPersistConfig, app),
   officers,
   offices,
   complaints,

--- a/frontend/src/app/store/store.ts
+++ b/frontend/src/app/store/store.ts
@@ -6,7 +6,8 @@ import { rootReducer } from "./reducers";
 const persistConfig = {
   key: "enforcement",
   storage,
-  whitelist: ["app", "codeTables"],
+  blacklist: ["app"],
+  whitelist: ["codeTables"],
 };
 
 const persistedReducer = persistReducer(persistConfig, rootReducer);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
This fix address a problem with how the redux state is persisted when the browser is closed, and previous state is reloaded. Prior to this fix the whole app state was persisted. This has been updated to exclude the app state, but to keep the alerts, profile, configuration and notification items. 

Fixes # CE-232


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-197-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-compliance-enforcement-197-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)