### PR TITLE
fix: bug/CE-848: Complaints Created in NatComplaints without an Incident Date/Time can't be exported

### DIFF
--- a/backend/src/middleware/maps/automapper-entity-to-dto-maps.ts
+++ b/backend/src/middleware/maps/automapper-entity-to-dto-maps.ts
@@ -891,7 +891,12 @@ export const mapWildlifeReport = (mapper: Mapper, tz: string = "America/Vancouve
     ),
     forMember(
       (destination) => destination.reportedOn,
-      mapFrom((source) => source.complaint_identifier.incident_reported_utc_timestmp),
+      mapFrom((source) => {
+        const {
+          complaint_identifier: { incident_reported_utc_timestmp: reported },
+        } = source;
+        return reported ? reported : "";
+      }),
     ),
     forMember(
       (destination) => destination.updatedOn,

--- a/backend/src/middleware/maps/automapper-entity-to-dto-maps.ts
+++ b/backend/src/middleware/maps/automapper-entity-to-dto-maps.ts
@@ -895,7 +895,7 @@ export const mapWildlifeReport = (mapper: Mapper, tz: string = "America/Vancouve
         const {
           complaint_identifier: { incident_reported_utc_timestmp: reported },
         } = source;
-        return reported ? reported : "";
+        return reported || "";
       }),
     ),
     forMember(
@@ -1167,7 +1167,12 @@ export const mapAllegationReport = (mapper: Mapper, tz: string = "America/Vancou
     ),
     forMember(
       (destination) => destination.reportedOn,
-      mapFrom((source) => source.complaint_identifier.incident_reported_utc_timestmp),
+      mapFrom((source) => {
+        const {
+          complaint_identifier: { incident_reported_utc_timestmp: reported },
+        } = source;
+        return reported || "";
+      }),
     ),
     forMember(
       (destination) => destination.updatedOn,

--- a/backend/src/v1/complaint/complaint.service.ts
+++ b/backend/src/v1/complaint/complaint.service.ts
@@ -1439,7 +1439,10 @@ export class ComplaintService {
 
       data.reportedOn = _applyTimezone(data.reportedOn, tz, "datetime");
       data.updatedOn = _applyTimezone(data.updatedOn, tz, "datetime");
-      if (data?.incidentDateTime) {
+
+      //-- incidentDateTime may not be set, if there's no date
+      //-- don't try and apply the incident date
+      if (data.incidentDateTime) {
         data.incidentDateTime = _applyTimezone(data.incidentDateTime, tz, "datetime");
       }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
Update to the export complaint to prevent the export process from failing and returning an empty complaint 

Fixes # CE-848

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manually tested  (local and dev)


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-493-frontend.apps.silver.devops.gov.bc.ca/api/) available
[Frontend](https://nr-compliance-enforcement-493-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)