### PR TITLE
Update complaint list view assignment and state changes

### DIFF
--- a/frontend/src/app/components/containers/complaints/complaint-ellipsis-popover.tsx
+++ b/frontend/src/app/components/containers/complaints/complaint-ellipsis-popover.tsx
@@ -1,7 +1,7 @@
 import { OverlayTrigger, Popover } from "react-bootstrap";
 import { useAppDispatch } from "../../../hooks/hooks";
 import { openModal } from "../../../store/reducers/app";
-import { AssignOfficer, ChangeStatus } from "../../../types/modal/modal-types";
+import { ASSIGN_OFFICER, CHANGE_STATUS } from "../../../types/modal/modal-types";
 import { FC, useContext } from "react";
 import { ComplaintFilterContext } from "../../../providers/complaint-filter-provider";
 
@@ -70,7 +70,7 @@ export const ComplaintEllipsisPopover: FC<Props> = ({
     dispatch(
       openModal({
         modalSize: "md",
-        modalType: ChangeStatus,
+        modalType: CHANGE_STATUS,
         data: {
           title: "Update status?",
           description: "Status",
@@ -93,7 +93,7 @@ export const ComplaintEllipsisPopover: FC<Props> = ({
     dispatch(
       openModal({
         modalSize: "md",
-        modalType: AssignOfficer,
+        modalType: ASSIGN_OFFICER,
         data: {
           title: "Assign Complaint",
           description: "",

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-create.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-create.tsx
@@ -31,7 +31,7 @@ import {
 import { Officer } from "../../../../types/person/person";
 import { selectOfficersByAgency } from "../../../../store/reducers/officer";
 import { CreateComplaintHeader } from "./create-complaint-header";
-import { CancelConfirm } from "../../../../types/modal/modal-types";
+import { CANCEL_CONFIRM } from "../../../../types/modal/modal-types";
 import {
   createAllegationComplaint,
   createWildlifeComplaint,
@@ -910,7 +910,7 @@ export const CreateComplaint: FC = () => {
     dispatch(
       openModal({
         modalSize: "md",
-        modalType: CancelConfirm,
+        modalType: CANCEL_CONFIRM,
         data: {
           title: "Cancel Changes?",
           description: "Your changes will be lost.",

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
@@ -52,7 +52,7 @@ import { CompInput } from "../../../common/comp-input";
 import { from } from "linq-to-typescript";
 import { openModal, userId } from "../../../../store/reducers/app";
 import { useParams } from "react-router-dom";
-import { CancelConfirm } from "../../../../types/modal/modal-types";
+import { CANCEL_CONFIRM } from "../../../../types/modal/modal-types";
 import { ToggleError } from "../../../../common/toast";
 import { ToastContainer } from "react-toastify";
 import { ComplaintHeader } from "./complaint-header";
@@ -116,7 +116,7 @@ export const ComplaintDetailsEdit: FC = () => {
     dispatch(
       openModal({
         modalSize: "md",
-        modalType: CancelConfirm,
+        modalType: CANCEL_CONFIRM,
         data: {
           title: "Cancel Changes?",
           description: "Your changes will be lost.",

--- a/frontend/src/app/components/containers/complaints/details/complaint-header.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-header.tsx
@@ -15,8 +15,8 @@ import { Button } from "react-bootstrap";
 import { BsPersonPlus, BsPencil, BsArrowRepeat } from "react-icons/bs";
 import { openModal } from "../../../../store/reducers/app";
 import {
-  AssignOfficer,
-  ChangeStatus,
+  ASSIGN_OFFICER,
+  CHANGE_STATUS,
 } from "../../../../types/modal/modal-types";
 
 interface ComplaintHeaderProps {
@@ -57,7 +57,7 @@ export const ComplaintHeader: FC<ComplaintHeaderProps> = ({
     dispatch(
       openModal({
         modalSize: "md",
-        modalType: ChangeStatus,
+        modalType: CHANGE_STATUS,
         data: {
           title: "Update status?",
           description: "Status",
@@ -73,7 +73,7 @@ export const ComplaintHeader: FC<ComplaintHeaderProps> = ({
     dispatch(
       openModal({
         modalSize: "md",
-        modalType: AssignOfficer,
+        modalType: ASSIGN_OFFICER,
         data: {
           title: "Assign Complaint",
           description: "Suggested Officers",

--- a/frontend/src/app/components/containers/complaints/list-items/complaint-action-items.tsx
+++ b/frontend/src/app/components/containers/complaints/list-items/complaint-action-items.tsx
@@ -1,16 +1,10 @@
 import { FC } from "react";
-import {
-  BsPersonPlus,
-  BsSend,
-  BsArrowRepeat,
-} from "react-icons/bs";
+import { BsPersonPlus, BsSend, BsArrowRepeat } from "react-icons/bs";
 import { useAppDispatch } from "../../../../hooks/hooks";
 import { openModal } from "../../../../store/reducers/app";
-import {
-  AssignOfficer,
-  ChangeStatus,
-} from "../../../../types/modal/modal-types";
+import { ASSIGN_OFFICER, CHANGE_STATUS } from "../../../../types/modal/modal-types";
 import { OverlayTrigger, Tooltip } from "react-bootstrap";
+import { refreshComplaintItem } from "../../../../store/reducers/complaints";
 
 type Props = {
   complaint_identifier: string;
@@ -19,13 +13,7 @@ type Props = {
   agency_code: string;
 };
 
-export const ComplaintActionItems: FC<Props> = ({
-  complaint_identifier,
-  complaint_type,
-  zone,
-  agency_code,
-}) => {
-
+export const ComplaintActionItems: FC<Props> = ({ complaint_identifier, complaint_type, zone, agency_code }) => {
   const dispatch = useAppDispatch();
 
   const openAsignOfficerModal = () => {
@@ -33,7 +21,7 @@ export const ComplaintActionItems: FC<Props> = ({
     dispatch(
       openModal({
         modalSize: "md",
-        modalType: AssignOfficer,
+        modalType: ASSIGN_OFFICER,
         data: {
           title: "Assign Complaint",
           description: "",
@@ -51,7 +39,7 @@ export const ComplaintActionItems: FC<Props> = ({
     dispatch(
       openModal({
         modalSize: "md",
-        modalType: ChangeStatus,
+        modalType: CHANGE_STATUS,
         data: {
           title: "Update status?",
           description: "Status",
@@ -68,26 +56,22 @@ export const ComplaintActionItems: FC<Props> = ({
         placement="top"
         key={`tt-assign-${complaint_identifier}`}
         overlay={
-            <Tooltip id={`tt-assign-${complaint_identifier}`} className="comp-tooltip">
-              Assign
-            </Tooltip>
+          <Tooltip id={`tt-assign-${complaint_identifier}`} className="comp-tooltip">
+            Assign
+          </Tooltip>
         }
       >
-        <span className="tt-assign-span"
-          onClick={openAsignOfficerModal}
-          onKeyUp={openAsignOfficerModal}
-        >
-            <BsPersonPlus className="comp-table-row-hover-icons comp-table-icon comp-table-icon-weighted" />
+        <span className="tt-assign-span" onClick={openAsignOfficerModal} onKeyUp={openAsignOfficerModal}>
+          <BsPersonPlus className="comp-table-row-hover-icons comp-table-icon comp-table-icon-weighted" />
         </span>
       </OverlayTrigger>
       <OverlayTrigger
         placement="top"
         key={`tt-update-${complaint_identifier}`}
         overlay={
-          
-            <Tooltip id={`tt-update-${complaint_identifier}`} className="comp-tooltip">
-              Update Status
-            </Tooltip>
+          <Tooltip id={`tt-update-${complaint_identifier}`} className="comp-tooltip">
+            Update Status
+          </Tooltip>
         }
       >
         <span>
@@ -101,13 +85,13 @@ export const ComplaintActionItems: FC<Props> = ({
         placement="top"
         key={`tt-refer-${complaint_identifier}`}
         overlay={
-            <Tooltip id="tt-refer" className="comp-tooltip">
-              Refer
-            </Tooltip>
+          <Tooltip id="tt-refer" className="comp-tooltip">
+            Refer
+          </Tooltip>
         }
       >
         <span>
-            <BsSend className="comp-table-row-hover-icons comp-table-icon comp-table-icon-weighted" />
+          <BsSend className="comp-table-row-hover-icons comp-table-icon comp-table-icon-weighted" />
         </span>
       </OverlayTrigger>
     </>

--- a/frontend/src/app/components/containers/complaints/list-items/complaint-action-items.tsx
+++ b/frontend/src/app/components/containers/complaints/list-items/complaint-action-items.tsx
@@ -4,7 +4,6 @@ import { useAppDispatch } from "../../../../hooks/hooks";
 import { openModal } from "../../../../store/reducers/app";
 import { ASSIGN_OFFICER, CHANGE_STATUS } from "../../../../types/modal/modal-types";
 import { OverlayTrigger, Tooltip } from "react-bootstrap";
-import { refreshComplaintItem } from "../../../../store/reducers/complaints";
 
 type Props = {
   complaint_identifier: string;

--- a/frontend/src/app/components/modal/model-components.ts
+++ b/frontend/src/app/components/modal/model-components.ts
@@ -1,8 +1,8 @@
 import {
   Sample,
-  AssignOfficer,
-  ChangeStatus,
-  CancelConfirm,
+  ASSIGN_OFFICER,
+  CHANGE_STATUS,
+  CANCEL_CONFIRM,
 } from "../../types/modal/modal-types";
 
 import {
@@ -14,7 +14,7 @@ import { CancelConfirmModal } from "./instances/cancel-confirm-modal";
 
 export const MODAL_COMPONENTS: { [key: string]: React.ComponentType<any> } = {
   [Sample]: SampleModal,
-  [AssignOfficer]: AssignOfficerModal,
-  [ChangeStatus]: ChangeStatusModal,
-  [CancelConfirm]: CancelConfirmModal,
+  [ASSIGN_OFFICER]: AssignOfficerModal,
+  [CHANGE_STATUS]: ChangeStatusModal,
+  [CANCEL_CONFIRM]: CancelConfirmModal,
 };

--- a/frontend/src/app/store/reducers/complaints.ts
+++ b/frontend/src/app/store/reducers/complaints.ts
@@ -26,7 +26,6 @@ import { WildlifeComplaint } from "../../types/app/complaints/wildlife-complaint
 import { MapSearchResults } from "../../types/complaints/map-return";
 import { ComplaintMapItem } from "../../types/app/complaints/complaint-map-item";
 import { Delegate } from "../../types/app/people/delegate";
-import { WildlifeComplaintListHeader } from "../../components/containers/complaints/headers/wildlife-complaint-list-header";
 
 const initialState: ComplaintState = {
   complaintItems: {

--- a/frontend/src/app/store/reducers/officer.ts
+++ b/frontend/src/app/store/reducers/officer.ts
@@ -161,7 +161,7 @@ export const updateComplaintAssignee =
           `${config.API_BASE_URL}/v1/hwcr-complaint/by-complaint-identifier/${complaint_identifier}`
         );
         const response = await get<HwcrComplaint>(dispatch, parameters);
-
+debugger
         dispatch(updateWildlifeComplaintByRow(response));
         dispatch(
           getWildlifeComplaintByComplaintIdentifier(complaint_identifier)

--- a/frontend/src/app/store/reducers/officer.ts
+++ b/frontend/src/app/store/reducers/officer.ts
@@ -104,7 +104,13 @@ export const assignCurrentUserToComplaint =
         dispatch(getWildlifeComplaintByComplaintIdentifier(complaint_identifier));
         dispatch(updateWildlifeComplaintByRow(response));
       } else {
+        const parameters = generateApiParameters(
+          `${config.API_BASE_URL}/v1/allegation-complaint/by-complaint-identifier/${complaint_identifier}`
+        );
+        const response = await get<AllegationComplaint>(dispatch, parameters);
+
         dispatch(getAllegationComplaintByComplaintIdentifier(complaint_identifier));
+        dispatch(updateAllegationComplaintByRow(response));
       }
     } catch (error) {
       //-- handle error

--- a/frontend/src/app/store/reducers/officer.ts
+++ b/frontend/src/app/store/reducers/officer.ts
@@ -50,9 +50,7 @@ export const getOfficers =
   (zone?: string): AppThunk =>
   async (dispatch) => {
     try {
-      const parameters = generateApiParameters(
-        `${config.API_BASE_URL}/v1/officer/`
-      );
+      const parameters = generateApiParameters(`${config.API_BASE_URL}/v1/officer/`);
       const response = await get<Array<Officer>>(dispatch, parameters);
 
       if (response && from(response).any()) {
@@ -69,34 +67,21 @@ export const getOfficers =
 
 // Assigns the current user to an office
 export const assignCurrentUserToComplaint =
-  (
-    userId: string,
-    userGuid: UUID,
-    complaint_identifier: string,
-    complaint_type: string
-  ): AppThunk =>
+  (userId: string, userGuid: UUID, complaint_identifier: string, complaint_type: string): AppThunk =>
   async (dispatch) => {
     try {
-      let officerParams = generateApiParameters(
-        `${config.API_BASE_URL}/v1/officer/find-by-auth-user-guid/${userGuid}`
-      );
+      let officerParams = generateApiParameters(`${config.API_BASE_URL}/v1/officer/find-by-auth-user-guid/${userGuid}`);
       let officerResponse = await get<Officer>(dispatch, officerParams);
 
       if (officerResponse.auth_user_guid === undefined) {
-        officerParams = generateApiParameters(
-          `${config.API_BASE_URL}/v1/officer/find-by-userid/${userId}`
-        );
+        officerParams = generateApiParameters(`${config.API_BASE_URL}/v1/officer/find-by-userid/${userId}`);
 
-        let officerByUserIdResponse = await get<Officer>(
-          dispatch,
-          officerParams
-        );
+        let officerByUserIdResponse = await get<Officer>(dispatch, officerParams);
         const officerGuid = officerByUserIdResponse.officer_guid;
 
-        officerParams = generateApiParameters(
-          `${config.API_BASE_URL}/v1/officer/${officerGuid}`,
-          { auth_user_guid: userGuid }
-        );
+        officerParams = generateApiParameters(`${config.API_BASE_URL}/v1/officer/${officerGuid}`, {
+          auth_user_guid: userGuid,
+        });
 
         await patch<Officer>(dispatch, officerParams);
       }
@@ -111,13 +96,15 @@ export const assignCurrentUserToComplaint =
       );
 
       if (complaint_type === COMPLAINT_TYPES.HWCR) {
-        dispatch(
-          getWildlifeComplaintByComplaintIdentifier(complaint_identifier)
+        const parameters = generateApiParameters(
+          `${config.API_BASE_URL}/v1/hwcr-complaint/by-complaint-identifier/${complaint_identifier}`
         );
+        const response = await get<HwcrComplaint>(dispatch, parameters);
+
+        dispatch(getWildlifeComplaintByComplaintIdentifier(complaint_identifier));
+        dispatch(updateWildlifeComplaintByRow(response));
       } else {
-        dispatch(
-          getAllegationComplaintByComplaintIdentifier(complaint_identifier)
-        );
+        dispatch(getAllegationComplaintByComplaintIdentifier(complaint_identifier));
       }
     } catch (error) {
       //-- handle error
@@ -126,12 +113,7 @@ export const assignCurrentUserToComplaint =
 
 // creates a new cross reference for a person and office.  Assigns a person to an office.
 export const updateComplaintAssignee =
-  (
-    currentUser: string,
-    complaint_identifier: string,
-    complaint_type: string,
-    person_guid?: UUID
-  ): AppThunk =>
+  (currentUser: string, complaint_identifier: string, complaint_type: string, person_guid?: UUID): AppThunk =>
   async (dispatch) => {
     try {
       // add new person complaint record
@@ -150,10 +132,7 @@ export const updateComplaintAssignee =
         `${config.API_BASE_URL}/v1/person-complaint-xref/${complaint_identifier}`,
         payload
       );
-      await post<Array<PersonComplaintXref>>(
-        dispatch,
-        personComplaintXrefGuidParams
-      );
+      await post<Array<PersonComplaintXref>>(dispatch, personComplaintXrefGuidParams);
 
       // refresh complaints.  Note we should just update the changed record instead of the entire list of complaints
       if (COMPLAINT_TYPES.HWCR === complaint_type) {
@@ -161,11 +140,9 @@ export const updateComplaintAssignee =
           `${config.API_BASE_URL}/v1/hwcr-complaint/by-complaint-identifier/${complaint_identifier}`
         );
         const response = await get<HwcrComplaint>(dispatch, parameters);
-debugger
+
         dispatch(updateWildlifeComplaintByRow(response));
-        dispatch(
-          getWildlifeComplaintByComplaintIdentifier(complaint_identifier)
-        );
+        dispatch(getWildlifeComplaintByComplaintIdentifier(complaint_identifier));
       } else {
         const parameters = generateApiParameters(
           `${config.API_BASE_URL}/v1/allegation-complaint/by-complaint-identifier/${complaint_identifier}`
@@ -174,9 +151,7 @@ debugger
 
         dispatch(updateAllegationComplaintByRow(response));
 
-        dispatch(
-          getAllegationComplaintByComplaintIdentifier(complaint_identifier)
-        );
+        dispatch(getAllegationComplaintByComplaintIdentifier(complaint_identifier));
       }
     } catch (error) {
       console.log(error);
@@ -216,8 +191,7 @@ export const selectOfficersByZone =
     if (zone) {
       return officers.filter((officer) => {
         // check for nulls
-        const zoneCode =
-          officer?.office_guid?.cos_geo_org_unit?.zone_code ?? null;
+        const zoneCode = officer?.office_guid?.cos_geo_org_unit?.zone_code ?? null;
         return zone === zoneCode;
       });
     }
@@ -225,36 +199,31 @@ export const selectOfficersByZone =
     return [];
   };
 
-  // find officers that have an office in the given zone
+// find officers that have an office in the given zone
 export const selectOfficersByAgency =
-(agency: string) =>
-(state: RootState): Officer[] | null => {
-  const { officers: officerRoot } = state;
-  const { officers } = officerRoot;
+  (agency: string) =>
+  (state: RootState): Officer[] | null => {
+    const { officers: officerRoot } = state;
+    const { officers } = officerRoot;
 
     return officers.filter((officer) => {
       // check for nulls
-      const agencyCode =
-        officer?.office_guid?.agency_code?.agency_code ?? null;
+      const agencyCode = officer?.office_guid?.agency_code?.agency_code ?? null;
       return agency === agencyCode;
     });
+  };
 
-};
-
-  export const selectOfficersByZoneAndAgency =
-  (agency: string,
-    zone?: string) =>
+export const selectOfficersByZoneAndAgency =
+  (agency: string, zone?: string) =>
   (state: RootState): Officer[] | null => {
     const { officers: officerRoot } = state;
     const { officers } = officerRoot;
     if (zone) {
       return officers.filter((officer) => {
         // check for nulls
-        const zoneCode =
-          officer?.office_guid?.cos_geo_org_unit?.zone_code ?? null;
-        const agencyCode =
-          officer?.office_guid?.agency_code?.agency_code ?? null;
-        return (zone === zoneCode && (agency === agencyCode || !agency));
+        const zoneCode = officer?.office_guid?.cos_geo_org_unit?.zone_code ?? null;
+        const agencyCode = officer?.office_guid?.agency_code?.agency_code ?? null;
+        return zone === zoneCode && (agency === agencyCode || !agency);
       });
     }
 
@@ -281,22 +250,18 @@ export const assignOfficerToOffice =
 
       const update = { ...selectedOfficer, office_guid: updatedOffice };
 
-      const parameters = generateApiParameters(
-        `${config.API_BASE_URL}/v1/officer/${selectedOfficer?.officer_guid}`,
-        { ...update }
-      );
+      const parameters = generateApiParameters(`${config.API_BASE_URL}/v1/officer/${selectedOfficer?.officer_guid}`, {
+        ...update,
+      });
 
       const response = await patch<Array<Officer>>(dispatch, parameters);
 
       if (response && from(response).any()) {
         dispatch(toggleNotification("success", "officer assigned"));
       }
-      
     } catch (error) {
       //-- handle errors
-      dispatch(
-        toggleNotification("error", "unable to assign officer to office")
-      );
+      dispatch(toggleNotification("error", "unable to assign officer to office"));
     }
   };
 

--- a/frontend/src/app/types/modal/modal-types.ts
+++ b/frontend/src/app/types/modal/modal-types.ts
@@ -1,9 +1,9 @@
 export const Sample = "SAMPLE_MODAL";
-export const YesNo = "YES_NO_MODAL";
+export const YES_NO_MODAL = "YES_NO_MODAL";
 export const OK = "OK_MODAL";
-export const AssignOfficer = "ASSIGN_OFFICER";
-export const ChangeStatus = "CHANGE_STATUS";
-export const CancelConfirm = "CANCEL_CONFIRM";
+export const ASSIGN_OFFICER = "ASSIGN_OFFICER";
+export const CHANGE_STATUS = "CHANGE_STATUS";
+export const CANCEL_CONFIRM = "CANCEL_CONFIRM";
 
 export interface ModalProps {
   modalType: string;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

When on the complaint list view when a user changes a complaint status, or changes the officer assignment the list view does not update with the new changes.

This fix addresses this and makes it so that when a user does change the status, or assigns a complaint to an officer that the list view is updated to reflect this change.

Fixes # CE-324

# How Has This Been Tested?

Existing cypress tests will cover this, no need for additional testing



---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-233-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-compliance-enforcement-233-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)