### PR TITLE
bug/CE-551-Reduce spacing between lines and fix the error message behaviour

### DIFF
--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-complaint-assessment.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-complaint-assessment.tsx
@@ -227,7 +227,7 @@ export const HWCRComplaintAssessment: FC = () => {
       <h6>Complaint assessment</h6>
       <div className="comp-outcome-report-complaint-assessment">
         <div className="comp-details-edit-container">
-          <div className="comp-details-edit-column">
+          <div className="assessment-details-edit-column">
             <div className="comp-details-edit-container">
               <div className="comp-details-edit-column">
                 <div id="assessment-checkbox-div" className="comp-details-label-checkbox-div-pair">
@@ -340,7 +340,7 @@ export const HWCRComplaintAssessment: FC = () => {
                       id="complaint-outcome-date"
                       selectedDate={selectedDate}
                       onChange={handleDateChange}
-                      placeholder="Select Date"
+                      placeholder="Select date"
                       className="comp-details-edit-calendar-input" // Adjust class as needed
                       classNamePrefix="comp-select" // Adjust class as needed
                       errMsg={assessmentDateErrorMessage} // Pass error message if any

--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-complaint-assessment.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-complaint-assessment.tsx
@@ -29,6 +29,8 @@ import { ValidationDatePicker } from "../../../../common/validation-date-picker"
 import { BsPencil } from "react-icons/bs";
 import { CompTextIconButton } from "../../../common/comp-text-icon-button";
 
+import "../../../../../assets/sass/hwcr-assessment.scss"
+
 export const HWCRComplaintAssessment: FC = () => {
   const dispatch = useAppDispatch();
   type ComplaintParams = {
@@ -126,7 +128,7 @@ export const HWCRComplaintAssessment: FC = () => {
     setSelectedJustification(assessmentState.justification);
     setSelectedAssessmentTypes(assessmentState.assessment_type);
     resetValidationErrors();
-    if (assessmentState.assessment_type.length > 0) { // This handles the case where the user clicks cancel before saving anything
+    if (assessmentState.assessment_type?.length > 0) { // This handles the case where the user clicks cancel before saving anything
       setEditable(false);
     }
   };
@@ -254,7 +256,7 @@ export const HWCRComplaintAssessment: FC = () => {
             </div>
             <div className="comp-details-edit-container">
               <div className="comp-details-edit-column">
-                <div id="action-required-div" className="comp-details-label-input-pair">
+                <div id="action-required-div" className="assessment-details-label-input-pair">
                   <label htmlFor="action-required">Action required?</label>
                   {editable ? (
                     <CompSelect
@@ -274,7 +276,7 @@ export const HWCRComplaintAssessment: FC = () => {
                 </div>
               </div>
               <div className="comp-details-edit-column comp-details-right-column">
-                <div id="justification-div" className="comp-details-label-input-pair">
+                <div id="justification-div" className="assessment-details-label-input-pair">
                   <label
                     className={justificationLabelClass}
                     htmlFor="justification"
@@ -301,7 +303,7 @@ export const HWCRComplaintAssessment: FC = () => {
             </div>
             <div className="comp-details-edit-container">
               <div className="comp-details-edit-column">
-                <div id="outcome-officer-div" className="comp-details-label-input-pair">
+                <div id="outcome-officer-div" className="assessment-details-label-input-pair">
                   <label htmlFor="outcome-officer">Officer</label>
                   {editable ? (
                     <CompSelect
@@ -331,7 +333,7 @@ export const HWCRComplaintAssessment: FC = () => {
                 </div>
               </div>
               <div className="comp-details-edit-column comp-details-right-column">
-                <div id="complaint-outcome-date-div" className="comp-details-label-input-pair">
+                <div id="complaint-outcome-date-div" className="assessment-details-label-input-pair">
                   <label htmlFor="complaint-outcome-date">Date</label>
                   {editable ? (
                     <ValidationDatePicker

--- a/frontend/src/assets/sass/hwcr-assessment.scss
+++ b/frontend/src/assets/sass/hwcr-assessment.scss
@@ -1,0 +1,10 @@
+@import "./colours.scss";
+@import "./complaint.scss";
+
+.assessment-details-label-input-pair {
+    @extend .comp-details-label-input-pair;
+    align-items: baseline;
+    margin: 16px 0px;
+    min-height: 0;
+  }
+  

--- a/frontend/src/assets/sass/hwcr-assessment.scss
+++ b/frontend/src/assets/sass/hwcr-assessment.scss
@@ -7,4 +7,9 @@
     margin: 16px 0px;
     min-height: 0;
   }
+
+  .assessment-details-edit-column {
+    @extend .comp-details-edit-column;
+    margin-right: 0px;
+  }
   


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

This addresses the issue of inconsistent space between the elements in Assessment view mode. Also when errors appear, now the fields remain in line with the field label and the fields below are pushed down to make space for the error message.

Fixes # CE-551

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Verify that vertical spacing in the Assessment section is consistent with other sections ( ex: Equipment)
- [x] Check if the fields and labels are aligned correctly when validation error occurs


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-317-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-compliance-enforcement-317-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)