### PR TITLE
fix: CE-615

### DIFF
--- a/backend/src/types/models/case-files/supplemental-notes/equipment/delete-equipment-dto.ts
+++ b/backend/src/types/models/case-files/supplemental-notes/equipment/delete-equipment-dto.ts
@@ -1,4 +1,4 @@
 export interface DeleteEquipmentDto { 
     id: string;
-    userId: string;
+    updateUserId: string;
 }

--- a/backend/src/types/models/case-files/supplemental-notes/equipment/delete-equipment-dto.ts
+++ b/backend/src/types/models/case-files/supplemental-notes/equipment/delete-equipment-dto.ts
@@ -1,4 +1,4 @@
 export interface DeleteEquipmentDto { 
-    equipmentGuid: string;
-    updateUserId: string;
+    id: string;
+    userId: string;
 }

--- a/backend/src/types/models/case-files/supplemental-notes/equipment/equipment-details.ts
+++ b/backend/src/types/models/case-files/supplemental-notes/equipment/equipment-details.ts
@@ -1,9 +1,9 @@
 import { AssessmentActionDto } from "../../assessment-action";
 export interface EquipmentDetailsDto { 
-    equipmentTypeCode: string;
-    equipmentTypeShortDescription;
-    equipmentTypeLongDescription;
-    equipmentTypeActiveIndicator: boolean;
+    typeCode: string;
+    typeShortDescription;
+    typeLongDescription;
+    activeIndicator: boolean;
     address: string;
     xCoordinate: string;
     yCoordinate: string;

--- a/backend/src/v1/case_file/case_file.controller.ts
+++ b/backend/src/v1/case_file/case_file.controller.ts
@@ -35,11 +35,11 @@ export class CaseFileController {
   async deleteEquipment(
     @Token() token,
     @Query("id") id: string,
-    @Query("userId") userId: string,
+    @Query("updateUserId") userId: string,
   ): Promise<boolean> {
     const deleteEquipment = {
       id: id,
-      userId: userId,
+      updateUserId: userId,
     };
     return await this.service.deleteEquipment(token, deleteEquipment);
   }

--- a/backend/src/v1/case_file/case_file.controller.ts
+++ b/backend/src/v1/case_file/case_file.controller.ts
@@ -34,12 +34,12 @@ export class CaseFileController {
   @Roles(Role.COS_OFFICER)
   async deleteEquipment(
     @Token() token,
-    @Query("equipmentGuid") equipmentGuid: string,
-    @Query("updateUserId") updateUserId: string,
+    @Query("id") id: string,
+    @Query("userId") userId: string,
   ): Promise<boolean> {
     const deleteEquipment = {
-      equipmentGuid: equipmentGuid,
-      updateUserId: updateUserId,
+      id: id,
+      userId: userId,
     };
     return await this.service.deleteEquipment(token, deleteEquipment);
   }

--- a/backend/src/v1/case_file/case_file.service.ts
+++ b/backend/src/v1/case_file/case_file.service.ts
@@ -60,9 +60,9 @@ export class CaseFileService {
       }
     }
     equipment {
-      equipmentGuid
-      equipmentTypeCode
-      equipmentTypeActiveIndicator
+      id
+      typeCode
+      actionInd
       address
       xCoordinate
       yCoordinate

--- a/backend/src/v1/case_file/case_file.service.ts
+++ b/backend/src/v1/case_file/case_file.service.ts
@@ -62,10 +62,11 @@ export class CaseFileService {
     equipment {
       id
       typeCode
-      actionInd
+      activeIndicator
       address
       xCoordinate
       yCoordinate
+      createDate
       actions { 
         actionGuid
         actor

--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-equipment/equipment-form.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-equipment/equipment-form.tsx
@@ -233,9 +233,9 @@ export const EquipmentForm: FC<EquipmentFormProps> = ({ equipment, onSave, onCan
     // Create an equipment object to persist
     if (type) {
       const equipmentDetails = {
-        equipmentGuid: equipment?.equipmentGuid,
-        equipmentTypeCode: type.value,
-        equipmentTypeActiveIndicator: true,
+        id: equipment?.id,
+        typeCode: type.value,
+        activeIndicator: true,
         address: address,
         xCoordinate: xCoordinate,
         yCoordinate: yCoordinate,
@@ -247,7 +247,7 @@ export const EquipmentForm: FC<EquipmentFormProps> = ({ equipment, onSave, onCan
   };
 
   const handleFormErrors = () => {
-    const errorMsg = equipment?.equipmentGuid ? "Errors editing equipment" : "Errors creating equipment";
+    const errorMsg = equipment?.id ? "Errors editing equipment" : "Errors creating equipment";
     ToggleError(errorMsg);
   };
 
@@ -283,7 +283,7 @@ export const EquipmentForm: FC<EquipmentFormProps> = ({ equipment, onSave, onCan
 
   // for turning codes into values
   const getValue = (property: string): Option | undefined => {
-    return equipmentTypeCodes.find((item) => item.value === equipment?.equipmentTypeCode);
+    return equipmentTypeCodes.find((item) => item.value === equipment?.typeCode);
   };
 
   const hasCoordinates = complaintData?.location?.coordinates[0] !== 0 || complaintData?.location?.coordinates[1] !== 0;

--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-equipment/equipment-item.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-equipment/equipment-item.tsx
@@ -26,19 +26,19 @@ export const EquipmentItem: FC<EquipmentItemProps> = ({ equipment, isEditDisable
   const [showModal, setShowModal] = useState(false);
 
   const handleEdit = (equipment: EquipmentDetailsDto) => {
-    if (equipment.equipmentGuid) {
-      onEdit(equipment.equipmentGuid);
+    if (equipment.id) {
+      onEdit(equipment.id);
     }
   };
 
   // for turning codes into values
   const getValue = (property: string): Option | undefined => {
-    return equipmentTypeCodes.find((item) => item.value === equipment.equipmentTypeCode);
+    return equipmentTypeCodes.find((item) => item.value === equipment.typeCode);
   };
 
-  const handleDeleteEquipment = (equipmentGuid: string | undefined) => {
-    if (equipmentGuid) {
-      dispatch(deleteEquipment(equipmentGuid));
+  const handleDeleteEquipment = (id: string | undefined) => {
+    if (id) {
+      dispatch(deleteEquipment(id));
     }
   };
 
@@ -75,7 +75,7 @@ export const EquipmentItem: FC<EquipmentItemProps> = ({ equipment, isEditDisable
         content="All the data in this section will be lost."
         onHide={() => setShowModal(false)}
         onDelete={() => {
-          handleDeleteEquipment(equipment.equipmentGuid);
+          handleDeleteEquipment(equipment.id);
           setShowModal(false);
         }}
         confirmText="Yes, delete equipment"
@@ -178,7 +178,7 @@ export const EquipmentItem: FC<EquipmentItemProps> = ({ equipment, isEditDisable
             </div>
           </Col>
         </Row>
-        {equipment.equipmentGuid && removedEquipmentActor && (
+        {equipment.id && removedEquipmentActor && (
           <Row>
             <Col
               xs={12}

--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-equipment/index.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-equipment/index.tsx
@@ -35,7 +35,6 @@ export const HWCREquipment: FC = memo(() => {
   const handleSave = () => {
     setShowEquipmentForm(false);
     setEditingGuid("");
-    dispatch(findCase())
   };
 
   const handleCancel = () => {

--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-equipment/index.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-equipment/index.tsx
@@ -48,19 +48,19 @@ export const HWCREquipment: FC = memo(() => {
     <div className="comp-outcome-report-block">
       <h6>Equipment</h6>
       {equipmentList && equipmentList.length > 0 ? equipmentList.map((equipment)=>
-          editingGuid === equipment.equipmentGuid ?
+          editingGuid === equipment.id ?
           <EquipmentForm
-            key={equipment.equipmentGuid}
+            key={equipment.id}
             equipment={equipment}
             onSave={handleSave}
             onCancel={handleCancel}
           />
           :
           <EquipmentItem
-            key={equipment.equipmentGuid}
+            key={equipment.id}
             equipment={equipment}
             onEdit={handleEdit}
-            isEditDisabled={!!editingGuid && editingGuid !== equipment.equipmentGuid}
+            isEditDisabled={!!editingGuid && editingGuid !== equipment.id}
           />
       ): null}
 

--- a/frontend/src/app/store/reducers/case-thunks.ts
+++ b/frontend/src/app/store/reducers/case-thunks.ts
@@ -609,9 +609,8 @@ export const updateReview =
 
     const deleteEquipmentInput = {
       id: id,
-      userId: profile.idir_username,
+      updateUserId: profile.idir_username,
     };
-    
       const parameters = generateApiParameters(`${config.API_BASE_URL}/v1/case/equipment`, deleteEquipmentInput);
       await deleteMethod<boolean>(dispatch, parameters).then(async (res) => {
         if (res) {
@@ -662,7 +661,7 @@ export const updateReview =
       let updateEquipmentInput = {
         updateEquipmentInput: {
           leadIdentifier: complaintIdentifier,
-          createUserId: profile.idir_username,
+          updateUserId: profile.idir_username,
           agencyCode: "COS",
           caseCode: "HWCR",
           equipment: [equipment],

--- a/frontend/src/app/store/reducers/case-thunks.ts
+++ b/frontend/src/app/store/reducers/case-thunks.ts
@@ -596,9 +596,9 @@ export const updateReview =
   };
 
   export const deleteEquipment =
-  (equipmentGuid: string): AppThunk =>
+  (id: string): AppThunk =>
   async (dispatch, getState) => {
-    if (!equipmentGuid) {
+    if (!id) {
       return;
     }
 
@@ -608,8 +608,8 @@ export const updateReview =
 
 
     const deleteEquipmentInput = {
-      equipmentGuid: equipmentGuid,
-      updateUserId: profile.idir_username,
+      id: id,
+      userId: profile.idir_username,
     };
     
       const parameters = generateApiParameters(`${config.API_BASE_URL}/v1/case/equipment`, deleteEquipmentInput);
@@ -617,7 +617,7 @@ export const updateReview =
         if (res) {
           // remove equipment from state
           const { cases: { equipment } } =  getState();
-          const updatedEquipment = equipment?.filter(equipment => equipment.equipmentGuid !== equipmentGuid);
+          const updatedEquipment = equipment?.filter(equipment => equipment.id !== id);
           
           dispatch(setCaseFile({ equipment: updatedEquipment }));
           ToggleSuccess(`Equipment has been deleted`);
@@ -639,7 +639,7 @@ export const updateReview =
     } = getState();
     // equipment does not exist, let's create it
     if (complaintIdentifier
-       && !equipment.equipmentGuid) {
+       && !equipment.id) {
       let createEquipmentInput = {
         createEquipmentInput: {
           leadIdentifier: complaintIdentifier,

--- a/frontend/src/app/types/app/case-files/equipment-details.ts
+++ b/frontend/src/app/types/app/case-files/equipment-details.ts
@@ -1,11 +1,11 @@
 import { CaseActionDto } from "./case-action";
 
 export interface EquipmentDetailsDto {
-  equipmentGuid?: string;
-  equipmentTypeCode: string;
-  equipmentTypeShortDescription?: string;
-  equipmentTypeLongDescription?: string;
-  equipmentTypeActiveIndicator: boolean;
+  id?: string;
+  typeCode: string;
+  shortDescription: string;
+  longDescription: string ;
+  activeIndicator: boolean;
   address?: string;
   xCoordinate: string;
   yCoordinate: string;

--- a/frontend/src/app/types/app/case-files/equipment-inputs/delete-equipment-input.ts
+++ b/frontend/src/app/types/app/case-files/equipment-inputs/delete-equipment-input.ts
@@ -1,4 +1,4 @@
 export interface DeleteEquipmentInput {
-  equipmentGuid: string;
-  updateUserId: string;
+  id: string;
+  userId: string;
 }

--- a/frontend/src/app/types/app/case-files/equipment-inputs/delete-equipment-input.ts
+++ b/frontend/src/app/types/app/case-files/equipment-inputs/delete-equipment-input.ts
@@ -1,4 +1,4 @@
 export interface DeleteEquipmentInput {
   id: string;
-  userId: string;
+  updateUserId: string;
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Users can now set the "Removed By" user/date as part of an equipment update.

Fixes # (issue)

# How Has This Been Tested?

- [x] Create an equipment record without a "removed by" action
- [x] Update the equipment record to set a "removed by" action

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-341-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-compliance-enforcement-341-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)