### PR TITLE
fix: CE-553 - Ensure officer list is populated

### DIFF
--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-complaint-assessment.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-complaint-assessment.tsx
@@ -3,13 +3,13 @@ import Option from "../../../../types/app/option";
 import { Button } from "react-bootstrap";
 import { Officer } from "../../../../types/person/person";
 import { useAppDispatch, useAppSelector } from "../../../../hooks/hooks";
-import { selectOfficersByAgency } from "../../../../store/reducers/officer";
+import { selectOfficersByAgency, selectOfficers } from "../../../../store/reducers/officer";
 import {
   getComplaintById,
   selectComplaint,
   selectComplaintCallerInformation,
   selectComplaintHeader,
-  selectComplaintAssignedBy
+  selectComplaintAssignedBy,
 } from "../../../../store/reducers/complaints";
 import {
   selectAssessmentTypeCodeDropdown,
@@ -30,7 +30,7 @@ import { ValidationDatePicker } from "../../../../common/validation-date-picker"
 import { BsPencil } from "react-icons/bs";
 import { CompTextIconButton } from "../../../common/comp-text-icon-button";
 
-import "../../../../../assets/sass/hwcr-assessment.scss"
+import "../../../../../assets/sass/hwcr-assessment.scss";
 import { selectAssessment } from "../../../../store/reducers/case-selectors";
 import { getAssessment, upsertAssessment } from "../../../../store/reducers/case-thunks";
 
@@ -62,12 +62,14 @@ export const HWCRComplaintAssessment: FC = () => {
   const { id = "", complaintType = "" } = useParams<ComplaintParams>();
   const { ownedByAgencyCode } = useAppSelector(selectComplaintCallerInformation);
   const officersInAgencyList = useAppSelector(selectOfficersByAgency(ownedByAgencyCode?.agency));
+  const officerList = useAppSelector(selectOfficers);
+
   const assignableOfficers: Option[] =
     officersInAgencyList !== null
       ? officersInAgencyList.map((officer: Officer) => ({
-        value: officer.person_guid.person_guid,
-        label: `${officer.person_guid.first_name} ${officer.person_guid.last_name}`,
-      }))
+          value: officer.person_guid.person_guid,
+          label: `${officer.person_guid.first_name} ${officer.person_guid.last_name}`,
+        }))
       : [];
   const handleDateChange = (date: Date | null) => {
     setSelectedDate(date);
@@ -110,7 +112,7 @@ export const HWCRComplaintAssessment: FC = () => {
     if (complaintData) {
       const officer = getSelectedOfficer(assignableOfficers, personGuid, complaintData);
       setSelectedOfficer(officer);
-      dispatch(getAssessment(complaintData.id));
+      dispatch(getAssessment(complaintData.id, officerList ?? undefined));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [complaintData]);
@@ -131,27 +133,27 @@ export const HWCRComplaintAssessment: FC = () => {
     const selectedOfficer = (
       assessmentState.officer
         ? {
-          label: assessmentState.officer?.key,
-          value: assessmentState.officer?.value,
-        }
+            label: assessmentState.officer?.key,
+            value: assessmentState.officer?.value,
+          }
         : null
     ) as Option;
 
     const selectedActionRequired = (
       assessmentState.action_required
         ? {
-          label: assessmentState.action_required,
-          value: assessmentState.action_required,
-        }
+            label: assessmentState.action_required,
+            value: assessmentState.action_required,
+          }
         : null
     ) as Option;
 
     const selectedJustification = (
       assessmentState.justification
         ? {
-          label: assessmentState.justification?.key,
-          value: assessmentState.justification?.value,
-        }
+            label: assessmentState.justification?.key,
+            value: assessmentState.justification?.value,
+          }
         : null
     ) as Option;
 
