### PR TITLE
bug/CE-258 

### DIFF
--- a/frontend/cypress/e2e/complaint-filter-cascade.cy.ts
+++ b/frontend/cypress/e2e/complaint-filter-cascade.cy.ts
@@ -118,7 +118,7 @@ describe("Complaint Filter Cascading spec", () => {
 
    const _totalRegions = 1;
    const _totalZones = 1;
-   const _totalCommunities = 49;
+   const _totalCommunities = 970;
 
    //-- load the page and remove existing default filters
    cy.visit("/");

--- a/frontend/src/app/store/reducers/code-table.ts
+++ b/frontend/src/app/store/reducers/code-table.ts
@@ -858,15 +858,6 @@ export const selectCascadedZone =
       codeTables: { communities },
     } = state;
 
-    let results = communities;
-
-    if (community) {
-      const selected = communities.find((item) => item.code === community);
-      if (selected) {
-        results = communities.filter((item) => item.zone === selected.zone);
-      }
-    }
-
     if(zone){ 
       return communities
       .filter((item) => item.zone === zone)
@@ -891,7 +882,7 @@ export const selectCascadedZone =
       });
     }
 
-    return results.map(({ code, name }) => {
+    return communities.map(({ code, name }) => {
       return {
         label: name,
         value: code,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
Updated the selector used to populate the community filter drop down. When no zone is selected, the community filter should not cascade

Fixes # CE-258

# How Has This Been Tested?
Existing tests should cover this fix



---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-265-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-compliance-enforcement-265-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)