### PR TITLE
fix: CE-746 - complaint list view community sorting incorrect

### DIFF
--- a/backend/src/v1/complaint/complaint.service.ts
+++ b/backend/src/v1/complaint/complaint.service.ts
@@ -132,6 +132,8 @@ export class ComplaintService {
       case "violation_code":
       case "in_progress_ind":
         return "allegation";
+      case "area_name":
+        return "cos_organization";
       case "complaint_identifier":
       default:
         return "complaint";

--- a/frontend/src/app/components/containers/complaints/complaint-list.tsx
+++ b/frontend/src/app/components/containers/complaints/complaint-list.tsx
@@ -98,6 +98,7 @@ export const ComplaintList: FC<Props> = ({ type, searchQuery }) => {
 
       dispatch(getComplaints(type, payload));
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filters, sortKey, sortDirection, page, pageSize]);
 
   useEffect(() => {
@@ -107,6 +108,7 @@ export const ComplaintList: FC<Props> = ({ type, searchQuery }) => {
       payload = { ...payload, query: searchQuery };
       dispatch(getComplaints(type, payload));
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchQuery]);
 
   useEffect(() => {
@@ -120,6 +122,7 @@ export const ComplaintList: FC<Props> = ({ type, searchQuery }) => {
     return () => {
       dispatch(setComplaints({ type: { type }, data: [] }));
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleSort = (sortInput: string) => {

--- a/frontend/src/app/components/containers/complaints/headers/wildlife-complaint-list-header.tsx
+++ b/frontend/src/app/components/containers/complaints/headers/wildlife-complaint-list-header.tsx
@@ -46,7 +46,7 @@ export const WildlifeComplaintListHeader: FC<Props> = ({ handleSort, sortKey, so
         <SortableHeader
           title="Community"
           sortFnc={handleSort}
-          sortKey="geo_organization_unit_code"
+          sortKey="area_name"
           currentSort={sortKey}
           sortDirection={sortDirection}
         />


### PR DESCRIPTION
updated the search query to correctly use the area_name opposed to the area_code when sorting by community

<!-- Provide a general summary of your changes in the Title above -->

# Description

When sorting by community in the list view the search was incorrectly using the wrong column to sort on. Code updated to use the community name rather than the community code.

Fixes # CE-746

# How Has This Been Tested?

Manually tested to confirm correct sort order. To confirm: 
- load list view, HWCR or ERS
- sort by community
- skip to the communities starting with C
- verify correct sorting, communities should not go from Cluculz Lake back to Campbell River 

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-499-frontend.apps.silver.devops.gov.bc.ca/api/) available
[Frontend](https://nr-compliance-enforcement-499-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-499-frontend.apps.silver.devops.gov.bc.ca/api/) available
[Frontend](https://nr-compliance-enforcement-499-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)