### PR TITLE
fix: CE-752 - Date filter default months

### DIFF
--- a/frontend/src/app/common/validation-date-picker.tsx
+++ b/frontend/src/app/common/validation-date-picker.tsx
@@ -46,6 +46,7 @@ export const ValidationDatePicker: FC<ValidationDatePickerProps> = ({
           maxDate={maxDate}
           minDate={minDate}
           autoComplete="false"
+          monthsShown={2}
         />
       </div>
       <div className={calculatedClass}>{errMsg}</div>

--- a/frontend/src/app/common/validation-date-picker.tsx
+++ b/frontend/src/app/common/validation-date-picker.tsx
@@ -47,6 +47,7 @@ export const ValidationDatePicker: FC<ValidationDatePickerProps> = ({
           minDate={minDate}
           autoComplete="false"
           monthsShown={2}
+          showPreviousMonths
         />
       </div>
       <div className={calculatedClass}>{errMsg}</div>

--- a/frontend/src/app/components/containers/complaints/complaint-filter.tsx
+++ b/frontend/src/app/components/containers/complaints/complaint-filter.tsx
@@ -216,6 +216,7 @@ export const ComplaintFilter: FC<Props> = ({ type }) => {
               selectsRange={true}
               isClearable={true}
               wrapperClassName="comp-filter-calendar-input"
+              showPreviousMonths
             />
           </div>
         </div>

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-create.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-create.tsx
@@ -786,6 +786,7 @@ export const CreateComplaint: FC = () => {
                 timeFormat="HH:mm"
                 wrapperClassName="comp-details-edit-calendar-input"
                 maxDate={currentDate}
+                monthsShown={2}
               />
             </div>
           </div>

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-create.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-create.tsx
@@ -787,6 +787,7 @@ export const CreateComplaint: FC = () => {
                 wrapperClassName="comp-details-edit-calendar-input"
                 maxDate={currentDate}
                 monthsShown={2}
+                showPreviousMonths
               />
             </div>
           </div>

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
@@ -872,6 +872,7 @@ export const ComplaintDetailsEdit: FC = () => {
                     timeFormat="HH:mm"
                     wrapperClassName="comp-details-edit-calendar-input"
                     maxDate={maxDate}
+                    monthsShown={2}
                   />
                 </div>
               </div>

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
@@ -873,6 +873,7 @@ export const ComplaintDetailsEdit: FC = () => {
                     wrapperClassName="comp-details-edit-calendar-input"
                     maxDate={maxDate}
                     monthsShown={2}
+                    showPreviousMonths
                   />
                 </div>
               </div>

--- a/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/drug-used.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/drug-used.tsx
@@ -75,12 +75,9 @@ export const DrugUsed = forwardRef<refProps, props>((props, ref) => {
   //-- use to validate the drug-used component inputs
   const isValid = (): boolean => {
     let result = true;
-    debugger;
+
     //-- validate that amount used is a positive number
     if (amountUsed && !isPositiveNum(amountUsed)) {
-      setAmountUsedError("Must be a positive number");
-      result = false;
-    } else if (Number.parseFloat(amountUsed) === 0) {
       setAmountUsedError("Must be a positive number");
       result = false;
     } else if (!amountUsed) {

--- a/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/drug-used.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/drug-used.tsx
@@ -75,12 +75,12 @@ export const DrugUsed = forwardRef<refProps, props>((props, ref) => {
   //-- use to validate the drug-used component inputs
   const isValid = (): boolean => {
     let result = true;
-    debugger;
+
     //-- validate that amount used is a positive number
     if (amountUsed && !isPositiveNum(amountUsed)) {
       setAmountUsedError("Must be a positive number");
       result = false;
-    } else if (Number.parseFloat(amountUsed) === 0) {
+    } else if (amountUsed && Number.parseFloat(amountUsed) === 0) {
       setAmountUsedError("Must be a positive number");
       result = false;
     } else if (!amountUsed) {
@@ -89,6 +89,9 @@ export const DrugUsed = forwardRef<refProps, props>((props, ref) => {
     }
 
     if (amountDiscarded && !isPositiveNum(amountDiscarded)) {
+      setAmountDiscardedError("Must be a positive number");
+      result = false;
+    } else if (amountDiscarded && Number.parseFloat(amountDiscarded) === 0) {
       setAmountDiscardedError("Must be a positive number");
       result = false;
     }

--- a/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/drug-used.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/drug-used.tsx
@@ -75,9 +75,12 @@ export const DrugUsed = forwardRef<refProps, props>((props, ref) => {
   //-- use to validate the drug-used component inputs
   const isValid = (): boolean => {
     let result = true;
-
+    debugger;
     //-- validate that amount used is a positive number
     if (amountUsed && !isPositiveNum(amountUsed)) {
+      setAmountUsedError("Must be a positive number");
+      result = false;
+    } else if (Number.parseFloat(amountUsed) === 0) {
       setAmountUsedError("Must be a positive number");
       result = false;
     } else if (!amountUsed) {

--- a/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/drug-used.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/drug-used.tsx
@@ -75,12 +75,12 @@ export const DrugUsed = forwardRef<refProps, props>((props, ref) => {
   //-- use to validate the drug-used component inputs
   const isValid = (): boolean => {
     let result = true;
-
+    debugger;
     //-- validate that amount used is a positive number
     if (amountUsed && !isPositiveNum(amountUsed)) {
       setAmountUsedError("Must be a positive number");
       result = false;
-    } else if (amountUsed && Number.parseFloat(amountUsed) === 0) {
+    } else if (Number.parseFloat(amountUsed) === 0) {
       setAmountUsedError("Must be a positive number");
       result = false;
     } else if (!amountUsed) {
@@ -89,9 +89,6 @@ export const DrugUsed = forwardRef<refProps, props>((props, ref) => {
     }
 
     if (amountDiscarded && !isPositiveNum(amountDiscarded)) {
-      setAmountDiscardedError("Must be a positive number");
-      result = false;
-    } else if (amountDiscarded && Number.parseFloat(amountDiscarded) === 0) {
       setAmountDiscardedError("Must be a positive number");
       result = false;
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
The date pickers currently only show a single month, this should instead show two months and restrict the selectable date to the max date of today. The date pickers have been updated to all display the previous and current month when selecting a new date, and restrict all delectable dates to a max date of the current date.

Fixes # CE-752

# How Has This Been Tested?
- Manually testes

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-504-frontend.apps.silver.devops.gov.bc.ca/api/) available
[Frontend](https://nr-compliance-enforcement-504-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-504-frontend.apps.silver.devops.gov.bc.ca/api/) available
[Frontend](https://nr-compliance-enforcement-504-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)