### PR TITLE
bug: Phone Numbers are not loaded from webEOC

### DIFF
--- a/backend/db/migrations/R__0.14.0__CE-101.sql
+++ b/backend/db/migrations/R__0.14.0__CE-101.sql
@@ -1,7 +1,16 @@
  CREATE OR replace FUNCTION PUBLIC.insert_complaint_from_staging(_complaint_identifier CHARACTER varying) returns void LANGUAGE plpgsql
 AS
   $function$
-  DECLARE
+  declare
+    non_digit_regex CONSTANT text := '[^\d]'; -- used to strip out non-numeric characters from the phone number fields
+    
+    -- jsonb attribute names
+    jsonb_cos_primary_phone CONSTANT text := 'cos_primary_phone';
+    jsonb_cos_alt_phone CONSTANT text := 'cos_alt_phone';
+    jsonb_cos_alt_phone_2 CONSTANT text := 'cos_alt_phone_2';
+   
+
+   
     complaint_data jsonb;
     -- Variable to hold the JSONB data from staging_complaint.  Used to create a new complaint
     -- Variables for 'complaint' table
@@ -98,21 +107,21 @@ AS
     -- add the + (or +1) prefix
    
 	_caller_phone_1 := CASE
-	    WHEN left(regexp_replace(complaint_data ->> 'cos_primary_phone', '[^\d]', '', 'g'), 15) ~ '^1'
-	    THEN '+' || left(regexp_replace(complaint_data ->> 'cos_primary_phone', '[^\d]', '', 'g'), 15)
-	    ELSE '+1' || regexp_replace(complaint_data ->> 'cos_primary_phone', '[^\d]', '', 'g')
+	    WHEN left(regexp_replace(complaint_data ->> jsonb_cos_primary_phone, non_digit_regex, '', 'g'), 15) ~ '^1'
+	    THEN '+' || left(regexp_replace(complaint_data ->> jsonb_cos_primary_phone, non_digit_regex, '', 'g'), 15)
+	    ELSE '+1' || regexp_replace(complaint_data ->> jsonb_cos_primary_phone, non_digit_regex, '', 'g')
 	END;
 	
 	_caller_phone_2 := CASE
-	    WHEN left(regexp_replace(complaint_data ->> 'cos_alt_phone', '[^\d]', '', 'g'), 15) ~ '^1'
-	    THEN '+' || left(regexp_replace(complaint_data ->> 'cos_alt_phone', '[^\d]', '', 'g'), 15)
-	    ELSE '+1' || regexp_replace(complaint_data ->> 'cos_alt_phone', '[^\d]', '', 'g')
+	    WHEN left(regexp_replace(complaint_data ->> jsonb_cos_alt_phone, non_digit_regex, '', 'g'), 15) ~ '^1'
+	    THEN '+' || left(regexp_replace(complaint_data ->> jsonb_cos_alt_phone, non_digit_regex, '', 'g'), 15)
+	    ELSE '+1' || regexp_replace(complaint_data ->> jsonb_cos_alt_phone, non_digit_regex, '', 'g')
 	END;
 	
 	_caller_phone_3 := CASE
-	    WHEN left(regexp_replace(complaint_data ->> 'cos_alt_phone_2', '[^\d]', '', 'g'), 15) ~ '^1'
-	    THEN '+' || left(regexp_replace(complaint_data ->> 'cos_alt_phone_2', '[^\d]', '', 'g'), 15)
-	    ELSE '+1' || regexp_replace(complaint_data ->> 'cos_alt_phone_2', '[^\d]', '', 'g')
+	    WHEN left(regexp_replace(complaint_data ->> jsonb_cos_alt_phone_2, non_digit_regex, '', 'g'), 15) ~ '^1'
+	    THEN '+' || left(regexp_replace(complaint_data ->> jsonb_cos_alt_phone_2, non_digit_regex, '', 'g'), 15)
+	    ELSE '+1' || regexp_replace(complaint_data ->> jsonb_cos_alt_phone_2, non_digit_regex, '', 'g')
 	END;
 
    

--- a/frontend/cypress/e2e/complaint-search.v2.cy.ts
+++ b/frontend/cypress/e2e/complaint-search.v2.cy.ts
@@ -48,14 +48,14 @@ describe("Complaint Search Functionality", () => {
     cy.navigateToTab(complaintTypes[1], true);
 
     //-- there should be a whole page of complaints
-    cy.get("#complaint-list tbody").find("tr").should("be.gt", 10);
+    cy.get("#complaint-list tbody").find("tr").should("have.length.at.least", 10);
 
     //-- search for Oil and verify there's at least 23 complaints (this may increase as new complaints are added from WebEOC)
     cy.get("#complaint-search").click({ force: true });
     cy.get("#complaint-search").clear().type("Oil{enter}"); //-- {enter} will perform an enter keypress
 
     //-- verify one complaint, and verify complaint-id
-    cy.get("#complaint-list tbody").find("tr").should("be.gt", 23);
+    cy.get("#complaint-list tbody").find("tr").should("have.length.at.least", 23);
 
     //-- switch tabs
     cy.get(complaintTypes[0]).click({ force: true });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Strip all non-numeric characters from the webEOC field

If the first digit is not a 1, prepend it.

If the first character is not a + prepend it to the field

Fixes # (issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Verified that phone numbers appear on screen when not prefixed with +1


## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-279-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-compliance-enforcement-279-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)