### PR TITLE
fix: CE-800 Do not default officer/date on outcome

### DIFF
--- a/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/create-outcome.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/create-outcome.tsx
@@ -48,7 +48,7 @@ const defaultOutcome: AnimalOutcomeV2 = {
   drugs: [],
   outcome: "",
   officer: "",
-  date: new Date(),
+  date: undefined,
   order: 0,
 };
 
@@ -79,7 +79,7 @@ export const CreateAnimalOutcome: FC<props> = ({ index, assignedOfficer: officer
 
   //-- new input data
   // eslint-disable-line no-console, max-len
-  const [data, applyData] = useState<AnimalOutcomeV2>({ ...defaultOutcome, species, officer });
+  const [data, applyData] = useState<AnimalOutcomeV2>({ ...defaultOutcome, species });
 
   //-- refs
   // eslint-disable-next-line @typescript-eslint/no-array-constructor
@@ -596,7 +596,7 @@ export const CreateAnimalOutcome: FC<props> = ({ index, assignedOfficer: officer
                     onChange={(input: Date) => {
                       handleOutcomeDateChange(input);
                     }}
-                    selectedDate={!data?.date ? new Date() : data.date}
+                    selectedDate={data?.date}
                     classNamePrefix="comp-details-edit-calendar-input"
                     className={"animal-outcome-details-input"}
                     placeholder={"Select"}

--- a/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/edit-outcome.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/edit-outcome.tsx
@@ -58,10 +58,7 @@ export const EditOutcome: FC<props> = ({ id, index, outcome, assignedOfficer: of
   const [showModal, setShowModal] = useState(false);
 
   //-- new input data
-  const [data, applyData] = useState<AnimalOutcomeV2>({
-    ...outcome,
-    officer: !outcome.officer ? officer : outcome.officer,
-  });
+  const [data, applyData] = useState<AnimalOutcomeV2>({ ...outcome });
 
   //-- refs
   // eslint-disable-next-line @typescript-eslint/no-array-constructor
@@ -326,7 +323,6 @@ export const EditOutcome: FC<props> = ({ id, index, outcome, assignedOfficer: of
     if (authorizationRef.current && !authorizationRef.current.isValid()) {
       _isValid = false;
     }
-
     return _isValid;
   };
 
@@ -355,8 +351,8 @@ export const EditOutcome: FC<props> = ({ id, index, outcome, assignedOfficer: of
   const handleUpdate = () => {
     if (isValid()) {
       update(data);
+      toggle("");
     }
-    toggle("");
   };
 
   const handleCancel = () => {
@@ -595,7 +591,7 @@ export const EditOutcome: FC<props> = ({ id, index, outcome, assignedOfficer: of
                     onChange={(input: Date) => {
                       handleOutcomeDateChange(input);
                     }}
-                    selectedDate={!data?.date ? new Date() : data.date}
+                    selectedDate={data?.date}
                     classNamePrefix="comp-details-edit-calendar-input"
                     className={"animal-outcome-details-input"}
                     placeholder={"Select"}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Please provide a summary of the change and the issue fixed. Please include relevant context. List dependency changes.

Fixes CE-800

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Assign Complain, Add Animal - Outcome Officer/Date not populated
- [ ] Edit Added Animal - Outcome Officer/Date not populated

Note: This PR also fixes an unreported bug that after an outcome edit, validation messages aren't visible.


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-472-frontend.apps.silver.devops.gov.bc.ca/api/) available
[Frontend](https://nr-compliance-enforcement-472-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)