### PR TITLE
Fix saving complaints with coordinates - Bug/CE-447

### DIFF
--- a/frontend/cypress/e2e/hwcr-details-create-enter-coordinates.cy.ts
+++ b/frontend/cypress/e2e/hwcr-details-create-enter-coordinates.cy.ts
@@ -1,0 +1,190 @@
+/*
+Test to verify that the user is able to click the edit button
+on the wildlife contacts details page and see all the inputs
+*/
+describe("Complaint Create Page spec - Enter Coordinates - Create View", () => {
+  const createCallDetails = {
+    description:
+      "Calling to report a black bear getting into the garbage on a regular basis. Also wanted to confirm that residents of the trailer home park could call to report sightings themselves ---- testing",
+    location: "2975 Jutland Rd.",
+    locationDescription: "---- testing",
+    incidentDateDay: "01",
+    attractants: ["Livestock", "BBQ", "Beehive"],
+    attractantCodes: ["LIVESTCK", "BBQ", "BEEHIVE"],
+    attratantsIndex: [9, 0, 0],
+    xCoord: "-123.3776552",
+    yCoord: "48.4406837",
+    community: "Victoria",
+    office: "Victoria",
+    zone: "South Island",
+    region: "West Coast",
+    natureOfComplaint: "Dead wildlife - no violation suspected",
+    natureOfComplaintIndex: 5,
+    species: "Coyote",
+    speciesIndex: 3,
+    status: "Closed",
+    statusIndex: 1,
+    assigned: "Chris Nesmith",
+    assignedIndex: 1,
+  };
+
+  const createCallerInformation = {
+    name: "Phoebe ---- testing",
+    phone: "(250) 555-5555",
+    phoneInput: "2505555555",
+    secondary: "(250) 666-6666",
+    secondaryInput: "2506666666",
+    alternate: "(250) 666-8888",
+    alternateInput: "2506668888",
+    address: "437 Fake St ---- testing",
+    email: "tester512@gmail.com",
+    reported: "Conservation Officer Service",
+    reportedCode: "BCWF",
+    reportedIndex: 1,
+  };
+
+  beforeEach(function () {
+    cy.viewport("macbook-16");
+    cy.kcLogout().kcLogin();
+  });
+
+  it("Navigate to the Complaint Create page & create and verify data", function () {
+    //start create
+    cy.navigateToCreateScreen();
+
+    // select complaint type
+    cy.selectItemById("complaint-type-select-id", "Human Wildlife Conflict");
+    cy.get("#caller-name-id").clear().type(createCallerInformation.name);
+    cy.get("#complaint-address-id")
+      .clear()
+      .type(createCallerInformation.address);
+    cy.get("#complaint-email-id").clear().type(createCallerInformation.email);
+
+    cy.get("#caller-primary-phone-id").click({ force: true });
+    cy.get("#caller-primary-phone-id").clear();
+    cy.get("#caller-primary-phone-id").typeAndTriggerChange(
+      createCallerInformation.phoneInput,
+    );
+
+    cy.get("#caller-info-secondary-phone-id")
+      .clear()
+      .typeAndTriggerChange(createCallerInformation.secondaryInput);
+    cy.get("#caller-info-alternate-phone-id")
+      .clear()
+      .typeAndTriggerChange(createCallerInformation.alternateInput);
+
+    cy.selectItemById("reported-select-id", createCallerInformation.reported);
+
+    cy.get("#comp-details-edit-x-coordinate-input").click({ force: true });
+    cy.get("#comp-details-edit-x-coordinate-input").clear().type(createCallDetails.xCoord);
+
+    cy.get("#comp-details-edit-y-coordinate-input").click({ force: true });
+    cy.get("#comp-details-edit-y-coordinate-input").clear().type(createCallDetails.yCoord);
+    
+    cy.get("#complaint-location-description-textarea-id").click({
+      force: true,
+    });
+    cy.get("#complaint-location-description-textarea-id")
+      .clear()
+      .type(createCallDetails.locationDescription, { delay: 0 });
+    cy.get("#complaint-description-textarea-id").click({ force: true });
+    cy.get("#complaint-description-textarea-id")
+      .clear()
+      .type(createCallDetails.description, { delay: 0 });
+    cy.get("#complaint-description-textarea-id").click({ force: true });
+
+    cy.enterDateTimeInDatePicker("complaint-incident-time","01","13","45");
+
+    cy.selectItemById(
+      "attractants-select-id",
+      createCallDetails.attractants[0],
+    );
+    cy.selectItemById(
+      "attractants-select-id",
+      createCallDetails.attractants[1],
+    );
+    cy.selectItemById(
+      "attractants-select-id",
+      createCallDetails.attractants[2],
+    );
+
+    cy.selectItemById("community-select-id", createCallDetails.community);
+
+    cy.selectItemById(
+      "nature-of-complaint-select-id",
+      createCallDetails.natureOfComplaint,
+    );
+
+    cy.selectItemById("species-select-id", createCallDetails.species);
+
+    cy.selectItemById("officer-assigned-select-id", createCallDetails.assigned);
+
+    cy.get("#details-screen-cancel-save-button-top").click({ force: true });
+    //end create changes
+    //start verifying changes are created
+    cy.waitForSpinner();
+
+    cy.get('div[id="comp-details-name"]').contains(
+      createCallerInformation.name,
+    );
+    cy.get('div[id="comp-details-address"]').contains(
+      createCallerInformation.address,
+    );
+    cy.get('div[id="comp-details-email"]').contains(
+      createCallerInformation.email,
+    );
+
+    cy.get('div[id="comp-details-phone"]').contains(
+      createCallerInformation.phone,
+    );
+    cy.get('div[id="comp-details-phone-2"]').should(($el) => {
+      expect($el.text().trim()).equal(createCallerInformation.secondary);
+    });
+    cy.get('div[id="comp-details-phone-3"]').should(($el) => {
+      expect($el.text().trim()).equal(createCallerInformation.alternate);
+    });
+
+    cy.get('div[id="comp-details-reported"]').contains(
+      createCallerInformation.reported,
+    );
+
+    cy.get('p[id="comp-details-location-description"]').should(
+      "have.text",
+      createCallDetails.locationDescription,
+    );
+
+    cy.get('div[id="call-details-x-coordinate-div"]').contains(
+      createCallDetails.xCoord
+    );
+
+    cy.get('div[id="call-details-y-coordinate-div"]').contains(
+      createCallDetails.yCoord
+    );
+
+    //Commented out until COMPENF-843 is Fixed
+    cy.get('div[id="complaint-incident-date-time"]').contains(
+      createCallDetails.incidentDateDay
+    );
+
+    cy.get('p[id="comp-details-description"]').contains(
+      createCallDetails.description,
+    );
+
+    cy.get('span[id="comp-details-community"]').contains(
+      createCallDetails.community,
+    );
+
+    cy.get('span[id="comp-details-office"]').contains(createCallDetails.office);
+
+    cy.get('span[id="comp-details-zone"]').contains(createCallDetails.zone);
+
+    cy.get('span[id="comp-details-region"]').contains(createCallDetails.region);
+
+    cy.get(".comp-attactant-badge").then(function ($defaultValue) {
+      expect($defaultValue.eq(0)).to.contain("Livestock");
+      expect($defaultValue.eq(1)).to.contain("BBQ");
+      expect($defaultValue.eq(2)).to.contain("Beehive");
+    });
+    //end verifying changes are created
+  });
+});

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-create.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-create.tsx
@@ -402,7 +402,7 @@ export const CreateComplaint: FC = () => {
       coordinates[Coordinates.Latitude] = parseFloat(latitude);
     }
 
-    const complaint = { ...complaintData, location: { coordinates } } as ComplaintDto;
+    const complaint = { ...complaintData, location: { type: "Point", coordinates } } as ComplaintDto;
     applyComplaintData(complaint);
   };
 


### PR DESCRIPTION
# Description

When attempting to create a complaint with coordinates the application displays a toast “Unable to create complaint” and fails to save the complaint data.

The issue occurs because on the backend PostGIS fails to create geometry object from the input JSON if the object type is not passed.  To fix the issue I modified a front-end component to have the object type in addition to coordinates.


Fixes # (CE-447)

# How Has This Been Tested?

- [X] Click to create a new complaint. Enter all mandatory fields. Enter coordinates (X = -123.470769, Y = 48.500560). Click Save Changes. The result is complaint created, with a pin on the map matching the entered coordinates.



## Checklist

- [x] I have added a new Cypress test _hwcr-details-create-enter-coordinates.cy.ts_ that prove my fix is effective. It passed when ran locally. 
- [x] New and existing unit tests pass locally with my changes


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-276-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-compliance-enforcement-276-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)