### PR TITLE
feature/CE-216 - Set complaint ownership on create

### DIFF
--- a/backend/src/v1/complaint/complaint.controller.spec.ts
+++ b/backend/src/v1/complaint/complaint.controller.spec.ts
@@ -17,6 +17,9 @@ import { AllegationComplaint } from '../allegation_complaint/entities/allegation
 import { HwcrComplaint } from '../hwcr_complaint/entities/hwcr_complaint.entity';
 import { MockAllegationComplaintRepository } from '../../../test/mocks/mock-allegation-complaint-repository';
 import { MockWildlifeConflictComplaintRepository } from '../../../test/mocks/mock-wildlife-conflict-complaint-repository';
+import { AgencyCode } from '../agency_code/entities/agency_code.entity';
+import { Officer } from '../officer/entities/officer.entity';
+import { Office } from '../office/entities/office.entity';
 
 describe("Testing: Complaint Controller", () => {
   let app: INestApplication;
@@ -43,6 +46,18 @@ describe("Testing: Complaint Controller", () => {
         },
         {
           provide: getRepositoryToken(HwcrComplaint),
+          useFactory: MockWildlifeConflictComplaintRepository
+        },
+        {
+          provide: getRepositoryToken(AgencyCode),
+          useFactory: MockWildlifeConflictComplaintRepository
+        },
+        {
+          provide: getRepositoryToken(Officer),
+          useFactory: MockWildlifeConflictComplaintRepository
+        },
+        {
+          provide: getRepositoryToken(Office),
           useFactory: MockWildlifeConflictComplaintRepository
         },
       ],

--- a/backend/src/v1/complaint/complaint.module.ts
+++ b/backend/src/v1/complaint/complaint.module.ts
@@ -5,12 +5,18 @@ import { TypeOrmModule } from "@nestjs/typeorm";
 import { Complaint } from "../complaint/entities/complaint.entity";
 import { HwcrComplaint } from "../hwcr_complaint/entities/hwcr_complaint.entity";
 import { AllegationComplaint } from "../allegation_complaint/entities/allegation_complaint.entity";
+import { AgencyCode } from "../agency_code/entities/agency_code.entity";
+import { Office } from "../office/entities/office.entity";
+import { Officer } from "../officer/entities/officer.entity";
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Complaint]),
     TypeOrmModule.forFeature([HwcrComplaint]),
     TypeOrmModule.forFeature([AllegationComplaint]),
+    TypeOrmModule.forFeature([AgencyCode]),
+    TypeOrmModule.forFeature([Office]),
+    TypeOrmModule.forFeature([Officer]),
   ],
   controllers: [ComplaintController],
   providers: [ComplaintService],

--- a/backend/src/v1/complaint/complaint.service.spec.ts
+++ b/backend/src/v1/complaint/complaint.service.spec.ts
@@ -12,6 +12,9 @@ import { HwcrComplaint } from "../hwcr_complaint/entities/hwcr_complaint.entity"
 import { AllegationComplaint } from "../allegation_complaint/entities/allegation_complaint.entity";
 import { MockAllegationComplaintRepository  } from "../../../test/mocks/mock-allegation-complaint-repository";
 import { MockWildlifeConflictComplaintRepository } from "../../../test/mocks/mock-wildlife-conflict-complaint-repository";
+import { AgencyCode } from "../agency_code/entities/agency_code.entity";
+import { Officer } from "../officer/entities/officer.entity";
+import { Office } from "../office/entities/office.entity";
 
 describe("Testing: Complaint Service", () => {
    let service: ComplaintService;
@@ -41,6 +44,19 @@ describe("Testing: Complaint Service", () => {
           },
           {
             provide: getRepositoryToken(HwcrComplaint),
+            useFactory: MockWildlifeConflictComplaintRepository
+          },
+
+          {
+            provide: getRepositoryToken(AgencyCode),
+            useFactory: MockWildlifeConflictComplaintRepository
+          },
+          {
+            provide: getRepositoryToken(Officer),
+            useFactory: MockWildlifeConflictComplaintRepository
+          },
+          {
+            provide: getRepositoryToken(Office),
             useFactory: MockWildlifeConflictComplaintRepository
           },
         ],


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
Set the agency ownership when creating a new complaint to the agency that is associated with the user creating the new complaint

Story # CE-216

# How Has This Been Tested?
A new service test has been created to verify that the complaint has a valid owned_by_agency_code agency code
~~- [ ] complaint.service - verify owned_by_agency_code has agency code of officer creating complaint~~


## Checklist
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] New and existing unit tests pass locally with my changes~~


unable to create unit tests at this point in time. unable to create mock objects to facilitate testing with typeORM's QueryRunner used during the create complaint process. Will need to revisit this drring continued refactoring of the complaint service

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-204-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-compliance-enforcement-204-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)