### PR TITLE
feat:CE-835-Remove-rule-for-closing-a-complaint

### DIFF
--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-complaint-assessment.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-complaint-assessment.tsx
@@ -251,6 +251,7 @@ export const HWCRComplaintAssessment: FC = () => {
 
       dispatch(upsertAssessment(id, updatedAssessmentData));
       setEditable(false);
+      dispatch(setIsInEdit({ showSectionErrors: false }));
     } else {
       handleFormErrors();
     }

--- a/frontend/src/app/components/modal/instances/change-status-modal.tsx
+++ b/frontend/src/app/components/modal/instances/change-status-modal.tsx
@@ -103,7 +103,9 @@ export const ChangeStatusModal: FC<ChangeStatusModalProps> = ({ close, submit, c
     if (
       noEditSections &&
       assessmentCriteria &&
-      preventionCriteria &&
+      //The code line below commented becasue according to CE-835
+      //users can close a complaint when Action required is Yes and the Prevention and education section is not completed.
+      //preventionCriteria &&
       equipmentCriteria &&
       animalCriteria &&
       fileReviewCriteria


### PR DESCRIPTION
# Description

This PR is allow users to close a complaint when Action required is Yes and the Prevention and education section is not completed

Fixes # (CE-835)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Open a complaint, navigate to Assessment section of outcome report. Select Action required: "Yes", check at least one action, select an officer and click Save. Then click Update Status button, select "Closed" status, and click Update. Verify that the complaint status is updated without any warnings. 

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-485-frontend.apps.silver.devops.gov.bc.ca/api/) available
[Frontend](https://nr-compliance-enforcement-485-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)