### PR TITLE
bug/CE-533 - update selected officer when assigning officer to complaint

### DIFF
--- a/frontend/src/app/components/modal/instances/assign-officer-modal.tsx
+++ b/frontend/src/app/components/modal/instances/assign-officer-modal.tsx
@@ -84,7 +84,17 @@ export const AssignOfficerModal: FC<AssignOfficerModalProps> = ({ close, submit,
   };
 
   const renderOfficers = () => {
-    const items = from(searchResults).any() ? searchResults : officersJson;
+    const getOfficerList = () => {
+      if (searchInput && from(searchResults).any()) {
+        return searchResults;
+      } else if (searchInput && !from(searchResults).any()) {
+        return [];
+      } else {
+        return officersJson;
+      }
+    };
+
+    const items = getOfficerList();
 
     if (items && from(items).any()) {
       return items.map((val) => {

--- a/frontend/src/app/components/modal/instances/assign-officer-modal.tsx
+++ b/frontend/src/app/components/modal/instances/assign-officer-modal.tsx
@@ -29,7 +29,6 @@ export const AssignOfficerModal: FC<AssignOfficerModalProps> = ({ close, submit,
   const displayName = useAppSelector(profileDisplayName);
   const idir = useAppSelector(profileIdir);
   const userid = useAppSelector(userId);
-  const [selectedAssigneeIndex, setSelectedAssigneeIndex] = useState(-1);
   const [selectedAssignee, setSelectedAssignee] = useState("");
   const [searchInput, setSearchInput] = useState<string>("");
 
@@ -37,9 +36,8 @@ export const AssignOfficerModal: FC<AssignOfficerModalProps> = ({ close, submit,
   const searchResults = useAppSelector(searchOfficers(searchInput));
 
   // stores the state of the officer that was clicked
-  const handleAssigneeClick = (index: number, person_guid: string) => {
-    setSelectedAssigneeIndex(index);
-    setSelectedAssignee(person_guid);
+  const handleAssigneeClick = (personId: string) => {
+    setSelectedAssignee(personId);
   };
 
   // assigns the selected officer to a complaint
@@ -82,15 +80,14 @@ export const AssignOfficerModal: FC<AssignOfficerModalProps> = ({ close, submit,
   };
 
   const handleInputFocus = (): void => {
-    setSelectedAssigneeIndex(-1);
     setSelectedAssignee("");
   };
 
   const renderOfficers = () => {
-    if (searchInput.length >= 3 && !from(searchResults).any()) {
-      return <></>;
-    } else if (from(searchResults).any()) {
-      return searchResults.map((val, key) => {
+    const items = from(searchResults).any() ? searchResults : officersJson;
+
+    if (items && from(items).any()) {
+      return items.map((val) => {
         const {
           person_guid: { first_name: firstName, last_name: lastName },
         } = val;
@@ -107,12 +104,12 @@ export const AssignOfficerModal: FC<AssignOfficerModalProps> = ({ close, submit,
           return (
             <div
               className={`${
-                selectedAssigneeIndex === key
+                selectedAssignee === personId
                   ? "assign_officer_modal_profile_card_selected"
                   : "assign_officer_modal_profile_card"
               }`}
-              key={key}
-              onClick={() => handleAssigneeClick(key, personId)}
+              key={personId}
+              onClick={() => handleAssigneeClick(personId)}
             >
               <div className="assign_officer_modal_profile_card_column">
                 <div className="assign_officer_modal_profile_card_profile-picture">
@@ -131,47 +128,6 @@ export const AssignOfficerModal: FC<AssignOfficerModalProps> = ({ close, submit,
         }
       });
     }
-
-    return officersJson?.map((val, key) => {
-      const {
-        person_guid: { first_name: firstName, last_name: lastName },
-      } = val;
-      const {
-        person_guid: { person_guid: personId },
-        auth_user_guid: authUserId,
-      } = val;
-
-      const displayName = `${firstName} ${lastName}`;
-      const officerInitials = firstName?.substring(0, 1) + lastName?.substring(0, 1);
-
-      // don't display the current user in the list since we already have the current user at the top of the modal
-      if (authUserId === undefined || !compareUuidToString(authUserId, idir)) {
-        return (
-          <div
-            className={`${
-              selectedAssigneeIndex === key
-                ? "assign_officer_modal_profile_card_selected"
-                : "assign_officer_modal_profile_card"
-            }`}
-            key={personId}
-            onClick={() => handleAssigneeClick(key, personId)}
-          >
-            <div className="assign_officer_modal_profile_card_column">
-              <div className="assign_officer_modal_profile_card_profile-picture">
-                <div data-initials-modal={officerInitials}></div>
-              </div>
-            </div>
-            <div className="assign_officer_modal_profile_card_column">
-              <div className="assign_officer_modal_profile_card_row_1">{displayName}</div>
-              <div className="assign_officer_modal_profile_card_row_2">Officer</div>
-            </div>
-            <div className="assign_officer_modal_profile_card_column"></div>
-          </div>
-        );
-      } else {
-        return <></>;
-      }
-    });
   };
 
   const renderHeading = () => {

--- a/frontend/src/app/components/modal/instances/assign-officer-modal.tsx
+++ b/frontend/src/app/components/modal/instances/assign-officer-modal.tsx
@@ -81,6 +81,11 @@ export const AssignOfficerModal: FC<AssignOfficerModalProps> = ({ close, submit,
     setSearchInput(value);
   };
 
+  const handleInputFocus = (): void => {
+    setSelectedAssigneeIndex(-1);
+    setSelectedAssignee("");
+  };
+
   const renderOfficers = () => {
     if (searchInput.length >= 3 && !from(searchResults).any()) {
       return <></>;
@@ -90,15 +95,15 @@ export const AssignOfficerModal: FC<AssignOfficerModalProps> = ({ close, submit,
           person_guid: { first_name: firstName, last_name: lastName },
         } = val;
         const {
-          person_guid: { person_guid },
-          auth_user_guid,
+          person_guid: { person_guid: personId },
+          auth_user_guid: authUserId,
         } = val;
 
         const displayName = `${firstName} ${lastName}`;
         const officerInitials = firstName?.substring(0, 1) + lastName?.substring(0, 1);
 
         // don't display the current user in the list since we already have the current user at the top of the modal
-        if (auth_user_guid === undefined || !compareUuidToString(auth_user_guid, idir)) {
+        if (authUserId === undefined || !compareUuidToString(authUserId, idir)) {
           return (
             <div
               className={`${
@@ -107,7 +112,7 @@ export const AssignOfficerModal: FC<AssignOfficerModalProps> = ({ close, submit,
                   : "assign_officer_modal_profile_card"
               }`}
               key={key}
-              onClick={() => handleAssigneeClick(key, person_guid)}
+              onClick={() => handleAssigneeClick(key, personId)}
             >
               <div className="assign_officer_modal_profile_card_column">
                 <div className="assign_officer_modal_profile_card_profile-picture">
@@ -225,6 +230,7 @@ export const AssignOfficerModal: FC<AssignOfficerModalProps> = ({ close, submit,
               aria-label="Search"
               aria-describedby="basic-addon2"
               onChange={(evt) => handleInputChange(evt)}
+              onFocus={() => handleInputFocus()}
               value={searchInput}
             />
             {searchInput && (

--- a/frontend/src/assets/sass/modals.scss
+++ b/frontend/src/assets/sass/modals.scss
@@ -56,5 +56,3 @@ $modal-md: 508px !default;
 .modal-backdrop {
   z-index: 9000 !important;
 }
-
-//body > div.fade.modal.show > div > div > div.border-0.modal-header > button

--- a/frontend/src/assets/sass/modals.scss
+++ b/frontend/src/assets/sass/modals.scss
@@ -49,10 +49,13 @@ $modal-md: 508px !default;
   z-index: 10000 !important;
 }
 
-.modal-header > button {
-  padding-right: 16px;
+.modal-header .btn-close {
+  padding-right: 16px !important;  
 }
 
 .modal-backdrop {
   z-index: 9000 !important;
 }
+
+//body > div.fade.modal.show > div > div > div.border-0.modal-header > button
+//body > div.fade.modal.show > div > div > div.border-0.modal-header > button


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
When searching for an officer to assign to a complaint, if the user had previously selected an officer, the previously selected officers index remains selected, incorrectly selecting a new officer

Fixes # CE-533

# How Has This Been Tested?
- [x] Test A

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes



---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-300-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-compliance-enforcement-300-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)