@@ -173,19 +175,23 @@ export const HWCRComplaintAssessment: FC = () => {
     setEditable(!assessmentState.date);
 
     if (!selectedOfficer && assigned && officersInAgencyList) {
-        const officerAssigned: Option[] = officersInAgencyList.filter((officer) => officer.person_guid.person_guid === assigned)
-          .map((item) => {
-            return {
-              label: `${item.person_guid?.first_name} ${item.person_guid?.last_name}`,
-              value: assigned
-            } as Option;
-          });
-        if (officerAssigned && Array.isArray(officerAssigned) && officerAssigned.length > 0 &&
-          typeof (officerAssigned[0].label) !== 'undefined') {
-          setSelectedOfficer(officerAssigned[0]);
-        } 
+      const officerAssigned: Option[] = officersInAgencyList
+        .filter((officer) => officer.person_guid.person_guid === assigned)
+        .map((item) => {
+          return {
+            label: `${item.person_guid?.first_name} ${item.person_guid?.last_name}`,
+            value: assigned,
+          } as Option;
+        });
+      if (
+        officerAssigned &&
+        Array.isArray(officerAssigned) &&
+        officerAssigned.length > 0 &&
+        typeof officerAssigned[0].label !== "undefined"
+      ) {
+        setSelectedOfficer(officerAssigned[0]);
+      }
     }
-    
   };
 
   const justificationLabelClass = selectedActionRequired?.value === "No" ? "" : "comp-outcome-hide";

--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-prevention-education.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-prevention-education.tsx
@@ -3,7 +3,7 @@ import Option from "../../../../types/app/option";
 import { Button } from "react-bootstrap";
 import { Officer } from "../../../../types/person/person";
 import { useAppDispatch, useAppSelector } from "../../../../hooks/hooks";
