### PR TITLE
Pre-populate Officer field

### DIFF
--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-complaint-assessment.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-complaint-assessment.tsx
@@ -9,6 +9,7 @@ import {
   selectComplaint,
   selectComplaintCallerInformation,
   selectComplaintHeader,
+  selectComplaintAssignedBy
 } from "../../../../store/reducers/complaints";
 import {
   selectAssessmentTypeCodeDropdown,
@@ -30,6 +31,7 @@ import { BsPencil } from "react-icons/bs";
 import { CompTextIconButton } from "../../../common/comp-text-icon-button";
 
 import "../../../../../assets/sass/hwcr-assessment.scss";
+import KeyValuePair from "../../../../types/app/key-value-pair";
 
 export const HWCRComplaintAssessment: FC = () => {
   const dispatch = useAppDispatch();
@@ -62,9 +64,9 @@ export const HWCRComplaintAssessment: FC = () => {
   const assignableOfficers: Option[] =
     officersInAgencyList !== null
       ? officersInAgencyList.map((officer: Officer) => ({
-          value: officer.person_guid.person_guid,
-          label: `${officer.person_guid.first_name} ${officer.person_guid.last_name}`,
-        }))
+        value: officer.person_guid.person_guid,
+        label: `${officer.person_guid.first_name} ${officer.person_guid.last_name}`,
+      }))
       : [];
   const handleDateChange = (date: Date | null) => {
     setSelectedDate(date);
@@ -95,6 +97,7 @@ export const HWCRComplaintAssessment: FC = () => {
   const justificationList = useAppSelector(selectJustificationCodeDropdown);
   const assessmentTypeList = useAppSelector(selectAssessmentTypeCodeDropdown);
   const { personGuid } = useAppSelector(selectComplaintHeader(complaintType));
+  const assigned = useAppSelector(selectComplaintAssignedBy);
 
   useEffect(() => {
     if (id && (!complaintData || complaintData.id !== id)) {
@@ -108,12 +111,12 @@ export const HWCRComplaintAssessment: FC = () => {
       setSelectedOfficer(officer);
       dispatch(getAssessment(complaintData.id));
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [complaintData]);
 
   useEffect(() => {
     populateAssessmentUI();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [assessmentState]);
 
   // clear the redux state
@@ -127,27 +130,27 @@ export const HWCRComplaintAssessment: FC = () => {
     const selectedOfficer = (
       assessmentState.officer
         ? {
-            label: assessmentState.officer?.key,
-            value: assessmentState.officer?.value,
-          }
+          label: assessmentState.officer?.key,
+          value: assessmentState.officer?.value,
+        }
         : null
     ) as Option;
 
     const selectedActionRequired = (
       assessmentState.action_required
         ? {
-            label: assessmentState.action_required,
-            value: assessmentState.action_required,
-          }
+          label: assessmentState.action_required,
+          value: assessmentState.action_required,
+        }
         : null
     ) as Option;
 
     const selectedJustification = (
       assessmentState.justification
         ? {
-            label: assessmentState.justification?.key,
-            value: assessmentState.justification?.value,
-          }
+          label: assessmentState.justification?.key,
+          value: assessmentState.justification?.value,
+        }
         : null
     ) as Option;
 
@@ -165,6 +168,21 @@ export const HWCRComplaintAssessment: FC = () => {
     setSelectedAssessmentTypes(selectedAssessmentTypes);
     resetValidationErrors();
     setEditable(!assessmentState.date);
+
+    if (!selectedOfficer && assigned && officersInAgencyList) {
+        const officerAssigned: Option[] = officersInAgencyList.filter((officer) => officer.person_guid.person_guid === assigned)
+          .map((item) => {
+            return {
+              label: `${item.person_guid?.first_name} ${item.person_guid?.last_name}`,
+              value: assigned
+            } as Option;
+          });
+        if (officerAssigned && Array.isArray(officerAssigned) && officerAssigned.length > 0 &&
+          typeof (officerAssigned[0].label) !== 'undefined') {
+          setSelectedOfficer(officerAssigned[0]);
+        } 
+    }
+    
   };
 
   const justificationLabelClass = selectedActionRequired?.value === "No" ? "" : "comp-outcome-hide";

--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-prevention-education.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-prevention-education.tsx
@@ -9,6 +9,7 @@ import {
   selectComplaint,
   selectComplaintCallerInformation,
   selectComplaintHeader,
+  selectComplaintAssignedBy,
 } from "../../../../store/reducers/complaints";
 import {
   selectPreventionTypeCodeDropdown,
@@ -71,6 +72,7 @@ export const HWCRComplaintPrevention: FC = () => {
 
   const preventionTypeList = useAppSelector(selectPreventionTypeCodeDropdown);
   const { personGuid } = useAppSelector(selectComplaintHeader(complaintType));
+  const assigned = useAppSelector(selectComplaintAssignedBy);
 
   useEffect(() => {
     if (id && (!complaintData || complaintData.id !== id)) {
@@ -84,12 +86,12 @@ export const HWCRComplaintPrevention: FC = () => {
       setSelectedOfficer(officer);
       dispatch(getPrevention(complaintData.id));
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [complaintData]);
 
   useEffect(() => {
     populatePreventionUI();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [preventionState]);
 
   // clear the redux state
@@ -121,6 +123,22 @@ export const HWCRComplaintPrevention: FC = () => {
     setShowContent(preventionState.prevention_type?.length > 0);
     resetValidationErrors();
     setEditable(!preventionState.date);
+
+    if (!selectedOfficer && officersInAgencyList && assigned) {
+      const officerAssigned: Option[] = officersInAgencyList.filter((officer : Officer) =>
+        officer.person_guid.person_guid === assigned)
+        .map((element : Officer) => {
+          return {
+            label: `${element.person_guid?.first_name} ${element.person_guid?.last_name}`, value: assigned
+          } as Option;
+        });
+      if (officerAssigned && Array.isArray(officerAssigned) &&
+        officerAssigned.length > 0 && 
+        typeof (officerAssigned[0].label) !== 'undefined') {
+        setSelectedOfficer(officerAssigned[0]);
+      }
+    }
+
   };
 
   const cancelConfirmed = () => {


### PR DESCRIPTION
# Description

This change is needed to speed up the business process. It ensures that the officer field is pre-populated to the officer that has indicated that they are working on the HWC.

Fixes # (CE-572)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] When a complaint is assigned, the Officer field in the Complaint assessment section of a HWC is pre-populated to be the assigned officer
- [x] When a complaint is assigned, the Officer field in the Prevention and education section of a HWC is pre-populated to be the assigned officer

## Checklist

- [x] New and existing unit tests pass locally with my changes
