### PR TITLE
feature/CE-531: scroll to top when editing

### DIFF
--- a/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
@@ -224,6 +224,8 @@ export const ComplaintDetailsEdit: FC = () => {
         setAttachmentsToAdd,
         setAttachmentsToDelete
       );
+
+      window.scrollTo({ top: 0, behavior: "smooth" });
     } else {
       ToggleError("Errors in form");
       setErrorNotificationClass("comp-complaint-error");


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

When editing a complaint, when the user saves their changes the browser does not scroll to top. Added fix to scroll user to top of page on save edit

story # CE-531

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Complaint Details Scrolls to Top

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-306-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-compliance-enforcement-306-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-306-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-compliance-enforcement-306-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)