### PR TITLE
fix: updated location update labels

### DIFF
--- a/frontend/src/app/components/containers/complaints/webeoc-complaint-updates/webeoc-complaint-update-list.tsx
+++ b/frontend/src/app/components/containers/complaints/webeoc-complaint-updates/webeoc-complaint-update-list.tsx
@@ -111,10 +111,10 @@ export const WebEOCComplaintUpdateList: FC<Props> = ({ complaintIdentifier }) =>
               </div>
               {update.updLocationGeometryPoint?.coordinates && (
                 <div className="coordinates-section">
-                  <div className="complaint-description-label">Longitude:</div>
-                  <div className="complaint-description-text">{update.updLocationGeometryPoint.coordinates[0]}</div>
                   <div className="complaint-description-label">Latitude:</div>
                   <div className="complaint-description-text">{update.updLocationGeometryPoint.coordinates[1]}</div>
+                  <div className="complaint-description-label">Longitude:</div>
+                  <div className="complaint-description-text">{update.updLocationGeometryPoint.coordinates[0]}</div>
                 </div>
               )}
             </div>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
The complaint update banners incorrectly had the latitude and longitude values displayed. This update corrects and swaps the two values and labels

Fixes # CE-870

# How Has This Been Tested?
- manually tested


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-507-frontend.apps.silver.devops.gov.bc.ca/api/) available
[Frontend](https://nr-compliance-enforcement-507-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)