### PR TITLE
bug/CE-560 Save Assessment sometimes does not display saved info

### DIFF
--- a/frontend/src/app/common/validation-checkbox-group.tsx
+++ b/frontend/src/app/common/validation-checkbox-group.tsx
@@ -30,7 +30,7 @@ export const ValidationCheckboxGroup: FC<ValidationCheckboxGroupProps> = ({
 
   useEffect(() => {
     setCheckedItems(checkedValues);
-  }, [checkedValues]);
+  }, [checkedValues.length]);
 
   return (
     <div id="checkbox-div" className="checkbox-left-padding">

--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-complaint-assessment.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-complaint-assessment.tsx
@@ -106,12 +106,12 @@ export const HWCRComplaintAssessment: FC = () => {
       const officer = getSelectedOfficer(assignableOfficers, personGuid, complaintData);
       setSelectedOfficer(officer);
       dispatch(getAssessment(complaintData.id));
-      if (assessmentState.date) {
-        populateAssessment();
-      }
-
     }
   }, [complaintData]);
+
+  useEffect(() => {
+      populateAssessmentUI();
+  }, [assessmentState]);
 
   // clear the redux state
   useEffect(() => {
@@ -120,17 +120,15 @@ export const HWCRComplaintAssessment: FC = () => {
     };
   }, [dispatch]);
 
-
-  const populateAssessment = () => {
+  
+  const populateAssessmentUI = () => {
     setSelectedDate((assessmentState.date) ? new Date(assessmentState.date) : null);
     setSelectedOfficer(assessmentState.officer);
     setSelectedActionRequired(assessmentState.action_required);
     setSelectedJustification(assessmentState.justification);
     setSelectedAssessmentTypes(assessmentState.assessment_type);
     resetValidationErrors();
-    if (assessmentState.assessment_type?.length > 0) { // This handles the case where the user clicks cancel before saving anything
-      setEditable(false);
-    }
+    setEditable(!assessmentState.date);
   };
 
 
@@ -139,7 +137,7 @@ export const HWCRComplaintAssessment: FC = () => {
     selectedActionRequired?.value === "No" ? "comp-details-input" : "comp-details-input comp-outcome-hide";
 
   const cancelConfirmed = () => {
-    populateAssessment();
+    populateAssessmentUI();
   };
 
 
@@ -169,7 +167,6 @@ export const HWCRComplaintAssessment: FC = () => {
 
     if (!hasErrors()) {
       dispatch(upsertAssessment(id, updatedAssessmentData));
-      ToggleSuccess(`Assessment has been saved`);
       setEditable(false);
     } else {
       handleFormErrors();

--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-complaint-assessment.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-complaint-assessment.tsx
@@ -206,7 +206,7 @@ export const HWCRComplaintAssessment: FC = () => {
       hasErrors = true;
     }
 
-    if (selectedAssessmentTypes?.length <= 0) {
+    if (!selectedAssessmentTypes || selectedAssessmentTypes?.length <= 0) {
       setAssessmentRequiredErrorMessage("One or more assessment is required");
       hasErrors = true;
     }

--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-complaint-assessment.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-complaint-assessment.tsx
@@ -22,7 +22,7 @@ import { ValidationCheckboxGroup } from "../../../../common/validation-checkbox-
 import { resetAssessment, selectAssessment, upsertAssessment, getAssessment } from "../../../../store/reducers/cases";
 import { openModal } from "../../../../store/reducers/app";
 import { CANCEL_CONFIRM } from "../../../../types/modal/modal-types";
-import { ToggleError, ToggleSuccess } from "../../../../common/toast";
+import { ToggleError } from "../../../../common/toast";
 import "react-toastify/dist/ReactToastify.css";
 import { Assessment } from "../../../../types/outcomes/assessment";
 import { ValidationDatePicker } from "../../../../common/validation-date-picker";


### PR DESCRIPTION
# Description

This is to fix the issue when Save Assessment does not display saved info after user navigate away & back

Fixes # CE-560

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Add an assessment to a complaint and save. Navigate back to the list of complaints. Find the complaint you just added an assessment to and click on it. Assessment section should display the info you entered in the view mode.

## Checklist

- [x] New and existing unit tests pass locally with my changes

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-318-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-compliance-enforcement-318-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)