-import { selectOfficersByAgency } from "../../../../store/reducers/officer";
+import { selectOfficersByAgency, selectOfficers } from "../../../../store/reducers/officer";
 import {
   getComplaintById,
   selectComplaint,
@@ -75,6 +75,7 @@ export const HWCRComplaintPrevention: FC = () => {
   const preventionTypeList = useAppSelector(selectPreventionTypeCodeDropdown);
   const { personGuid } = useAppSelector(selectComplaintHeader(complaintType));
   const assigned = useAppSelector(selectComplaintAssignedBy);
+  const officerList = useAppSelector(selectOfficers);
 
   useEffect(() => {
     if (id && (!complaintData || complaintData.id !== id)) {
@@ -86,7 +87,7 @@ export const HWCRComplaintPrevention: FC = () => {
     if (complaintData) {
       const officer = getSelectedOfficer(assignableOfficers, personGuid, complaintData);
       setSelectedOfficer(officer);
-      dispatch(getPrevention(complaintData.id));
+      dispatch(getPrevention(complaintData.id, officerList ?? undefined));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [complaintData]);
@@ -130,20 +131,23 @@ export const HWCRComplaintPrevention: FC = () => {
     setEditable(!preventionState.date);
 
     if (!selectedOfficer && officersInAgencyList && assigned) {
-      const officerAssigned: Option[] = officersInAgencyList.filter((officer : Officer) =>
-        officer.person_guid.person_guid === assigned)
-        .map((element : Officer) => {
+      const officerAssigned: Option[] = officersInAgencyList
+        .filter((officer: Officer) => officer.person_guid.person_guid === assigned)
+        .map((element: Officer) => {
           return {
-            label: `${element.person_guid?.first_name} ${element.person_guid?.last_name}`, value: assigned
+            label: `${element.person_guid?.first_name} ${element.person_guid?.last_name}`,
+            value: assigned,
           } as Option;
         });
-      if (officerAssigned && Array.isArray(officerAssigned) &&
-        officerAssigned.length > 0 && 
-        typeof (officerAssigned[0].label) !== 'undefined') {
+      if (
+        officerAssigned &&
+        Array.isArray(officerAssigned) &&
+        officerAssigned.length > 0 &&
+        typeof officerAssigned[0].label !== "undefined"
+      ) {
         setSelectedOfficer(officerAssigned[0]);
       }
     }
-
   };
 
   const cancelConfirmed = () => {

--- a/frontend/src/app/store/reducers/case-thunks.ts
+++ b/frontend/src/app/store/reducers/case-thunks.ts
@@ -52,14 +52,15 @@ export const getCaseFile =
 
 //-- assessment thunks
 export const getAssessment =
-  (complaintIdentifier?: string): AppThunk =>
+  (complaintIdentifier?: string, officerList?: Officer[]): AppThunk =>
   async (dispatch, getState) => {
     const {
       officers: { officers },
     } = getState();
+    const officerListParam = officers ?? officerList;
     const parameters = generateApiParameters(`${config.API_BASE_URL}/v1/case/${complaintIdentifier}`);
     await get<CaseFileDto>(dispatch, parameters).then(async (res) => {
-      const updatedAssessmentData = await parseAssessmentResponse(res, officers);
+      const updatedAssessmentData = await parseAssessmentResponse(res, officerListParam);
       dispatch(setCaseId(res.caseIdentifier));
       dispatch(setAssessment({ assessment: updatedAssessmentData }));
       dispatch(setIsReviewedRequired(res.isReviewRequired));
@@ -220,16 +221,7 @@ const parseAssessmentResponse = async (
     })[0];
 
     let officerFullName = null;
-    
-    console.trace();
-    console.log("actor:", actor);
-    console.log("officers:");
-    officers.map((officer) => {
-      const {person_guid, first_name, last_name} = officer.person_guid;
-      console.log(`  guid='${person_guid}' name='${first_name} ${last_name}'`);
-      return null;
-    });
-    
+
     let officerNames = officers
       .filter((person) => person.person_guid.person_guid === actor)
       .map((officer) => {
@@ -266,14 +258,15 @@ const parseAssessmentResponse = async (
 
 //-- prevention and education thunks
 export const getPrevention =
-  (complaintIdentifier?: string): AppThunk =>
+  (complaintIdentifier?: string, officerList?: Officer[]): AppThunk =>
   async (dispatch, getState) => {
     const {
       officers: { officers },
     } = getState();
+    const officerListParam = officers ?? officerList;
     const parameters = generateApiParameters(`${config.API_BASE_URL}/v1/case/${complaintIdentifier}`);
     await get<CaseFileDto>(dispatch, parameters).then(async (res) => {
-      const updatedPreventionData = await parsePreventionResponse(res, officers);
+      const updatedPreventionData = await parsePreventionResponse(res, officerListParam);
       dispatch(setPrevention({ prevention: updatedPreventionData }));
     });
   };
@@ -663,7 +656,7 @@ export const updateReview =
     });
   };
 
-  export const deleteEquipment =
+export const deleteEquipment =
   (id: string): AppThunk =>
   async (dispatch, getState) => {
     if (!id) {
@@ -674,25 +667,26 @@ export const updateReview =
       app: { profile },
     } = getState();
 
-
     const deleteEquipmentInput = {
       id: id,
       updateUserId: profile.idir_username,
     };
-      const parameters = generateApiParameters(`${config.API_BASE_URL}/v1/case/equipment`, deleteEquipmentInput);
-      await deleteMethod<boolean>(dispatch, parameters).then(async (res) => {
-        if (res) {
-          // remove equipment from state
-          const { cases: { equipment } } =  getState();
-          const updatedEquipment = equipment?.filter(equipment => equipment.id !== id);
-          
-          dispatch(setCaseFile({ equipment: updatedEquipment }));
-          ToggleSuccess(`Equipment has been deleted`);
-        } else {
-          ToggleError(`Unable to update equipment`);
-        }
-      });
-     }
+    const parameters = generateApiParameters(`${config.API_BASE_URL}/v1/case/equipment`, deleteEquipmentInput);
+    await deleteMethod<boolean>(dispatch, parameters).then(async (res) => {
+      if (res) {
+        // remove equipment from state
+        const {
+          cases: { equipment },
+        } = getState();
+        const updatedEquipment = equipment?.filter((equipment) => equipment.id !== id);
+
+        dispatch(setCaseFile({ equipment: updatedEquipment }));
+        ToggleSuccess(`Equipment has been deleted`);
+      } else {
+        ToggleError(`Unable to update equipment`);
+      }
+    });
+  };
 
 export const upsertEquipment =
   (complaintIdentifier: string, equipment: EquipmentDetailsDto): AppThunk =>
@@ -705,8 +699,7 @@ export const upsertEquipment =
       app: { profile },
     } = getState();
     // equipment does not exist, let's create it
-    if (complaintIdentifier
-       && !equipment.id) {
+    if (complaintIdentifier && !equipment.id) {
       let createEquipmentInput = {
         createEquipmentInput: {
           leadIdentifier: complaintIdentifier,


### PR DESCRIPTION
# Description

This PR address the issue of Save Assessment sometimes displays officer GUID instead of name

Fixes # (CE-553)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Add an Assessment to a complaint. Refresh the page. Observe that officer name translated correctly in the view mode of the Assessment and Prevention and Education sections. 


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes



---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-359-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-compliance-enforcement-359-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)