### PR TITLE
feat: CE-720 Remove status select from create, make it read only on edit

### DIFF
--- a/frontend/cypress/e2e/allegation-details-edit.cy.ts
+++ b/frontend/cypress/e2e/allegation-details-edit.cy.ts
@@ -157,8 +157,6 @@ describe("Complaint Edit Page spec - Edit Allegation View", () => {
 
     cy.selectItemById("violation-observed-select-id", editCallDetails.violationObservedString);
 
-    cy.selectItemById("status-select-id", editCallDetails.status);
-
     cy.get("#officer-assigned-select-id").scrollIntoView();
     cy.selectItemById("officer-assigned-select-id", editCallDetails.assigned);
 
@@ -275,8 +273,6 @@ describe("Complaint Edit Page spec - Edit Allegation View", () => {
 
     cy.selectItemById("violation-observed-select-id", originalCallDetails.violationObservedString);
 
-    cy.selectItemById("status-select-id", originalCallDetails.status);
-
     cy.selectItemById("officer-assigned-select-id", originalCallDetails.assigned);
 
     cy.selectItemById("violation-type-select-id", originalCallDetails.violationType);
@@ -369,7 +365,6 @@ describe("Complaint Edit Page spec - Edit Allegation View", () => {
     cy.get("#status-pair-id label").should(($label) => {
       expect($label).to.contain.text("Status");
     });
-    cy.get("#status-pair-id .comp-details-input").should("exist");
 
     // Created By
     cy.get("#created-by-pair-id label").should(($label) => {

--- a/frontend/cypress/e2e/hwcr-details-edit.cy.ts
+++ b/frontend/cypress/e2e/hwcr-details-edit.cy.ts
@@ -157,8 +157,6 @@ describe("Complaint Edit Page spec - Edit View", () => {
 
     cy.selectItemById("species-select-id", editCallDetails.species);
 
-    cy.selectItemById("status-select-id", editCallDetails.status);
-
     cy.get("#officer-assigned-select-id").scrollIntoView();
     cy.selectItemById("officer-assigned-select-id", editCallDetails.assigned);
 
@@ -251,8 +249,6 @@ describe("Complaint Edit Page spec - Edit View", () => {
 
     cy.selectItemById("species-select-id", originalCallDetails.species);
 
-    cy.selectItemById("status-select-id", originalCallDetails.status);
-
     cy.get("#officer-assigned-select-id").scrollIntoView();
     cy.selectItemById("officer-assigned-select-id", originalCallDetails.assigned);
 
@@ -331,7 +327,6 @@ describe("Complaint Edit Page spec - Edit View", () => {
     cy.get("#status-pair-id label").should(($label) => {
       expect($label).to.contain.text("Status");
     });
-    cy.get("#status-pair-id .comp-details-input").should("exist");
 
     // Created By
     cy.get("#created-by-pair-id label").should(($label) => {

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-create.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-create.tsx
@@ -729,21 +729,6 @@ export const CreateComplaint: FC = () => {
                 />
               </div>
             )}
-            <div
-              className="comp-details-label-input-pair"
-              id="office-pair-id"
-            >
-              <label>Status</label>
-              <div className="comp-details-edit-input">
-                <input
-                  type="text"
-                  id="status-readonly-id"
-                  className="comp-form-control"
-                  disabled
-                  defaultValue="Open"
-                />
-              </div>
-            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
@@ -1,6 +1,6 @@
 import { FC, useEffect, useState } from "react";
 import { useAppDispatch, useAppSelector } from "../../../../hooks/hooks";
-import { bcBoundaries, formatDate, formatTime, getSelectedOfficer } from "../../../../common/methods";
+import { applyStatusClass, bcBoundaries, formatDate, formatTime, getSelectedOfficer } from "../../../../common/methods";
 import { Coordinates } from "../../../../types/app/coordinate-type";
 import {
   setComplaint,
@@ -17,7 +17,6 @@ import { ComplaintDetails } from "../../../../types/complaints/details/complaint
 import DatePicker from "react-datepicker";
 import Select from "react-select";
 import {
-  selectComplaintStatusCodeDropdown,
   selectSpeciesCodeDropdown,
   selectViolationCodeDropdown,
   selectHwcrNatureOfComplaintCodeDropdown,
@@ -102,7 +101,7 @@ export const ComplaintDetailsEdit: FC = () => {
     createdBy,
     lastUpdated,
     personGuid,
-    statusCode,
+    status,
     natureOfComplaintCode,
     speciesCode,
     violationTypeCode,
@@ -112,7 +111,6 @@ export const ComplaintDetailsEdit: FC = () => {
     useAppSelector(selectComplaintCallerInformation);
 
   // Get the code table lists to populate the Selects
-  const complaintStatusCodes = useSelector(selectComplaintStatusCodeDropdown) as Option[];
   const speciesCodes = useSelector(selectSpeciesCodeDropdown) as Option[];
   const hwcrNatureOfComplaintCodes = useSelector(selectHwcrNatureOfComplaintCodeDropdown) as Option[];
 
@@ -153,7 +151,6 @@ export const ComplaintDetailsEdit: FC = () => {
   const [errorNotificationClass, setErrorNotificationClass] = useState("comp-complaint-error display-none");
   const [natureOfComplaintError, setNatureOfComplaintError] = useState<string>("");
   const [speciesError, setSpeciesError] = useState<string>("");
-  const [statusError, setStatusError] = useState<string>("");
   const [complaintDescriptionError, setComplaintDescriptionError] = useState<string>("");
   const [attractantsErrorMsg, setAttractantsErrorMsg] = useState<string>("");
   const [communityError, setCommunityError] = useState<string>("");
@@ -246,9 +243,7 @@ export const ComplaintDetailsEdit: FC = () => {
     setErrorNotificationClass("comp-complaint-error display-none");
     setNatureOfComplaintError("");
     setSpeciesError("");
-    setStatusError("");
     setComplaintDescriptionError("");
-
     setAttractantsErrorMsg("");
     setCommunityError("");
     setGeoPointXMsg("");
@@ -291,7 +286,6 @@ export const ComplaintDetailsEdit: FC = () => {
     if (
       natureOfComplaintError === "" &&
       speciesError === "" &&
-      statusError === "" &&
       complaintDescriptionError === "" &&
       attractantsErrorMsg === "" &&
       communityError === "" &&
@@ -313,7 +307,6 @@ export const ComplaintDetailsEdit: FC = () => {
   ];
 
   // Used to set selected values in the dropdowns
-  const selectedStatus = complaintStatusCodes.find((option) => option.value === statusCode);
   const selectedSpecies = speciesCodes.find((option) => option.value === speciesCode);
   const selectedNatureOfComplaint = hwcrNatureOfComplaintCodes.find((option) => option.value === natureOfComplaintCode);
   const selectedAreaCode = areaCodes.find((option) => option.label === area);
@@ -384,20 +377,6 @@ export const ComplaintDetailsEdit: FC = () => {
         setSpeciesError("");
 
         let updatedComplaint = { ...complaintUpdate, species: value } as WildlifeComplaintDto;
-        applyComplaintUpdate(updatedComplaint);
-      }
-    }
-  };
-
-  const handleStatusChange = (selected: Option | null) => {
-    if (selected) {
-      const { value } = selected;
-      if (!value) {
-        setStatusError("Required");
-      } else {
-        setStatusError("");
-
-        let updatedComplaint = { ...complaintUpdate, status: value } as WildlifeComplaintDto;
         applyComplaintUpdate(updatedComplaint);
       }
     }
@@ -805,19 +784,18 @@ export const ComplaintDetailsEdit: FC = () => {
                   className="comp-details-label-input-pair"
                   id="status-pair-id"
                 >
-                  <label id="status-label-id">
-                    Status<span className="required-ind">*</span>
+                  <label
+                    htmlFor="comp-details-status-text-id"
+                    id="status-label-id"
+                  >
+                    Status
                   </label>
-                  <ValidationSelect
-                    className="comp-details-input"
-                    options={complaintStatusCodes}
-                    defaultValue={selectedStatus}
-                    placeholder="Select"
-                    id="status-select-id"
-                    classNamePrefix="comp-select"
-                    onChange={(e) => handleStatusChange(e)}
-                    errMsg={statusError}
-                  />
+                  <div
+                    id="comp-details-status-text-id"
+                    className={`badge ${applyStatusClass(status)}`}
+                  >
+                    {status}
+                  </div>
                 </div>
                 <div
                   className="comp-details-label-input-pair"

--- a/frontend/src/app/types/complaints/details/complaint-header.ts
+++ b/frontend/src/app/types/complaints/details/complaint-header.ts
@@ -7,7 +7,7 @@ export interface ComplaintHeader {
   violationType?: string;
   violationTypeCode?: string;
   species?: string;
-  statusCode?: string;
+  statusCode: string;
   natureOfComplaintCode?: string;
   speciesCode?: string;
   zone?: string;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Please provide a summary of the change and the issue fixed. Please include relevant context. List dependency changes.

Fixes # CE-720

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Verify Status is not on Create Page
- [x] Verify Status is read only on Edit Page for HWCR
- [x] Verify Status is read only on Edit Page for ERS


## Checklist

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-435-frontend.apps.silver.devops.gov.bc.ca/api/) available
[Frontend](https://nr-compliance-enforcement-435-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)