### PR TITLE
bug/CE-237

### DIFF
--- a/backend/db/migrations/V0.13.1__CE-237.sql
+++ b/backend/db/migrations/V0.13.1__CE-237.sql
@@ -1,0 +1,7 @@
+--
+-- ALTER person_complaint_xref_code table add missing 
+-- active_ind column, set default value true
+--
+
+ALTER TABLE public.person_complaint_xref_code
+  ADD COLUMN IF NOT EXISTS active_ind boolean NOT NULL DEFAULT true;

--- a/backend/src/v1/code-table/code-table.service.ts
+++ b/backend/src/v1/code-table/code-table.service.ts
@@ -234,12 +234,14 @@ export class CodeTableService {
             short_description,
             long_description,
             display_order,
+            active_ind,
           }) => {
             let table: PersonComplaintType = {
               personComplaintType: person_complaint_xref_code,
               shortDescription: short_description,
               longDescription: long_description,
               displayOrder: display_order,
+              isActive: active_ind
             };
             return table;
           }

--- a/backend/src/v1/person_complaint_xref_code/entities/person_complaint_xref_code.entity.ts
+++ b/backend/src/v1/person_complaint_xref_code/entities/person_complaint_xref_code.entity.ts
@@ -1,3 +1,4 @@
+import { ApiProperty } from "@nestjs/swagger";
 import { PersonComplaintXref } from "../../person_complaint_xref/entities/person_complaint_xref.entity";
 import { Column, Entity, Index, OneToMany } from "typeorm";
 
@@ -26,8 +27,9 @@ export class PersonComplaintXrefCode {
   @Column("integer", { name: "display_order" })
   display_order: number;
 
-  // @Column("boolean", { name: "active_ind" })
-  // active_ind: boolean;
+  @ApiProperty({ example: "True", description: "A boolean indicator to determine if the attractant code is active." })
+  @Column()
+  active_ind: boolean;
 
   @Column("character varying", { name: "create_user_id", length: 32 })
   create_user_id: string;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
Update to the person-complaint-xref-code table to include missing active_ind column. New DB script created to add missing column with default value of true

Fixes # CE-237

# How Has This Been Tested?
No tests created for this, verified via database tooling (azure data studio) dropped database creates new column, existing database alters table to include new column 

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-266-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-compliance-enforcement-266-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)