### PR TITLE
fix: save assessment/prevention functionality

### DIFF
--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-complaint-assessment.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-complaint-assessment.tsx
@@ -29,7 +29,7 @@ import { ValidationDatePicker } from "../../../../common/validation-date-picker"
 import { BsPencil } from "react-icons/bs";
 import { CompTextIconButton } from "../../../common/comp-text-icon-button";
 
-import "../../../../../assets/sass/hwcr-assessment.scss"
+import "../../../../../assets/sass/hwcr-assessment.scss";
 
 export const HWCRComplaintAssessment: FC = () => {
   const dispatch = useAppDispatch();
@@ -38,7 +38,7 @@ export const HWCRComplaintAssessment: FC = () => {
     complaintType: string;
   };
   const [selectedActionRequired, setSelectedActionRequired] = useState<Option | null>();
-  const [selectedJustification, setSelectedJustification] = useState<Option| null>();
+  const [selectedJustification, setSelectedJustification] = useState<Option | null>();
   const [selectedDate, setSelectedDate] = useState<Date | null | undefined>();
   const [selectedOfficer, setSelectedOfficer] = useState<Option | null>();
   const [selectedAssessmentTypes, setSelectedAssessmentTypes] = useState<Option[]>([]);
@@ -62,9 +62,9 @@ export const HWCRComplaintAssessment: FC = () => {
   const assignableOfficers: Option[] =
     officersInAgencyList !== null
       ? officersInAgencyList.map((officer: Officer) => ({
-        value: officer.person_guid.person_guid,
-        label: `${officer.person_guid.first_name} ${officer.person_guid.last_name}`,
-      }))
+          value: officer.person_guid.person_guid,
+          label: `${officer.person_guid.first_name} ${officer.person_guid.last_name}`,
+        }))
       : [];
   const handleDateChange = (date: Date | null) => {
     setSelectedDate(date);
@@ -77,7 +77,7 @@ export const HWCRComplaintAssessment: FC = () => {
   const handleActionRequiredChange = (selected: Option | null) => {
     if (selected) {
       setSelectedActionRequired(selected);
-      setSelectedJustification(null as unknown as Option);  
+      setSelectedJustification(null as unknown as Option);
     } else {
       setSelectedActionRequired(undefined);
     }
@@ -108,10 +108,12 @@ export const HWCRComplaintAssessment: FC = () => {
       setSelectedOfficer(officer);
       dispatch(getAssessment(complaintData.id));
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [complaintData]);
 
   useEffect(() => {
     populateAssessmentUI();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [assessmentState]);
 
   // clear the redux state
@@ -121,35 +123,42 @@ export const HWCRComplaintAssessment: FC = () => {
     };
   }, [dispatch]);
 
-
   const populateAssessmentUI = () => {
+    const selectedOfficer = (
+      assessmentState.officer
+        ? {
+            label: assessmentState.officer?.key,
+            value: assessmentState.officer?.value,
+          }
+        : null
+    ) as Option;
 
-    const selectedOfficer = (assessmentState.officer ? {
-      label: assessmentState.officer?.key,
-      value: assessmentState.officer?.value
-    } :
-      null) as Option;
+    const selectedActionRequired = (
+      assessmentState.action_required
+        ? {
+            label: assessmentState.action_required,
+            value: assessmentState.action_required,
+          }
+        : null
+    ) as Option;
 
-    const selectedActionRequired = (assessmentState.action_required ? {
-      label: assessmentState.action_required,
-      value: assessmentState.action_required
-    } :
-      null) as Option;
-
-    const selectedJustification = (assessmentState.justification ? {
-      label: assessmentState.justification?.key,
-      value: assessmentState.justification?.value
-    } :
-      null) as Option;
+    const selectedJustification = (
+      assessmentState.justification
+        ? {
+            label: assessmentState.justification?.key,
+            value: assessmentState.justification?.value,
+          }
+        : null
+    ) as Option;
 
     const selectedAssessmentTypes = assessmentState.assessment_type?.map((item) => {
       return {
         label: item.key,
-        value: item.value
-      }
+        value: item.value,
+      };
     }) as Option[];
 
-    setSelectedDate((assessmentState.date) ? new Date(assessmentState.date) : null);
+    setSelectedDate(assessmentState.date ? new Date(assessmentState.date) : null);
     setSelectedOfficer(selectedOfficer);
     setSelectedActionRequired(selectedActionRequired);
     setSelectedJustification(selectedJustification);
@@ -158,7 +167,6 @@ export const HWCRComplaintAssessment: FC = () => {
     setEditable(!assessmentState.date);
   };
 
-
   const justificationLabelClass = selectedActionRequired?.value === "No" ? "" : "comp-outcome-hide";
   const justificationEditClass =
     selectedActionRequired?.value === "No" ? "comp-details-input" : "comp-details-input comp-outcome-hide";
@@ -166,7 +174,6 @@ export const HWCRComplaintAssessment: FC = () => {
   const cancelConfirmed = () => {
     populateAssessmentUI();
   };
-
 
   const cancelButtonClick = () => {
     dispatch(
@@ -184,26 +191,26 @@ export const HWCRComplaintAssessment: FC = () => {
 
   // save to redux if no errors.  Otherwise, display error message(s).
   const saveButtonClick = async () => {
-    const updatedAssessmentData = {
-      date: selectedDate,
-      officer: {
-        key: selectedOfficer?.label,
-        value: selectedOfficer?.value
-      },
-      action_required: selectedActionRequired?.label,
-      justification: {
-        key: selectedJustification?.label,
-        value: selectedJustification?.value
-      },
-      assessment_type: selectedAssessmentTypes.map((item) => {
-        return {
-          key: item.label,
-          value: item.value
-        }
-      }),
-    } as Assessment;
-
     if (!hasErrors()) {
+      const updatedAssessmentData: Assessment = {
+        date: selectedDate,
+        officer: {
+          key: selectedOfficer?.label,
+          value: selectedOfficer?.value,
+        },
+        action_required: selectedActionRequired?.label,
+        justification: {
+          key: selectedJustification?.label,
+          value: selectedJustification?.value,
+        },
+        assessment_type: selectedAssessmentTypes?.map((item) => {
+          return {
+            key: item.label,
+            value: item.value,
+          };
+        }),
+      };
+
       dispatch(upsertAssessment(id, updatedAssessmentData));
       setEditable(false);
     } else {
@@ -265,7 +272,10 @@ export const HWCRComplaintAssessment: FC = () => {
           <div className="assessment-details-edit-column">
             <div className="comp-details-edit-container">
               <div className="comp-details-edit-column">
-                <div id="assessment-checkbox-div" className="comp-details-label-checkbox-div-pair">
+                <div
+                  id="assessment-checkbox-div"
+                  className="comp-details-label-checkbox-div-pair"
+                >
                   <label
                     htmlFor="checkbox-div"
                     className="comp-details-inner-content-label checkbox-label-padding"
@@ -282,7 +292,12 @@ export const HWCRComplaintAssessment: FC = () => {
                   ) : (
                     <div>
                       {selectedAssessmentTypes.map((assesmentValue) => (
-                        <div className="checkbox-label-padding" key={assesmentValue.label}>{assesmentValue.label}</div>
+                        <div
+                          className="checkbox-label-padding"
+                          key={assesmentValue.label}
+                        >
+                          {assesmentValue.label}
+                        </div>
                       ))}
                     </div>
                   )}
@@ -291,7 +306,10 @@ export const HWCRComplaintAssessment: FC = () => {
             </div>
             <div className="comp-details-edit-container">
               <div className="comp-details-edit-column">
-                <div id="action-required-div" className="assessment-details-label-input-pair">
+                <div
+                  id="action-required-div"
+                  className="assessment-details-label-input-pair"
+                >
                   <label htmlFor="action-required">Action required?</label>
                   {editable ? (
                     <CompSelect
@@ -311,14 +329,17 @@ export const HWCRComplaintAssessment: FC = () => {
                 </div>
               </div>
               <div className="comp-details-edit-column comp-details-right-column">
-                <div id="justification-div" className="assessment-details-label-input-pair">
+                <div
+                  id="justification-div"
+                  className="assessment-details-label-input-pair"
+                >
                   <label
                     className={justificationLabelClass}
                     htmlFor="justification"
                   >
                     Justification
                   </label>
-                  {editable ?
+                  {editable ? (
                     <CompSelect
                       id="justification"
                       className={justificationEditClass}
@@ -329,16 +350,19 @@ export const HWCRComplaintAssessment: FC = () => {
                       value={selectedJustification}
                       placeholder="Select"
                       onChange={(e) => handleJustificationChange(e)}
-                    /> : <span className={justificationEditClass}>
-                      {selectedJustification?.label || ''}
-                    </span>
-                  }
+                    />
+                  ) : (
+                    <span className={justificationEditClass}>{selectedJustification?.label || ""}</span>
+                  )}
                 </div>
               </div>
             </div>
             <div className="comp-details-edit-container">
               <div className="comp-details-edit-column">
-                <div id="outcome-officer-div" className="assessment-details-label-input-pair">
+                <div
+                  id="outcome-officer-div"
+                  className="assessment-details-label-input-pair"
+                >
                   <label htmlFor="outcome-officer">Officer</label>
                   {editable ? (
                     <CompSelect
@@ -368,7 +392,10 @@ export const HWCRComplaintAssessment: FC = () => {
                 </div>
               </div>
               <div className="comp-details-edit-column comp-details-right-column">
-                <div id="complaint-outcome-date-div" className="assessment-details-label-input-pair">
+                <div
+                  id="complaint-outcome-date-div"
+                  className="assessment-details-label-input-pair"
+                >
                   <label htmlFor="complaint-outcome-date">Date</label>
                   {editable ? (
                     <ValidationDatePicker

--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-prevention-education.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-prevention-education.tsx
@@ -84,10 +84,12 @@ export const HWCRComplaintPrevention: FC = () => {
       setSelectedOfficer(officer);
       dispatch(getPrevention(complaintData.id));
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [complaintData]);
 
   useEffect(() => {
     populatePreventionUI();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [preventionState]);
 
   // clear the redux state
@@ -142,21 +144,21 @@ export const HWCRComplaintPrevention: FC = () => {
 
   // save to redux if no errors.  Otherwise, display error message(s).
   const saveButtonClick = async () => {
-    const updatedPreventionData = {
-      date: selectedDate,
-      officer: {
-        key: selectedOfficer?.label,
-        value: selectedOfficer?.value
-      },
-      prevention_type: selectedPreventionTypes.map((item) => {
-        return {
-          key: item.label,
-          value: item.value
-        }
-      }),
-    } as Prevention;
-
     if (!hasErrors()) {
+      const updatedPreventionData: Prevention = {
+        date: selectedDate,
+        officer: {
+          key: selectedOfficer?.label,
+          value: selectedOfficer?.value
+        },
+        prevention_type: selectedPreventionTypes?.map((item) => {
+          return {
+            key: item.label,
+            value: item.value
+          }
+        }),
+      };
+
       dispatch(upsertPrevention(id, updatedPreventionData));
       setEditable(false);
     } else {

--- a/frontend/src/app/types/outcomes/assessment.ts
+++ b/frontend/src/app/types/outcomes/assessment.ts
@@ -5,7 +5,7 @@ export interface Assessment {
   action_required?: string | null
   justification?: KeyValuePair,
   officer?: KeyValuePair;
-  date?: Date;
+  date?: Date | null;
   createdBy?: string;
   createdAt?: Date;
   updatedBy?: string;

--- a/frontend/src/app/types/outcomes/prevention.ts
+++ b/frontend/src/app/types/outcomes/prevention.ts
@@ -3,7 +3,7 @@ import KeyValuePair from "../app/key-value-pair";
 export interface Prevention {
   prevention_type: KeyValuePair[];
   officer?: KeyValuePair;
-  date?: Date;
+  date?: Date | null;
   createdBy?: string;
   createdAt?: Date;
   updatedBy?: string;


### PR DESCRIPTION
# Description
Fixes a problem in the validation of both the assessment and prevention and education where if a user doesn't select an option from the checkbox list will cause the validation to fail.

Fixes # CE-595

# How Has This Been Tested?
- [x] Existing cypress tests

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works

## Further comments
This addresses errors when tested against the CE-410 case-management branch


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-331-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-compliance-enforcement-331-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)