### PR TITLE
bug: deploy nats before webeoc on test promotions

### DIFF
--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -41,6 +41,7 @@ jobs:
     name: TEST Deployments
     needs:
       - codeql
+      - deploys-nats-test
     environment: test
     runs-on: ubuntu-22.04
     strategy:
@@ -140,8 +141,6 @@ jobs:
 
   deploys-nats-test:
     name: Deploy NATS to TEST
-    needs:
-      - deploys-test  # This ensures NATS is deployed after your other services
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

WebEOC depends on NATS, so deploy NATS before the WebEOC container

Fixes # (issue)

# How Has This Been Tested?

Not tested in dev, needs to be tested on test migration.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-255-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-compliance-enforcement-255-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)