### PR TITLE
Remove data truncation from Call Details field

### DIFF
--- a/backend/db/migrations/R__0.14.0__CE-101.sql
+++ b/backend/db/migrations/R__0.14.0__CE-101.sql
@@ -221,14 +221,6 @@ AS $function$
     _report_type := complaint_data ->> 'report_type';
 
    -- Extract and prepare data for 'complaint' table
-   _detail_text := left( complaint_data ->> 'cos_call_details', 3980 )
-    ||
-    CASE
-   	  WHEN length( complaint_data ->> 'cos_call_details' ) > 3980 THEN
-      '… DATA TRUNCATED'
-    ELSE
-      ''
-    END;
     _caller_name := left( complaint_data ->> 'cos_caller_name', 100 )
     ||
     CASE

--- a/backend/db/migrations/R__0.14.0__CE-101.sql
+++ b/backend/db/migrations/R__0.14.0__CE-101.sql
@@ -246,7 +246,7 @@ AS $function$
       ''
     END;
 
-    _detail_text := complaint_data ->> 'cos_call_details'
+    _detail_text := complaint_data ->> 'cos_call_details';
 	
     -- phone numbers must be formatted as +1##########.  
     -- If the numbers from webeoc contain non-numeric characters, strip those and 

--- a/backend/db/migrations/R__0.14.0__CE-101.sql
+++ b/backend/db/migrations/R__0.14.0__CE-101.sql
@@ -163,7 +163,7 @@ AS $function$
     -- Variable to hold the JSONB data from staging_complaint.  Used to create a new complaint
     -- Variables for 'complaint' table
     _report_type            VARCHAR(120);
-    _detail_text            VARCHAR(4000);
+    _detail_text            TEXT;
     _caller_name            VARCHAR(120);
     _caller_address         VARCHAR(120);
     _caller_email           VARCHAR(120);

--- a/backend/db/migrations/R__0.14.0__CE-101.sql
+++ b/backend/db/migrations/R__0.14.0__CE-101.sql
@@ -245,6 +245,8 @@ AS $function$
     ELSE
       ''
     END;
+
+    _detail_text := complaint_data ->> 'cos_call_details'
 	
     -- phone numbers must be formatted as +1##########.  
     -- If the numbers from webeoc contain non-numeric characters, strip those and 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Please provide a summary of the change and the issue fixed. Please include relevant context. List dependency changes.

Fixes # CE-744

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Create complaint in webEOC with call details > 4000 characters and verify all data stored
- [ ] Verify that truncation still works on other fields (name, address, email)


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-444-frontend.apps.silver.devops.gov.bc.ca/api/) available
[Frontend](https://nr-compliance-enforcement-444-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)