### PR TITLE
fix: bug/CE-729 - updated animal outcome validation

### DIFF
--- a/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/drug-used.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/drug-used.tsx
@@ -80,12 +80,18 @@ export const DrugUsed = forwardRef<refProps, props>((props, ref) => {
     if (amountUsed && !isPositiveNum(amountUsed)) {
       setAmountUsedError("Must be a positive number");
       result = false;
+    } else if (amountUsed && Number.parseFloat(amountUsed) === 0) {
+      setAmountUsedError("Must be a positive number");
+      result = false;
     } else if (!amountUsed) {
       setAmountUsedError(REQUIRED);
       result = false;
     }
 
     if (amountDiscarded && !isPositiveNum(amountDiscarded)) {
+      setAmountDiscardedError("Must be a positive number");
+      result = false;
+    } else if (amountDiscarded && Number.parseFloat(amountDiscarded) === 0) {
       setAmountDiscardedError("Must be a positive number");
       result = false;
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
When editing or creating an animal outcome with a drug, the amount used and amount discarded will allow a user to add an animal outcome with values of 0. This has been updated to prevent this from happening and only allowing users to use positive values.

Fixes # CE-729

# How Has This Been Tested?
- existing tests
- manually tested



---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-506-frontend.apps.silver.devops.gov.bc.ca/api/) available
[Frontend](https://nr-compliance-enforcement-506-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)