### PR TITLE
feat: Add pg_cron and schedule reset sequence job

### DIFF
--- a/backend/db/migrations/V0.20.1__CE-157-sequence-reset-cron.sql
+++ b/backend/db/migrations/V0.20.1__CE-157-sequence-reset-cron.sql
@@ -1,0 +1,6 @@
+--Reset Sequence to 900000
+alter sequence complaint_sequence restart with 900000;
+
+CREATE EXTENSION IF NOT EXISTS "pg_cron";
+
+SELECT cron.schedule('restart-complaint-seq', '0 0 1 1 *', 'alter sequence complaint_sequence restart with 900000;');

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -5,6 +5,10 @@ FROM postgis/postgis:15-master@sha256:11d424c70a9bfbec79fcfcd6fdacfefa9895c790c4
 RUN sed -i '/EXISTS postgis_tiger_geocoder;*/a CREATE EXTENSION IF NOT EXISTS pgcrypto;' \
         /docker-entrypoint-initdb.d/10_postgis.sh
 
+RUN apt-get update && apt-get install -y curl
+
+RUN apt-get -y install postgresql-15-cron
+
 # Health check - recommended for local dev
 HEALTHCHECK --interval=15s --timeout=5s --retries=3 CMD [ "pg_isready" ]
 

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -5,9 +5,9 @@ FROM postgis/postgis:15-master@sha256:11d424c70a9bfbec79fcfcd6fdacfefa9895c790c4
 RUN sed -i '/EXISTS postgis_tiger_geocoder;*/a CREATE EXTENSION IF NOT EXISTS pgcrypto;' \
         /docker-entrypoint-initdb.d/10_postgis.sh
 
-RUN apt-get update && apt-get install -y curl
+RUN apt-get --no-install-recommends update && apt-get --no-install-recommends install -y curl && apt-get clean
 
-RUN apt-get -y install postgresql-15-cron
+RUN apt-get --no-install-recommends -y install postgresql-15-cron && apt-get clean
 
 # Health check - recommended for local dev
 HEALTHCHECK --interval=15s --timeout=5s --retries=3 CMD [ "pg_isready" ]

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -9,6 +9,9 @@ RUN apt-get --no-install-recommends update && apt-get --no-install-recommends in
 
 RUN apt-get --no-install-recommends -y install postgresql-15-cron && apt-get clean
 
+RUN echo "shared_preload_libraries = 'pg_cron'" >> /var/lib/postgresql/data/postgresql.conf && \
+        echo "cron.database_name = 'nr-compliance-enforcement'" >> /var/lib/postgresql/data/postgresql.conf
+
 # Health check - recommended for local dev
 HEALTHCHECK --interval=15s --timeout=5s --retries=3 CMD [ "pg_isready" ]
 

--- a/database/postgis/Dockerfile
+++ b/database/postgis/Dockerfile
@@ -5,6 +5,13 @@ FROM postgis/postgis:15-master@sha256:11d424c70a9bfbec79fcfcd6fdacfefa9895c790c4
 RUN sed -i '/EXISTS postgis_tiger_geocoder;*/a CREATE EXTENSION IF NOT EXISTS pgcrypto;' \ 
         /docker-entrypoint-initdb.d/10_postgis.sh 
 
+RUN apt-get --no-install-recommends update && apt-get --no-install-recommends install -y curl && apt-get clean
+
+RUN apt-get --no-install-recommends -y install postgresql-15-cron && apt-get clean
+
+RUN echo "shared_preload_libraries = 'pg_cron'" >> /var/lib/postgresql/data/postgresql.conf && \
+        echo "cron.database_name = 'nr-compliance-enforcement'" >> /var/lib/postgresql/data/postgresql.conf
+
 # Health check - recommended for local dev 
 HEALTHCHECK --interval=15s --timeout=5s --retries=3 CMD [ "pg_isready" ] 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,12 @@ services:
   database:
     build:
       context: database
+    command:
+      - "postgres"
+      - "-c"
+      - "shared_preload_libraries=pg_cron"
+      - "-c"
+      - "cron.database_name=postgres"
     container_name: database
     environment:
       POSTGRES_USER: postgres


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Please provide a summary of the change and the issue fixed. Please include relevant context. List dependency changes.

Fixes # C#-157

Includes a postgres extension pg_cron and a scheduled job to reset the complaint sequence to 900000 at the start of every year.

Also includes a one off reset of the complaint sequence to 900000 for pilot to prevent collisions.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Created 3 complaints, verified that they were 9000001, ...2, ...3
- [ ] Deleted the complaints and update the cron job schedule to run sooner than January 1, verified next complaint created was 900000 as expected.


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-436-frontend.apps.silver.devops.gov.bc.ca/api/) available
[Frontend](https://nr-compliance-enforcement-436-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)