### PR TITLE
feature/CE-109v2: community cascade update

### DIFF
--- a/frontend/cypress/e2e/complaint-filter-cascade.cy.ts
+++ b/frontend/cypress/e2e/complaint-filter-cascade.cy.ts
@@ -118,7 +118,7 @@ describe("Complaint Filter Cascading spec", () => {
 
    const _totalRegions = 1;
    const _totalZones = 1;
-   const _totalCommunities = 1;
+   const _totalCommunities = 49;
 
    //-- load the page and remove existing default filters
    cy.visit("/");

--- a/frontend/src/app/store/reducers/code-table.ts
+++ b/frontend/src/app/store/reducers/code-table.ts
@@ -726,15 +726,10 @@ export const selectCascadedZone =
     let results = communities;
 
     if (community) {
-      return communities
-      .filter((item) => item.code === community)
-      .map(({ code, name }) => {
-        return {
-          label: name,
-          value: code,
-          description: name,
-        };
-      });
+      const selected = communities.find((item) => item.code === community);
+      if (selected) {
+        results = communities.filter((item) => item.zone === selected.zone);
+      }
     }
 
     if(zone){ 


### PR DESCRIPTION
# Description
Update to how the community cascade functions. previously selecting a community would restrict the community filter to just the selected community. After the update the community dropdown will cascade to the zone showing only communities in the selected community zone.

Story # CE-109

# How Has This Been Tested?

existing test: Verifies regions and zones are cascaded when selecting a community updated to reflect change

## Checklist

- [x] New and existing unit tests pass locally with my changes


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-198-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-compliance-enforcement-198-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)