### PR TITLE
bug/CE-485 - updated authorized drug assignment behaviour

### DIFF
--- a/frontend/src/app/components/containers/complaints/outcomes/animal-outcomes/add-animal-outcome.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/animal-outcomes/add-animal-outcome.tsx
@@ -112,8 +112,7 @@ export const AddAnimalOutcome: FC<props> = ({ animalCount, agency, species, assi
 
     let isValid = true;
 
-    // if (!species || !age || !sex || !threatLevel || !conflictHistory) {
-    if (!species) {
+    if (!species || !age || !sex || !threatLevel || !conflictHistory) {
       isValid = false;
     }
 

--- a/frontend/src/app/components/containers/complaints/outcomes/animal-outcomes/add-animal-outcome.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/animal-outcomes/add-animal-outcome.tsx
@@ -234,7 +234,7 @@ export const AddAnimalOutcome: FC<props> = ({ animalCount, agency, species, assi
               return <AddDrug {...item} update={updateDrug} remove={removeDrug} key={id} />;
             })}
 
-          <DrugAuthorization {...drugAuthorization} assigned={assigned} agency={agency} update={updateModel} />
+          <DrugAuthorization {...drugAuthorization} agency={agency} update={updateModel} />
         </>
       );
     }

--- a/frontend/src/app/components/containers/complaints/outcomes/animal-outcomes/add-animal-outcome.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/animal-outcomes/add-animal-outcome.tsx
@@ -54,6 +54,7 @@ export const AddAnimalOutcome: FC<props> = ({ animalCount, agency, species, assi
     outcome: "",
     officer: "",
     isEditable: false,
+    drugAuthorization: undefined
   });
 
   useEffect(() => {
@@ -111,7 +112,8 @@ export const AddAnimalOutcome: FC<props> = ({ animalCount, agency, species, assi
 
     let isValid = true;
 
-    if (!species || !age || !sex || !threatLevel || !conflictHistory) {
+    // if (!species || !age || !sex || !threatLevel || !conflictHistory) {
+    if (!species) {
       isValid = false;
     }
 

--- a/frontend/src/app/components/containers/complaints/outcomes/animal-outcomes/drug-authorization.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/animal-outcomes/drug-authorization.tsx
@@ -18,14 +18,18 @@ export const DrugAuthorization: FC<Props> = ({ agency, officer, date, update }) 
   const officers = useAppSelector(selectOfficersByAgencyDropdown(agency));
   const assigned = useAppSelector(selectComplaintAssignedBy);
 
+  const [assignedOfficer] = useState(assigned)
+
   const [authorizedBy, setAuthorizedBy] = useState(officer);
   const [authorizedOn, setAuthorizedOn] = useState(date);
 
   useEffect(() => {
-    if (assigned && !authorizedBy) {
+    if ((assigned && !authorizedBy)) {
       setAuthorizedBy(assigned);
+    } else if(assigned !== assignedOfficer && authorizedBy){
+      setAuthorizedBy(assigned || "");
     }
-  }, [assigned, authorizedBy]);
+  }, [assigned, authorizedBy, assignedOfficer]);
 
   const getValue = (property: string): Option | undefined => {
     if (property === "officer") {

--- a/frontend/src/app/components/containers/complaints/outcomes/animal-outcomes/drug-authorization.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/animal-outcomes/drug-authorization.tsx
@@ -1,41 +1,57 @@
-import { FC, useEffect } from "react";
+import { FC, useEffect, useState } from "react";
 import { Row, Col } from "react-bootstrap";
 import { CompSelect } from "../../../../common/comp-select";
 import DatePicker from "react-datepicker";
 import { useAppSelector } from "../../../../../hooks/hooks";
+import { selectComplaintAssignedBy } from "../../../../../store/reducers/complaints";
 import { selectOfficersByAgencyDropdown } from "../../../../../store/reducers/officer";
 import Option from "../../../../../types/app/option";
 
 type Props = {
-  assigned: string | null;
   officer?: string;
   date?: Date;
   agency: string;
   update: Function;
 };
 
-export const DrugAuthorization: FC<Props> = ({ agency, assigned, officer, date, update }) => {
+export const DrugAuthorization: FC<Props> = ({ agency, officer, date, update }) => {
   const officers = useAppSelector(selectOfficersByAgencyDropdown(agency));
+  const assigned = useAppSelector(selectComplaintAssignedBy);
 
-  useEffect(() => { 
-    if(!officer && assigned){ 
-      updateModel("officer", assigned)
+  const [authorizedBy, setAuthorizedBy] = useState(officer);
+  const [authorizedOn, setAuthorizedOn] = useState(date);
+
+  useEffect(() => {
+    if (assigned && !authorizedBy) {
+      console.log(assigned);
+      setAuthorizedBy(assigned);
     }
-  }, [officer, assigned])
+  }, [assigned, authorizedBy]);
 
   const getValue = (property: string): Option | undefined => {
     if (property === "officer") {
-      return officers.find((item) => item.value === (officer));
+      return officers.find((item) => item.value === authorizedBy);
     }
   };
 
   const updateModel = (property: string, value: string | Date | null | undefined) => {
-    const source = { officer, date };
+    const source = { officer: authorizedBy, date: authorizedOn };
     const authorization = { ...source, [property]: value };
 
     update("drugAuthorization", authorization);
   };
 
+  const handleAuthorizedByChange = (input: string | undefined) => {
+    setAuthorizedBy(input);
+    updateModel("officer", input);
+  };
+
+  const handleAuthorizedOnChange = (input: Date | undefined | null) => {
+    if (input) {
+      setAuthorizedOn(input);
+      updateModel("date", input);
+    }
+  };
 
   return (
     <div className="comp-outcome-report-inner-spacing">
@@ -52,7 +68,7 @@ export const DrugAuthorization: FC<Props> = ({ agency, assigned, officer, date, 
               id="officer-assigned-authorization-select-id"
               classNamePrefix="comp-select"
               onChange={(evt) => {
-                updateModel("officer", evt?.value);
+                handleAuthorizedByChange(evt?.value);
               }}
               className="comp-details-input"
               options={officers}
@@ -75,7 +91,7 @@ export const DrugAuthorization: FC<Props> = ({ agency, assigned, officer, date, 
               wrapperClassName="comp-details-edit-calendar-input"
               maxDate={new Date()}
               onChange={(evt) => {
-                updateModel("date", evt);
+                handleAuthorizedOnChange(evt);
               }}
               selected={date}
             />

--- a/frontend/src/app/components/containers/complaints/outcomes/animal-outcomes/drug-authorization.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/animal-outcomes/drug-authorization.tsx
@@ -23,7 +23,6 @@ export const DrugAuthorization: FC<Props> = ({ agency, officer, date, update }) 
 
   useEffect(() => {
     if (assigned && !authorizedBy) {
-      console.log(assigned);
       setAuthorizedBy(assigned);
     }
   }, [assigned, authorizedBy]);
@@ -93,7 +92,7 @@ export const DrugAuthorization: FC<Props> = ({ agency, officer, date, update }) 
               onChange={(evt) => {
                 handleAuthorizedOnChange(evt);
               }}
-              selected={date}
+              selected={authorizedOn}
             />
           </div>
         </Col>

--- a/frontend/src/app/components/containers/complaints/outcomes/animal-outcomes/edit-animal-outcome.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/animal-outcomes/edit-animal-outcome.tsx
@@ -83,7 +83,10 @@ export const EditAnimalOutcome: FC<props> = ({
     officer,
     date,
     isEditable,
+    drugAuthorization
   });
+
+  console.log(drugAuthorization);
 
   const updateModel = (property: string, value: string | Date | Array<AnimalTag | DrugUsed> | null | undefined) => {
     const model = { ...data, [property]: value };
@@ -255,6 +258,11 @@ export const EditAnimalOutcome: FC<props> = ({
     }
   };
 
+  //update({ ...data, isEditable: false })
+  const handleEditAnimalOutcomeUpdate = () => { 
+    update({ ...data, isEditable: false })
+  }
+
   return (
     <div className="comp-outcome-report-complaint-assessment">
       <div className="comp-outcome-report-container">
@@ -421,7 +429,7 @@ export const EditAnimalOutcome: FC<props> = ({
           id="outcome-save-button"
           title="Save Outcome"
           className="comp-outcome-save"
-          onClick={() => update({ ...data, isEditable: false })}
+          onClick={() => handleEditAnimalOutcomeUpdate()}
         >
           Save
         </Button>

--- a/frontend/src/app/components/containers/complaints/outcomes/animal-outcomes/edit-animal-outcome.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/animal-outcomes/edit-animal-outcome.tsx
@@ -249,7 +249,7 @@ export const EditAnimalOutcome: FC<props> = ({
               return <AddDrug {...item} update={updateDrug} remove={removeDrug} key={id} />;
             })}
 
-          <AddDrugAuthorization {...drugAuthorization} assigned={officer} agency={agency} update={updateModel} />
+          <AddDrugAuthorization {...drugAuthorization} agency={agency} update={updateModel} />
         </>
       );
     }

--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-outcome-by-animal.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-outcome-by-animal.tsx
@@ -62,6 +62,7 @@ export const HWCROutcomeByAnimal: FC = () => {
 
   const update = (model: AnimalOutcome) => {
     const { id } = model;
+    debugger;
 
     if (from(animals).any((item) => item.id === id)) {
       const filtered = animals.filter((item) => item.id !== id);

--- a/frontend/src/app/store/reducers/complaints.ts
+++ b/frontend/src/app/store/reducers/complaints.ts
@@ -852,7 +852,7 @@ export const selectComplaintAssignedBy =
       complaints: { complaint },
     } = state;
 
-    if (complaint && complaint.delegates) {
+    if (complaint?.delegates) {
       const { delegates } = complaint;
       if (from(delegates).any()) {
         const assigned = delegates.find((item) => item.type === "ASSIGNEE");

--- a/frontend/src/app/store/reducers/complaints.ts
+++ b/frontend/src/app/store/reducers/complaints.ts
@@ -279,7 +279,9 @@ export const getZoneAtAGlanceStats =
   async (dispatch) => {
     try {
       const parameters = generateApiParameters(
-        `${config.API_BASE_URL}/v1/complaint/stats/${type === ComplaintType.HWCR_COMPLAINT ? "HWCR" : "ERS"}/by-zone/${zone}`
+        `${config.API_BASE_URL}/v1/complaint/stats/${
+          type === ComplaintType.HWCR_COMPLAINT ? "HWCR" : "ERS"
+        }/by-zone/${zone}`
       );
 
       const response = await get<ZoneAtAGlanceStats>(dispatch, parameters);
@@ -507,7 +509,6 @@ export const selectAllegationComplaints = (state: RootState): Array<any> => {
   return allegations;
 };
 
-///---
 export const selectTotalComplaintsByType =
   (complaintType: string) =>
   (state: RootState): number => {
@@ -614,7 +615,6 @@ export const selectComplaintDetails =
     };
 
     let result: ComplaintDetails = {};
-
 
     if (complaint?.location) {
       const {
@@ -845,5 +845,28 @@ export const selectComplaintSuspectWitnessDetails = (state: RootState): Complain
 
   return results;
 };
+
+export const selectComplaintAssignedBy =
+  (state: RootState): string | null => {
+    const {
+      complaints: { complaint },
+    } = state;
+
+    if (complaint && complaint.delegates) {
+      const { delegates } = complaint;
+      if (from(delegates).any()) {
+        const assigned = delegates.find((item) => item.type === "ASSIGNEE");
+        if (assigned && assigned?.person !== null) {
+          const {
+            person: { id },
+          } = assigned;
+
+          return id;
+        }
+      }
+    }
+
+    return null;
+  };
 
 export default complaintSlice.reducer;


### PR DESCRIPTION
# Description
When adding a drug, if the user selects an officer and then reassigns the complaint, the selected officer in the drug authorization does not update to reflect the change in assigned officer

Fixes # CE-485

# How Has This Been Tested?
manually verified selected officer is updating when complaint is reassigned

## Checklist
- [x] manual verification

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-282-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-compliance-enforcement-282-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)