### PR TITLE
bug/CE-487 - fixes problem with default values

### DIFF
--- a/frontend/src/app/components/containers/complaints/outcomes/animal-outcomes/add-animal-outcome.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/animal-outcomes/add-animal-outcome.tsx
@@ -44,7 +44,7 @@ export const AddAnimalOutcome: FC<props> = ({ animalCount, agency, species, assi
 
   const [data, applyData] = useState<AnimalOutcome>({
     id: animalCount,
-    species: "",
+    species: species,
     sex: "",
     age: "",
     threatLevel: "",
@@ -57,15 +57,7 @@ export const AddAnimalOutcome: FC<props> = ({ animalCount, agency, species, assi
   });
 
   useEffect(() => {
-    if (species) {
-      updateModel("species", species);
-    }
-  }, [species]);
-
-  useEffect(() => {
-    if (assigned) {
-      updateModel("officer", assigned);
-    }
+    updateModel("officer", assigned);
   }, [assigned]);
 
   const getValue = (property: string): Option | undefined => {
@@ -226,7 +218,7 @@ export const AddAnimalOutcome: FC<props> = ({ animalCount, agency, species, assi
 
       return (
         <>
-          <div className="comp-outcome-report-container">Drug{drugs.length >1 && "s"}</div>
+          <div className="comp-outcome-report-container">Drug{drugs.length > 1 && "s"}</div>
 
           {from(drugs)
             .orderBy((item) => item.id)


### PR DESCRIPTION
# Description
When adding an animal outcome to a complaint that has been assigned to an officer, the species list is not selected with the animal selected in the wildlife complaint.

Fixes # CE-487

# How Has This Been Tested?
- [x] manual testing

## Checklist
- [x] no additional testing required


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-283-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-compliance-enforcement-283-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)