### PR TITLE
bug: CE-553 Resolve the issue of GUID in the officer field

### DIFF
--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-complaint-assessment.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-complaint-assessment.tsx
@@ -3,7 +3,7 @@ import Option from "../../../../types/app/option";
 import { Button } from "react-bootstrap";
 import { Officer } from "../../../../types/person/person";
 import { useAppDispatch, useAppSelector } from "../../../../hooks/hooks";
-import { selectOfficersByAgency, selectOfficers } from "../../../../store/reducers/officer";
+import { selectOfficersByAgency } from "../../../../store/reducers/officer";
 import {
   getComplaintById,
   selectComplaint,
@@ -62,7 +62,7 @@ export const HWCRComplaintAssessment: FC = () => {
   const { id = "", complaintType = "" } = useParams<ComplaintParams>();
   const { ownedByAgencyCode } = useAppSelector(selectComplaintCallerInformation);
   const officersInAgencyList = useAppSelector(selectOfficersByAgency(ownedByAgencyCode?.agency));
-  const officerList = useAppSelector(selectOfficers);
+  const { officers } = useAppSelector((state) => state.officers);
 
   const assignableOfficers: Option[] =
     officersInAgencyList !== null
@@ -112,10 +112,10 @@ export const HWCRComplaintAssessment: FC = () => {
     if (complaintData) {
       const officer = getSelectedOfficer(assignableOfficers, personGuid, complaintData);
       setSelectedOfficer(officer);
-      dispatch(getAssessment(complaintData.id, officerList ?? undefined));
+      dispatch(getAssessment(complaintData.id));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [complaintData]);
+  }, [complaintData, officers]);
 
   useEffect(() => {
     populateAssessmentUI();

--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-complaint-assessment.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-complaint-assessment.tsx
@@ -62,7 +62,6 @@ export const HWCRComplaintAssessment: FC = () => {
   const { id = "", complaintType = "" } = useParams<ComplaintParams>();
   const { ownedByAgencyCode } = useAppSelector(selectComplaintCallerInformation);
   const officersInAgencyList = useAppSelector(selectOfficersByAgency(ownedByAgencyCode?.agency));
-  const { officers } = useAppSelector((state) => state.officers);
 
   const assignableOfficers: Option[] =
     officersInAgencyList !== null
@@ -115,7 +114,7 @@ export const HWCRComplaintAssessment: FC = () => {
       dispatch(getAssessment(complaintData.id));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [complaintData, officers]);
+  }, [complaintData]);
 
   useEffect(() => {
     populateAssessmentUI();

--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-prevention-education.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-prevention-education.tsx
@@ -3,7 +3,7 @@ import Option from "../../../../types/app/option";
 import { Button } from "react-bootstrap";
 import { Officer } from "../../../../types/person/person";
 import { useAppDispatch, useAppSelector } from "../../../../hooks/hooks";
-import { selectOfficersByAgency, selectOfficers } from "../../../../store/reducers/officer";
+import { selectOfficersByAgency } from "../../../../store/reducers/officer";
 import {
   getComplaintById,
   selectComplaint,
@@ -75,7 +75,7 @@ export const HWCRComplaintPrevention: FC = () => {
   const preventionTypeList = useAppSelector(selectPreventionTypeCodeDropdown);
   const { personGuid } = useAppSelector(selectComplaintHeader(complaintType));
   const assigned = useAppSelector(selectComplaintAssignedBy);
-  const officerList = useAppSelector(selectOfficers);
+  const { officers } = useAppSelector((state) => state.officers);
 
   useEffect(() => {
     if (id && (!complaintData || complaintData.id !== id)) {
@@ -87,10 +87,10 @@ export const HWCRComplaintPrevention: FC = () => {
     if (complaintData) {
       const officer = getSelectedOfficer(assignableOfficers, personGuid, complaintData);
       setSelectedOfficer(officer);
-      dispatch(getPrevention(complaintData.id, officerList ?? undefined));
+      dispatch(getPrevention(complaintData.id));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [complaintData]);
+  }, [complaintData, officers]);
 
   useEffect(() => {
     populatePreventionUI();

--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-prevention-education.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-prevention-education.tsx
@@ -75,7 +75,6 @@ export const HWCRComplaintPrevention: FC = () => {
   const preventionTypeList = useAppSelector(selectPreventionTypeCodeDropdown);
   const { personGuid } = useAppSelector(selectComplaintHeader(complaintType));
   const assigned = useAppSelector(selectComplaintAssignedBy);
-  const { officers } = useAppSelector((state) => state.officers);
 
   useEffect(() => {
     if (id && (!complaintData || complaintData.id !== id)) {
@@ -90,7 +89,7 @@ export const HWCRComplaintPrevention: FC = () => {
       dispatch(getPrevention(complaintData.id));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [complaintData, officers]);
+  }, [complaintData]);
 
   useEffect(() => {
     populatePreventionUI();

--- a/frontend/src/app/store/reducers/case-thunks.ts
+++ b/frontend/src/app/store/reducers/case-thunks.ts
@@ -52,15 +52,14 @@ export const getCaseFile =
 
 //-- assessment thunks
 export const getAssessment =
-  (complaintIdentifier?: string, officerList?: Officer[]): AppThunk =>
+  (complaintIdentifier?: string): AppThunk =>
   async (dispatch, getState) => {
     const {
       officers: { officers },
     } = getState();
-    const officerListParam = officers ?? officerList;
     const parameters = generateApiParameters(`${config.API_BASE_URL}/v1/case/${complaintIdentifier}`);
     await get<CaseFileDto>(dispatch, parameters).then(async (res) => {
-      const updatedAssessmentData = await parseAssessmentResponse(res, officerListParam);
+      const updatedAssessmentData = await parseAssessmentResponse(res, officers);
       dispatch(setCaseId(res.caseIdentifier));
       dispatch(setAssessment({ assessment: updatedAssessmentData }));
       dispatch(setIsReviewedRequired(res.isReviewRequired));
@@ -258,15 +257,14 @@ const parseAssessmentResponse = async (
 
 //-- prevention and education thunks
 export const getPrevention =
-  (complaintIdentifier?: string, officerList?: Officer[]): AppThunk =>
+  (complaintIdentifier?: string): AppThunk =>
   async (dispatch, getState) => {
     const {
       officers: { officers },
     } = getState();
-    const officerListParam = officers ?? officerList;
     const parameters = generateApiParameters(`${config.API_BASE_URL}/v1/case/${complaintIdentifier}`);
     await get<CaseFileDto>(dispatch, parameters).then(async (res) => {
-      const updatedPreventionData = await parsePreventionResponse(res, officerListParam);
+      const updatedPreventionData = await parsePreventionResponse(res, officers);
       dispatch(setPrevention({ prevention: updatedPreventionData }));
     });
   };

--- a/frontend/src/app/store/store.ts
+++ b/frontend/src/app/store/store.ts
@@ -8,8 +8,8 @@ const persistConfig = {
   key: "enforcement",
   storage,
   blacklist: ["app"],
-  whitelist: ["codeTables"],
-  version: 6,  // This needs to be incremented every time a new migration is added
+  whitelist: ["codeTables", "officers"],
+  version: 6, // This needs to be incremented every time a new migration is added
   debug: true,
   migrate: createMigrate(migration, { debug: false }),
 };


### PR DESCRIPTION
# Description

The cause of the issue described in CE-553 is when a user refreshes the complaint details the data (officer list) that is supposed to be in Redux state is missing. It only occurs in the test environment. Debugging found the the app attempts to run setOfficers action but it happens late in a sequence when complaint detail component is already rendered.  

The code is modified to retrieve the Redux state in the Assessment and Prevention and Eductions sections in the same way as it was done in other sections. Also the list of officers is added to a dependency array of useEffect that refresh the view. It should re-render Complaint Details component when officer list is populated.

Fixes # (CE-553)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Add an Assessment to a complaint. Refresh the page. Observe that officer name is translated correctly


## Checklist

- [x] New and existing unit tests pass locally with my changes




---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-373-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-compliance-enforcement-373-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)