### PR TITLE
feature/CE-32-Add-Attachments-When-Creating-New-Complaint

### DIFF
--- a/frontend/cypress/e2e/allegation-details-create.cy.ts
+++ b/frontend/cypress/e2e/allegation-details-create.cy.ts
@@ -54,11 +54,11 @@ describe("Complaint Create Page spec - Create View", () => {
       cy.navigateToCreateScreen();
   
       cy.selectItemById("complaint-type-select-id", "Enforcement");
-      cy.get("#caller-name-id").clear().type(createCallerInformation.name);
-      cy.get("#complaint-address-id")
+      cy.get("#caller-name-id").click({ force: true }).clear().type(createCallerInformation.name);
+      cy.get("#complaint-address-id").click({ force: true })
         .clear()
         .type(createCallerInformation.address);
-      cy.get("#complaint-email-id").clear().type(createCallerInformation.email);
+      cy.get("#complaint-email-id").click({ force: true }).clear().type(createCallerInformation.email);
   
       cy.get("#caller-primary-phone-id").click({ force: true });
       cy.get("#caller-primary-phone-id").clear();
@@ -66,10 +66,10 @@ describe("Complaint Create Page spec - Create View", () => {
         createCallerInformation.phoneInput,
       );
   
-      cy.get("#caller-info-secondary-phone-id")
+      cy.get("#caller-info-secondary-phone-id").click({ force: true })
         .clear()
         .typeAndTriggerChange(createCallerInformation.secondaryInput);
-      cy.get("#caller-info-alternate-phone-id")
+      cy.get("#caller-info-alternate-phone-id").click({ force: true })
         .clear()
         .typeAndTriggerChange(createCallerInformation.alternateInput);
   
@@ -80,7 +80,7 @@ describe("Complaint Create Page spec - Create View", () => {
       cy.get("#complaint-location-description-textarea-id").click({
         force: true,
       });
-      cy.get("#complaint-location-description-textarea-id")
+      cy.get("#complaint-location-description-textarea-id").click({ force: true })
         .clear()
         .type(createCallDetails.locationDescription, { delay: 0 });
       cy.get("#complaint-description-textarea-id").click({ force: true });

--- a/frontend/cypress/e2e/complaint-attachments.cy.ts
+++ b/frontend/cypress/e2e/complaint-attachments.cy.ts
@@ -47,7 +47,7 @@ describe("Complaint Attachments", () => {
   });
 
   Cypress._.times(complaintTypes.length, (index) => {
-    it("Verifies that upload option exists ", () => {
+    it("Verifies that upload option exists on edit complaint pages", () => {
       if ("#hwcr-tab".includes(complaintTypes[index])) {
         cy.navigateToEditScreen(COMPLAINT_TYPES.HWCR, "23-000076");
       } else {
@@ -58,6 +58,12 @@ describe("Complaint Attachments", () => {
       cy.get("button.coms-carousel-upload-container").should("exist");
 
     });
+
+  it("Verifies that upload option exists on the create page", () => {
+    cy.navigateToCreateScreen();
+    cy.get("button.coms-carousel-upload-container").should("exist");
+  }
+    
 
   });
 });

--- a/frontend/cypress/e2e/complaint-attachments.cy.ts
+++ b/frontend/cypress/e2e/complaint-attachments.cy.ts
@@ -47,7 +47,7 @@ describe("Complaint Attachments", () => {
   });
 
   Cypress._.times(complaintTypes.length, (index) => {
-    it("Verifies that upload option exists on edit complaint pages", () => {
+    it("Verifies that upload option exists on edit page", () => {
       if ("#hwcr-tab".includes(complaintTypes[index])) {
         cy.navigateToEditScreen(COMPLAINT_TYPES.HWCR, "23-000076");
       } else {
@@ -59,11 +59,10 @@ describe("Complaint Attachments", () => {
 
     });
 
+  });
+
   it("Verifies that upload option exists on the create page", () => {
     cy.navigateToCreateScreen();
     cy.get("button.coms-carousel-upload-container").should("exist");
-  }
-    
-
   });
 });

--- a/frontend/src/app/common/attachment-utils.ts
+++ b/frontend/src/app/common/attachment-utils.ts
@@ -1,48 +1,61 @@
 import {
   deleteAttachments,
+  getAttachments,
   saveAttachments,
 } from "../store/reducers/attachments";
 import { COMSObject } from "../types/coms/object";
 
 // used to update the state of attachments that are to be added to a complaint
 export const handleAddAttachments = (
-    setAttachmentsToAdd: React.Dispatch<React.SetStateAction<File[] | null>>, 
-    selectedFiles: File[]
+  setAttachmentsToAdd: React.Dispatch<React.SetStateAction<File[] | null>>,
+  selectedFiles: File[]
 ) => {
-    setAttachmentsToAdd(prevFiles => prevFiles ? [...prevFiles, ...selectedFiles] : selectedFiles);
+  setAttachmentsToAdd((prevFiles) =>
+    prevFiles ? [...prevFiles, ...selectedFiles] : selectedFiles
+  );
 };
 
 // used to update the state of attachments that are to be deleted from a complaint
 export const handleDeleteAttachments = (
-    attachmentsToAdd: File[] | null,
-    setAttachmentsToAdd: React.Dispatch<React.SetStateAction<File[] | null>>,
-    setAttachmentsToDelete: React.Dispatch<React.SetStateAction<COMSObject[] | null>>,
-    fileToDelete: COMSObject
+  attachmentsToAdd: File[] | null,
+  setAttachmentsToAdd: React.Dispatch<React.SetStateAction<File[] | null>>,
+  setAttachmentsToDelete: React.Dispatch<
+    React.SetStateAction<COMSObject[] | null>
+  >,
+  fileToDelete: COMSObject
 ) => {
-    if (!fileToDelete.pendingUpload) {
-        setAttachmentsToDelete(prevFiles => prevFiles ? [...prevFiles, fileToDelete] : [fileToDelete]);
-    } else if (attachmentsToAdd) {
-        setAttachmentsToAdd(prevAttachments => prevAttachments ? prevAttachments.filter(file => file.name !== fileToDelete.name) : null);     
-    }
+  if (!fileToDelete.pendingUpload) {
+    setAttachmentsToDelete((prevFiles) =>
+      prevFiles ? [...prevFiles, fileToDelete] : [fileToDelete]
+    );
+  } else if (attachmentsToAdd) {
+    setAttachmentsToAdd((prevAttachments) =>
+      prevAttachments
+        ? prevAttachments.filter((file) => file.name !== fileToDelete.name)
+        : null
+    );
+  }
 };
 
 // Given a list of attachments to add/delete, call COMS to add/delete those attachments
-export function handlePersistAttachments(
+export async function handlePersistAttachments(
   dispatch: any,
   attachmentsToAdd: File[] | null,
   attachmentsToDelete: COMSObject[] | null,
-  id: string,
+  complaintIdentifier: string,
   setAttachmentsToAdd: any,
   setAttachmentsToDelete: any
 ) {
-    
-  if (attachmentsToAdd) {
-    dispatch(saveAttachments(attachmentsToAdd, id));
+  if (attachmentsToDelete) {
+    await dispatch(deleteAttachments(attachmentsToDelete));
   }
 
-  if (attachmentsToDelete) {
-    dispatch(deleteAttachments(attachmentsToDelete));
+  if (attachmentsToAdd) {
+    await dispatch(saveAttachments(attachmentsToAdd, complaintIdentifier));
   }
+
+  // refresh store
+  await dispatch(getAttachments(complaintIdentifier));
 
   // Clear the attachments since they've been added or saved.
   setAttachmentsToAdd(null);

--- a/frontend/src/app/common/attachment-utils.ts
+++ b/frontend/src/app/common/attachment-utils.ts
@@ -25,13 +25,15 @@ export const handleDeleteAttachments = (
   fileToDelete: COMSObject
 ) => {
   if (!fileToDelete.pendingUpload) {
+    // a user is wanting to delete a previously uploaded attachment
     setAttachmentsToDelete((prevFiles) =>
       prevFiles ? [...prevFiles, fileToDelete] : [fileToDelete]
     );
   } else if (attachmentsToAdd) {
+    // a user has added an attachment and deleted it, before the complaint was saved.  Let's make sure this file isn't uploaded, so remove it from the "attachmentsToAdd" state
     setAttachmentsToAdd((prevAttachments) =>
       prevAttachments
-        ? prevAttachments.filter((file) => file.name !== fileToDelete.name)
+        ? prevAttachments.filter((file) => decodeURIComponent(file.name) !== decodeURIComponent(fileToDelete.name))
         : null
     );
   }

--- a/frontend/src/app/common/attachment-utils.ts
+++ b/frontend/src/app/common/attachment-utils.ts
@@ -4,6 +4,7 @@ import {
 } from "../store/reducers/attachments";
 import { COMSObject } from "../types/coms/object";
 
+// used to update the state of attachments that are to be added to a complaint
 export const handleAddAttachments = (
     setAttachmentsToAdd: React.Dispatch<React.SetStateAction<File[] | null>>, 
     selectedFiles: File[]
@@ -11,6 +12,7 @@ export const handleAddAttachments = (
     setAttachmentsToAdd(prevFiles => prevFiles ? [...prevFiles, ...selectedFiles] : selectedFiles);
 };
 
+// used to update the state of attachments that are to be deleted from a complaint
 export const handleDeleteAttachments = (
     attachmentsToAdd: File[] | null,
     setAttachmentsToAdd: React.Dispatch<React.SetStateAction<File[] | null>>,
@@ -25,7 +27,7 @@ export const handleDeleteAttachments = (
 };
 
 // Given a list of attachments to add/delete, call COMS to add/delete those attachments
-export function handleAttachments(
+export function handlePersistAttachments(
   dispatch: any,
   attachmentsToAdd: File[] | null,
   attachmentsToDelete: COMSObject[] | null,

--- a/frontend/src/app/common/attachment-utils.ts
+++ b/frontend/src/app/common/attachment-utils.ts
@@ -1,0 +1,29 @@
+// attachmentUtils.ts
+
+import {
+  deleteAttachments,
+  saveAttachments,
+} from "../store/reducers/attachments";
+import { COMSObject } from "../types/coms/object";
+
+// Given a list of attachments to add/delete, call COMS to add/delete those attachments
+export function handleAttachments(
+  dispatch: any,
+  attachmentsToAdd: File[] | null,
+  attachmentsToDelete: COMSObject[] | null,
+  id: string,
+  setAttachmentsToAdd: any,
+  setAttachmentsToDelete: any
+) {
+  if (attachmentsToAdd) {
+    dispatch(saveAttachments(attachmentsToAdd, id));
+  }
+
+  if (attachmentsToDelete) {
+    dispatch(deleteAttachments(attachmentsToDelete));
+  }
+
+  // Clear the attachments since they've been added or saved.
+  setAttachmentsToAdd(null);
+  setAttachmentsToDelete(null);
+}

--- a/frontend/src/app/common/attachment-utils.ts
+++ b/frontend/src/app/common/attachment-utils.ts
@@ -6,6 +6,26 @@ import {
 } from "../store/reducers/attachments";
 import { COMSObject } from "../types/coms/object";
 
+export const handleAddAttachments = (
+    setAttachmentsToAdd: React.Dispatch<React.SetStateAction<File[] | null>>, 
+    selectedFiles: File[]
+) => {
+    setAttachmentsToAdd(prevFiles => prevFiles ? [...prevFiles, ...selectedFiles] : selectedFiles);
+};
+
+export const handleDeleteAttachments = (
+    attachmentsToAdd: File[] | null,
+    setAttachmentsToAdd: React.Dispatch<React.SetStateAction<File[] | null>>,
+    setAttachmentsToDelete: React.Dispatch<React.SetStateAction<COMSObject[] | null>>,
+    fileToDelete: COMSObject
+) => {
+    if (!fileToDelete.pendingUpload) {
+        setAttachmentsToDelete(prevFiles => prevFiles ? [...prevFiles, fileToDelete] : [fileToDelete]);
+    } else if (attachmentsToAdd) {
+        setAttachmentsToAdd(prevAttachments => prevAttachments ? prevAttachments.filter(file => file.name !== fileToDelete.name) : null);     
+    }
+};
+
 // Given a list of attachments to add/delete, call COMS to add/delete those attachments
 export function handleAttachments(
   dispatch: any,
@@ -15,6 +35,7 @@ export function handleAttachments(
   setAttachmentsToAdd: any,
   setAttachmentsToDelete: any
 ) {
+    
   if (attachmentsToAdd) {
     dispatch(saveAttachments(attachmentsToAdd, id));
   }

--- a/frontend/src/app/common/attachment-utils.ts
+++ b/frontend/src/app/common/attachment-utils.ts
@@ -1,5 +1,3 @@
-// attachmentUtils.ts
-
 import {
   deleteAttachments,
   saveAttachments,

--- a/frontend/src/app/components/common/attachments-carousel.tsx
+++ b/frontend/src/app/components/common/attachments-carousel.tsx
@@ -21,7 +21,7 @@ import { selectMaxFileSize } from "../../store/reducers/app";
 import { v4 as uuidv4 } from 'uuid';
 
 type Props = {
-  complaintIdentifier: string;
+  complaintIdentifier?: string;
   allowUpload?: boolean;
   allowDelete?: boolean;
   onFilesSelected?: (attachments: File[]) => void;
@@ -61,7 +61,9 @@ export const AttachmentsCarousel: FC<Props> = ({
 
   // get the attachments when the complaint loads
   useEffect(() => {
-    dispatch(getAttachments(complaintIdentifier));
+    if (complaintIdentifier) {
+      dispatch(getAttachments(complaintIdentifier));
+    }
   }, [complaintIdentifier, dispatch]);
 
   //-- when the component unmounts clear the attachments from redux

--- a/frontend/src/app/components/common/attachments-carousel.tsx
+++ b/frontend/src/app/components/common/attachments-carousel.tsx
@@ -53,7 +53,7 @@ export const AttachmentsCarousel: FC<Props> = ({
   // when the carousel data updates (from the selector, on load), populate the carousel slides
   useEffect(() => {
     if (carouselData) {
-      setSlides(carouselData);
+      setSlides(sortAttachmentsByName(carouselData));
     } else {
       setSlides([])
     }
@@ -72,6 +72,16 @@ export const AttachmentsCarousel: FC<Props> = ({
       dispatch(setAttachments([]));
     };
   }, [dispatch]);
+
+ function sortAttachmentsByName(comsObjects: COMSObject[]): COMSObject[] {
+  // Create a copy of the array using slice() or spread syntax
+  const copy = [...comsObjects];
+
+  // Sort the copy based on the name property
+  copy.sort((a, b) => a.name.localeCompare(b.name));
+
+  return copy;
+}
 
   // when a user selects files (via the file browser that pops up when clicking the upload slide) then add them to the carousel
   const onFileSelect = (newFiles: FileList) => {

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-create.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-create.tsx
@@ -48,7 +48,7 @@ import { useNavigate } from "react-router-dom";
 import { ComplaintLocation } from "./complaint-location";
 import { AttachmentsCarousel } from "../../../common/attachments-carousel";
 import { COMSObject } from "../../../../types/coms/object";
-import { handleAddAttachments, handleAttachments, handleDeleteAttachments } from "../../../../common/attachment-utils";
+import { handleAddAttachments, handleDeleteAttachments, handlePersistAttachments } from "../../../../common/attachment-utils";
 
 export const CreateComplaint: FC = () => {
   const dispatch = useAppDispatch();
@@ -1006,7 +1006,7 @@ export const CreateComplaint: FC = () => {
   
     let complaintId = await processComplaintBasedOnType(complaint);
     if (complaintId) {
-      handleAttachments(dispatch, attachmentsToAdd, attachmentsToDelete, complaintId, setAttachmentsToAdd, setAttachmentsToDelete);
+      handlePersistAttachments(dispatch, attachmentsToAdd, attachmentsToDelete, complaintId, setAttachmentsToAdd, setAttachmentsToDelete);
     }
   
     setErrorNotificationClass("comp-complaint-error display-none");

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-create.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-create.tsx
@@ -1034,15 +1034,15 @@ export const CreateComplaint: FC = () => {
   const processComplaintBasedOnType = async (complaint: HwcrComplaint | AllegationComplaint) => {
     switch (complaintType) {
       case COMPLAINT_TYPES.HWCR:
-        return handleHwcrComplaint(complaint as HwcrComplaint);
+        return handleHwcrComplaint(complaint);
       case COMPLAINT_TYPES.ERS:
-        return handleErsComplaint(complaint as AllegationComplaint);
+        return handleErsComplaint(complaint);
       default:
         return null;
     }
   };
   
-  const handleHwcrComplaint = async (complaint: HwcrComplaint) => {
+  const handleHwcrComplaint = async (complaint: HwcrComplaint | AllegationComplaint) => {
     const complaintId = await dispatch(
       createWildlifeComplaint(complaint as HwcrComplaint)
     );
@@ -1059,7 +1059,7 @@ export const CreateComplaint: FC = () => {
     return complaintId;
   };
   
-  const handleErsComplaint = async (complaint: AllegationComplaint) => {
+  const handleErsComplaint = async (complaint: HwcrComplaint | AllegationComplaint) => {
     const complaintId = await dispatch(
       createAllegationComplaint(complaint as AllegationComplaint)
     );

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-create.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-create.tsx
@@ -48,8 +48,7 @@ import { useNavigate } from "react-router-dom";
 import { ComplaintLocation } from "./complaint-location";
 import { AttachmentsCarousel } from "../../../common/attachments-carousel";
 import { COMSObject } from "../../../../types/coms/object";
-import { deleteAttachments, saveAttachments } from "../../../../store/reducers/attachments";
-import { handleAttachments } from "../../../../common/attachment-utils";
+import { handleAddAttachments, handleAttachments, handleDeleteAttachments } from "../../../../common/attachment-utils";
 
 export const CreateComplaint: FC = () => {
   const dispatch = useAppDispatch();
@@ -234,16 +233,12 @@ export const CreateComplaint: FC = () => {
     // files to remove from COMS when complaint is saved
     const [attachmentsToDelete, setAttachmentsToDelete] = useState<COMSObject[] | null>(null);
   
-    const handleAddAttachments = (selectedFiles: File[]) => {
-      setAttachmentsToAdd(prevFiles => prevFiles ? [...prevFiles, ...selectedFiles] : selectedFiles);
+    const onHandleAddAttachments = (selectedFiles: File[]) => {
+      handleAddAttachments(setAttachmentsToAdd, selectedFiles);
     };
   
-    const handleDeleteAttachment = (fileToDelete: COMSObject) => {
-      if (!fileToDelete.pendingUpload) {
-        setAttachmentsToDelete(prevFiles => prevFiles ? [...prevFiles, fileToDelete] : [fileToDelete]);
-      } else if (attachmentsToAdd) { // we're deleting an attachment that wasn't uploaded, so remove the attachment from the "attachmentsToDelete" state
-        setAttachmentsToAdd(prevAttachments => prevAttachments ? prevAttachments.filter(file => file.name !== fileToDelete.name) : null);     
-      }
+    const onHandleDeleteAttachment = (fileToDelete: COMSObject) => {
+      handleDeleteAttachments(attachmentsToAdd, setAttachmentsToAdd, setAttachmentsToDelete, fileToDelete);
     };
   
 
@@ -1634,8 +1629,8 @@ export const CreateComplaint: FC = () => {
       <AttachmentsCarousel
             allowUpload={true}
             allowDelete={true}
-            onFilesSelected={handleAddAttachments}
-            onFileDeleted={handleDeleteAttachment}
+            onFilesSelected={onHandleAddAttachments}
+            onFileDeleted={onHandleDeleteAttachment}
           />
     </div>
   );

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-create.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-create.tsx
@@ -49,6 +49,7 @@ import { ComplaintLocation } from "./complaint-location";
 import { AttachmentsCarousel } from "../../../common/attachments-carousel";
 import { COMSObject } from "../../../../types/coms/object";
 import { deleteAttachments, saveAttachments } from "../../../../store/reducers/attachments";
+import { handleAttachments } from "../../../../common/attachment-utils";
 
 export const CreateComplaint: FC = () => {
   const dispatch = useAppDispatch();
@@ -1010,7 +1011,7 @@ export const CreateComplaint: FC = () => {
   
     let complaintId = await processComplaintBasedOnType(complaint);
     if (complaintId) {
-      handleAttachments(complaintId);
+      handleAttachments(dispatch, attachmentsToAdd, attachmentsToDelete, complaintId, setAttachmentsToAdd, setAttachmentsToDelete);
     }
   
     setErrorNotificationClass("comp-complaint-error display-none");
@@ -1074,17 +1075,6 @@ export const CreateComplaint: FC = () => {
       navigate("/complaint/" + complaintType + "/" + complaintId);
     }
     return complaintId;
-  };
-  
-  const handleAttachments = (complaintId: string) => {
-    if (attachmentsToAdd) {
-      dispatch(saveAttachments(attachmentsToAdd, complaintId));
-    }
-    if (attachmentsToDelete) {
-      dispatch(deleteAttachments(attachmentsToDelete));
-    }
-    setAttachmentsToAdd(null);
-    setAttachmentsToDelete(null);
   };
   
   const handleFormErrors = () => {

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
@@ -60,9 +60,8 @@ import { CallDetails } from "./call-details";
 import { CallerInformation } from "./caller-information";
 import { SuspectWitnessDetails } from "./suspect-witness-details";
 import { AttachmentsCarousel } from "../../../common/attachments-carousel";
-import { deleteAttachments, saveAttachments } from "../../../../store/reducers/attachments";
 import { COMSObject } from "../../../../types/coms/object";
-import { handleAttachments } from "../../../../common/attachment-utils";
+import { handleAddAttachments, handleAttachments, handleDeleteAttachments } from "../../../../common/attachment-utils";
 
 type ComplaintParams = {
   id: string;
@@ -133,18 +132,13 @@ export const ComplaintDetailsEdit: FC = () => {
   // files to remove from COMS when complaint is saved
   const [attachmentsToDelete, setAttachmentsToDelete] = useState<COMSObject[] | null>(null);
 
-  const handleAddAttachments = (selectedFiles: File[]) => {
-    setAttachmentsToAdd(prevFiles => prevFiles ? [...prevFiles, ...selectedFiles] : selectedFiles);
+  const onHandleAddAttachments = (selectedFiles: File[]) => {
+    handleAddAttachments(setAttachmentsToAdd, selectedFiles);
   };
 
-  const handleDeleteAttachment = (fileToDelete: COMSObject) => {
-    if (!fileToDelete.pendingUpload) {
-      setAttachmentsToDelete(prevFiles => prevFiles ? [...prevFiles, fileToDelete] : [fileToDelete]);
-    } else if (attachmentsToAdd) { // we're deleting an attachment that wasn't uploaded, so remove the attachment from the "attachmentsToDelete" state
-      setAttachmentsToAdd(prevAttachments => prevAttachments ? prevAttachments.filter(file => file.name !== fileToDelete.name) : null);     
-    }
+  const onHandleDeleteAttachment = (fileToDelete: COMSObject) => {
+    handleDeleteAttachments(attachmentsToAdd, setAttachmentsToAdd, setAttachmentsToDelete, fileToDelete);
   };
-
 
   const [errorNotificationClass, setErrorNotificationClass] = useState(
     "comp-complaint-error display-none"
@@ -1648,8 +1642,8 @@ export const ComplaintDetailsEdit: FC = () => {
             complaintIdentifier={id}
             allowUpload={true}
             allowDelete={true}
-            onFilesSelected={handleAddAttachments}
-            onFileDeleted={handleDeleteAttachment}
+            onFilesSelected={onHandleAddAttachments}
+            onFileDeleted={onHandleDeleteAttachment}
           />
           <ComplaintLocation
             coordinates={{ lat: +latitude, lng: +longitude }}

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
@@ -61,7 +61,7 @@ import { CallerInformation } from "./caller-information";
 import { SuspectWitnessDetails } from "./suspect-witness-details";
 import { AttachmentsCarousel } from "../../../common/attachments-carousel";
 import { COMSObject } from "../../../../types/coms/object";
-import { handleAddAttachments, handleAttachments, handleDeleteAttachments } from "../../../../common/attachment-utils";
+import { handleAddAttachments, handleDeleteAttachments, handlePersistAttachments } from "../../../../common/attachment-utils";
 
 type ComplaintParams = {
   id: string;
@@ -170,7 +170,7 @@ export const ComplaintDetailsEdit: FC = () => {
       setErrorNotificationClass("comp-complaint-error display-none");
       setReadOnly(true);
 
-      handleAttachments(dispatch, attachmentsToAdd, attachmentsToDelete, id, setAttachmentsToAdd, setAttachmentsToDelete);
+      handlePersistAttachments(dispatch, attachmentsToAdd, attachmentsToDelete, id, setAttachmentsToAdd, setAttachmentsToDelete);
 
     } else {
       ToggleError("Errors in form");

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
@@ -62,6 +62,7 @@ import { SuspectWitnessDetails } from "./suspect-witness-details";
 import { AttachmentsCarousel } from "../../../common/attachments-carousel";
 import { deleteAttachments, saveAttachments } from "../../../../store/reducers/attachments";
 import { COMSObject } from "../../../../types/coms/object";
+import { handleAttachments } from "../../../../common/attachment-utils";
 
 type ComplaintParams = {
   id: string;
@@ -174,21 +175,14 @@ export const ComplaintDetailsEdit: FC = () => {
       }
       setErrorNotificationClass("comp-complaint-error display-none");
       setReadOnly(true);
+
+      handleAttachments(dispatch, attachmentsToAdd, attachmentsToDelete, id, setAttachmentsToAdd, setAttachmentsToDelete);
+
     } else {
       ToggleError("Errors in form");
       setErrorNotificationClass("comp-complaint-error");
     };
-    if (attachmentsToAdd) {
-      dispatch(saveAttachments(attachmentsToAdd, id));
-    }
 
-    if (attachmentsToDelete) {
-      dispatch(deleteAttachments(attachmentsToDelete))
-    }
-
-    // clear the attachments since they've been added or saved.  If they couldn't be added or saved then an error would have appeared
-    setAttachmentsToAdd(null);
-    setAttachmentsToDelete(null);
   };
 
   useEffect(() => {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

As an officer or Admin Staff, when creating a complaint I want to be able add an attachment to a complaint so that the officers have as much information as possible when actioning the complaint.

Fixes # (issue)

# How Has This Been Tested?

- [x] When creating a human wildlife complaint, user can add an attachment
- [x] When creating an enforcement complaint, user can add an attachment
- [x] User can add multiple attachments when creating a complaint
- [x] User can add pictures, videos, and documents - not restricted to certain formats
- [x] When adding attachment, if the file size is over the given threshold, will receiving message that file could not be attached due to file size. - 5GB
- [x] User can "create the complaint" and have the attachment(s) associated
- [x] User can cancel the creation of the complaint with no records created
- [x] User will receive separate success/failure messages for the complaint being creating and the files being attached


## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-223-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-compliance-enforcement-223-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)