### PR TITLE
feature/CE-629-Implement-changes-to-Complaint-Assessment-section-based-on-usability-testing-feedback

### DIFF
--- a/frontend/cypress/e2e/hwcr-outcome-assessment.cy.ts
+++ b/frontend/cypress/e2e/hwcr-outcome-assessment.cy.ts
@@ -84,21 +84,27 @@ describe("HWCR Outcome Assessments", () => {
       if ($assessment.find("#assessment-edit-button").length) {
         cy.get("#assessment-edit-button").click();
 
-        const newCheckboxForEdit = "#ASSESSHLTH";
-        cy.get(newCheckboxForEdit).should("exist");
-        cy.get(newCheckboxForEdit).check();
+        cy.get("#action-required-div")
+          .invoke("text")
+          .then((actionRequired) => {
+            if (actionRequired === "Yes") {
+              const newCheckboxForEdit = "#ASSESSHLTH";
+              cy.get(newCheckboxForEdit).should("exist");
+              cy.get(newCheckboxForEdit).check();
 
-        cy.get("#outcome-cancel-button").click();
+              cy.get("#outcome-cancel-button").click();
 
-        cy.get(".modal-footer > .btn-primary").click();
+              cy.get(".modal-footer > .btn-primary").click();
 
-        cy.get("#assessment-checkbox-div").should(($div) => {
-          expect($div).to.contain.text("Assessed public safety risk");
-        });
+              cy.get("#assessment-checkbox-div").should(($div) => {
+                expect($div).to.contain.text("Assessed public safety risk");
+              });
 
-        cy.get("#assessment-checkbox-div").should(($div) => {
-          expect($div).to.not.contain.text("Assessed health as per animal welfare guidelines");
-        });
+              cy.get("#assessment-checkbox-div").should(($div) => {
+                expect($div).to.not.contain.text("Assessed health as per animal welfare guidelines");
+              });
+            }
+          });
       } else {
         cy.log("Assessment Not Found, did a previous test fail? Skip the Test");
         this.skip();

--- a/frontend/cypress/e2e/hwcr-outcome-assessment.cy.ts
+++ b/frontend/cypress/e2e/hwcr-outcome-assessment.cy.ts
@@ -21,7 +21,7 @@ describe("HWCR Outcome Assessments", () => {
 
         //validate error message
         cy.get(".error-message").should(($error) => {
-          expect($error).to.contain.text("One or more assessment is required");
+          expect($error).to.contain.text("Required");
         });
 
         //validate Action Required is required
@@ -126,7 +126,6 @@ describe("HWCR Outcome Assessments", () => {
         };
 
         cy.fillInHWCSection(sectionParams).then(() => {
-          sectionParams.checkboxes = ["Assessed public safety risk", "Assessed known conflict history"];
           cy.validateHWCSection(sectionParams);
         });
       } else {

--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -338,12 +338,19 @@ Cypress.Commands.add("fillInHWCSection", ({ section, checkboxes, officer, date, 
     saveButtonId = "#outcome-save-prev-and-educ-button";
   }
 
-  Cypress._.times(checkboxes.length, (index) => {
-    cy.get(checkboxes[index]).check();
-  });
-
-  if (actionRequired) {
-    cy.selectItemById("action-required", actionRequired);
+  if (section === "ASSESSMENT") {
+    if (actionRequired) {
+      cy.selectItemById("action-required", actionRequired);
+      if (actionRequired === "Yes") {
+        Cypress._.times(checkboxes.length, (index) => {
+          cy.get(checkboxes[index]).check();
+        });
+      }
+    }
+  } else {
+    Cypress._.times(checkboxes.length, (index) => {
+      cy.get(checkboxes[index]).check();
+    });
   }
 
   if (justification) {
@@ -375,16 +382,25 @@ Cypress.Commands.add(
       dateDiv = "#prev-educ-outcome-date-div";
     }
 
-    //Verify Fields exist
-    Cypress._.times(checkboxes.length, (index) => {
-      cy.get(checkboxDiv).should(($div) => {
-        expect($div).to.contain.text(checkboxes[index]);
-      });
-    });
-
-    if (actionRequired) {
-      cy.get("#action-required-div").should(($div) => {
-        expect($div).to.contain.text(actionRequired);
+    if (section === "ASSESSMENT") {
+      if (actionRequired) {
+        cy.get("#action-required-div").should(($div) => {
+          expect($div).to.contain.text(actionRequired);
+        });
+        if (actionRequired === "Yes") {
+          //Verify Fields exist
+          Cypress._.times(checkboxes.length, (index) => {
+            cy.get(checkboxDiv).should(($div) => {
+              expect($div).to.contain.text(checkboxes[index]);
+            });
+          });
+        }
+      }
+    } else {
+      Cypress._.times(checkboxes.length, (index) => {
+        cy.get(checkboxDiv).should(($div) => {
+          expect($div).to.contain.text(checkboxes[index]);
+        });
       });
     }
 

--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-complaint-assessment.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-complaint-assessment.tsx
@@ -33,6 +33,7 @@ import { CompTextIconButton } from "../../../common/comp-text-icon-button";
 import "../../../../../assets/sass/hwcr-assessment.scss";
 import { selectAssessment } from "../../../../store/reducers/case-selectors";
 import { getAssessment, upsertAssessment } from "../../../../store/reducers/case-thunks";
+import { OptionLabels } from "../../../../constants/option-labels";
 
 export const HWCRComplaintAssessment: FC = () => {
   const dispatch = useAppDispatch();
@@ -230,7 +231,7 @@ export const HWCRComplaintAssessment: FC = () => {
           value: selectedJustification?.value,
         },
         assessment_type:
-          selectedActionRequired?.label === "No"
+          selectedActionRequired?.label === OptionLabels.OPTION_NO
             ? []
             : selectedAssessmentTypes?.map((item) => {
                 return {
@@ -280,7 +281,10 @@ export const HWCRComplaintAssessment: FC = () => {
       hasErrors = true;
     }
 
-    if (selectedActionRequired?.value === "Yes" && (!selectedAssessmentTypes || selectedAssessmentTypes?.length <= 0)) {
+    if (
+      selectedActionRequired?.value === OptionLabels.OPTION_YES &&
+      (!selectedAssessmentTypes || selectedAssessmentTypes?.length <= 0)
+    ) {
       setAssessmentRequiredErrorMessage("One or more assessment is required");
       hasErrors = true;
     }

--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-complaint-assessment.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-complaint-assessment.tsx
@@ -229,12 +229,15 @@ export const HWCRComplaintAssessment: FC = () => {
           key: selectedJustification?.label,
           value: selectedJustification?.value,
         },
-        assessment_type: selectedAssessmentTypes?.map((item) => {
-          return {
-            key: item.label,
-            value: item.value,
-          };
-        }),
+        assessment_type:
+          selectedActionRequired?.label === "No"
+            ? []
+            : selectedAssessmentTypes?.map((item) => {
+                return {
+                  key: item.label,
+                  value: item.value,
+                };
+              }),
       };
 
       dispatch(upsertAssessment(id, updatedAssessmentData));
@@ -277,7 +280,7 @@ export const HWCRComplaintAssessment: FC = () => {
       hasErrors = true;
     }
 
-    if (!selectedAssessmentTypes || selectedAssessmentTypes?.length <= 0) {
+    if (selectedActionRequired?.value === "Yes" && (!selectedAssessmentTypes || selectedAssessmentTypes?.length <= 0)) {
       setAssessmentRequiredErrorMessage("One or more assessment is required");
       hasErrors = true;
     }
@@ -290,46 +293,16 @@ export const HWCRComplaintAssessment: FC = () => {
     return hasErrors;
   };
 
+  const assessmentDivClass = `comp-details-label-checkbox-div-pair ${
+    selectedActionRequired?.value === "Yes" ? "" : "hidden"
+  }`;
+
   return (
     <div className="comp-outcome-report-block">
       <h6>Complaint assessment</h6>
       <div className="comp-outcome-report-complaint-assessment">
         <div className="comp-details-edit-container">
           <div className="assessment-details-edit-column">
-            <div className="comp-details-edit-container">
-              <div className="comp-details-edit-column">
-                <div
-                  id="assessment-checkbox-div"
-                  className="comp-details-label-checkbox-div-pair"
-                >
-                  <label
-                    htmlFor="checkbox-div"
-                    className="comp-details-inner-content-label checkbox-label-padding"
-                  >
-                    Assessment
-                  </label>
-                  {editable ? (
-                    <ValidationCheckboxGroup
-                      errMsg={assessmentRequiredErrorMessage}
-                      options={assessmentTypeList}
-                      onCheckboxChange={handleAssessmentTypesChange}
-                      checkedValues={selectedAssessmentTypes}
-                    ></ValidationCheckboxGroup>
-                  ) : (
-                    <div>
-                      {selectedAssessmentTypes.map((assesmentValue) => (
-                        <div
-                          className="checkbox-label-padding"
-                          key={assesmentValue.label}
-                        >
-                          {assesmentValue.label}
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              </div>
-            </div>
             <div className="comp-details-edit-container">
               <div className="comp-details-edit-column">
                 <div
@@ -379,6 +352,41 @@ export const HWCRComplaintAssessment: FC = () => {
                     />
                   ) : (
                     <span className={justificationEditClass}>{selectedJustification?.label || ""}</span>
+                  )}
+                </div>
+              </div>
+            </div>
+            <div className="comp-details-edit-container">
+              <div className="comp-details-edit-column">
+                {/* This is block that we will hide/show */}
+                <div
+                  id="assessment-checkbox-div"
+                  className={assessmentDivClass}
+                >
+                  <label
+                    htmlFor="checkbox-div"
+                    className="comp-details-inner-content-label checkbox-label-padding"
+                  >
+                    Assessment
+                  </label>
+                  {editable ? (
+                    <ValidationCheckboxGroup
+                      errMsg={assessmentRequiredErrorMessage}
+                      options={assessmentTypeList}
+                      onCheckboxChange={handleAssessmentTypesChange}
+                      checkedValues={selectedAssessmentTypes}
+                    ></ValidationCheckboxGroup>
+                  ) : (
+                    <div>
+                      {selectedAssessmentTypes?.map((assesmentValue) => (
+                        <div
+                          className="checkbox-label-padding"
+                          key={assesmentValue.label}
+                        >
+                          {assesmentValue.label}
+                        </div>
+                      ))}
+                    </div>
                   )}
                 </div>
               </div>

--- a/frontend/src/app/constants/option-labels.ts
+++ b/frontend/src/app/constants/option-labels.ts
@@ -1,0 +1,4 @@
+export const OptionLabels = {
+  OPTION_YES: "Yes",
+  OPTION_NO: "No",
+};

--- a/frontend/src/app/store/reducers/case-thunks.ts
+++ b/frontend/src/app/store/reducers/case-thunks.ts
@@ -98,14 +98,16 @@ const addAssessment =
         caseCode: "HWCR",
         assessmentDetails: {
           actionNotRequired: assessment.action_required === "No",
-          actions: assessment.assessment_type.map((item) => {
-            return {
-              date: assessment.date,
-              actor: assessment.officer?.value,
-              activeIndicator: true,
-              actionCode: item.value,
-            };
-          }),
+          actions: assessment.assessment_type
+            ? assessment.assessment_type.map((item) => {
+                return {
+                  date: assessment.date,
+                  actor: assessment.officer?.value,
+                  activeIndicator: true,
+                  actionCode: item.value,
+                };
+              })
+            : [],
           actionJustificationCode: assessment.justification?.value,
         },
       },
@@ -166,14 +168,16 @@ const updateAssessment =
         assessmentDetails: {
           actionNotRequired: assessment.action_required === "No",
           actionJustificationCode: assessment.justification?.value,
-          actions: assessment.assessment_type.map((item) => {
-            return {
-              actor: assessment.officer?.value,
-              date: assessment.date,
-              actionCode: item.value,
-              activeIndicator: true,
-            };
-          }),
+          actions: assessment.assessment_type
+            ? assessment.assessment_type.map((item) => {
+                return {
+                  actor: assessment.officer?.value,
+                  date: assessment.date,
+                  actionCode: item.value,
+                  activeIndicator: true,
+                };
+              })
+            : [],
         },
       },
     } as UpdateAssessmentInput;

--- a/frontend/src/app/store/reducers/case-thunks.ts
+++ b/frontend/src/app/store/reducers/case-thunks.ts
@@ -98,16 +98,14 @@ const addAssessment =
         caseCode: "HWCR",
         assessmentDetails: {
           actionNotRequired: assessment.action_required === "No",
-          actions: assessment.assessment_type
-            ? assessment.assessment_type.map((item) => {
-                return {
-                  date: assessment.date,
-                  actor: assessment.officer?.value,
-                  activeIndicator: true,
-                  actionCode: item.value,
-                };
-              })
-            : [],
+          actions: assessment.assessment_type.map((item) => {
+            return {
+              date: assessment.date,
+              actor: assessment.officer?.value,
+              activeIndicator: true,
+              actionCode: item.value,
+            };
+          }),
           actionJustificationCode: assessment.justification?.value,
         },
       },
@@ -168,16 +166,14 @@ const updateAssessment =
         assessmentDetails: {
           actionNotRequired: assessment.action_required === "No",
           actionJustificationCode: assessment.justification?.value,
-          actions: assessment.assessment_type
-            ? assessment.assessment_type.map((item) => {
-                return {
-                  actor: assessment.officer?.value,
-                  date: assessment.date,
-                  actionCode: item.value,
-                  activeIndicator: true,
-                };
-              })
-            : [],
+          actions: assessment.assessment_type.map((item) => {
+            return {
+              actor: assessment.officer?.value,
+              date: assessment.date,
+              actionCode: item.value,
+              activeIndicator: true,
+            };
+          }),
         },
       },
     } as UpdateAssessmentInput;
@@ -676,7 +672,7 @@ export const deleteEquipment =
       id: id,
       updateUserId: profile.idir_username,
     };
-    
+
     const parameters = generateApiParameters(`${config.API_BASE_URL}/v1/case/equipment`, deleteEquipmentInput);
     await deleteMethod<boolean>(dispatch, parameters).then(async (res) => {
       if (res) {


### PR DESCRIPTION
# Description

This change is required to address usability issue. The officers want it to be simple to close a HWC when no action is required so that they are not wasting time filling out fields that don’t make sense for certain use cases.

Fixes # (CE-629)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x]  In the complaint assessment the option to select ‘Action required’ appears above other options. Action required, officer and date fields are mandatory. If Action required is selected as no, Justification field is required. If Action required field is selected as yes, at least one checkbox must be selected (is mandatory)


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-420-frontend.apps.silver.devops.gov.bc.ca/api/) available
[Frontend](https://nr-compliance-enforcement-420-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)