### PR TITLE
bug: CE-766-Status-Modal-for-Pending-Review-complaint-briefly-displays-dropdown-before-displaying-validation-message

### DIFF
--- a/frontend/src/app/components/containers/complaints/list-items/complaint-action-items.tsx
+++ b/frontend/src/app/components/containers/complaints/list-items/complaint-action-items.tsx
@@ -42,9 +42,9 @@ export const ComplaintActionItems: FC<Props> = ({
     );
   };
 
-  const openStatusChangeModal = () => {
+  const openStatusChangeModal = async () => {
     document.body.click();
-    dispatch(getAssessment(complaint_identifier));
+    await dispatch(getAssessment(complaint_identifier));
     dispatch(
       openModal({
         modalSize: "md",

--- a/frontend/src/app/store/reducers/case-thunks.ts
+++ b/frontend/src/app/store/reducers/case-thunks.ts
@@ -69,7 +69,7 @@ export const getAssessment =
       officers: { officers },
     } = getState();
     const parameters = generateApiParameters(`${config.API_BASE_URL}/v1/case/${complaintIdentifier}`);
-    await get<CaseFileDto>(dispatch, parameters).then(async (res) => {
+    return await get<CaseFileDto>(dispatch, parameters).then(async (res) => {
       const updatedAssessmentData = await parseAssessmentResponse(res, officers);
       dispatch(setCaseId(res.caseIdentifier));
       dispatch(setAssessment({ assessment: updatedAssessmentData }));


### PR DESCRIPTION
# Description

This PR is to fix an issue when Status Modal for Pending Review complaint briefly displays dropdown before displaying validation message

Fixes # (CE-766)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Filter the list view by pending review. Click on the update status button for a complaint in pending review. Status dropdown should be displayed as disabled. Validation message should appear.  


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes



---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-450-frontend.apps.silver.devops.gov.bc.ca/api/) available
[Frontend](https://nr-compliance-enforcement-450-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)