### PR TITLE
bug/CE-872-Equipment-section-coordinates-missing-comma

### DIFF
--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-equipment/equipment-item.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-equipment/equipment-item.tsx
@@ -139,7 +139,7 @@ export const EquipmentItem: FC<EquipmentItemProps> = ({ equipment, isEditDisable
             <div>
               <dt>Latitude/Longitude</dt>
               <dd>
-                {equipment.yCoordinate} {equipment.xCoordinate}
+                {equipment.yCoordinate}, {equipment.xCoordinate}
               </dd>
             </div>
             <div>

--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-equipment/equipment-item.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-equipment/equipment-item.tsx
@@ -139,7 +139,9 @@ export const EquipmentItem: FC<EquipmentItemProps> = ({ equipment, isEditDisable
             <div>
               <dt>Latitude/Longitude</dt>
               <dd>
-                {equipment.yCoordinate}, {equipment.xCoordinate}
+                {equipment.xCoordinate && equipment.yCoordinate
+                  ? `${equipment.yCoordinate}, ${equipment.xCoordinate}`
+                  : ""}
               </dd>
             </div>
             <div>

--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-equipment/equipment-item.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-equipment/equipment-item.tsx
@@ -139,7 +139,7 @@ export const EquipmentItem: FC<EquipmentItemProps> = ({ equipment, isEditDisable
             <div>
               <dt>Latitude/Longitude</dt>
               <dd>
-                {equipment.xCoordinate && equipment.yCoordinate
+                {equipment.yCoordinate && equipment.xCoordinate
                   ? `${equipment.yCoordinate}, ${equipment.xCoordinate}`
                   : ""}
               </dd>


### PR DESCRIPTION
# Description

This PR is to add a missing comma to the Equipment section of HWC Outcome Report in view mode

Fixes # (CE-872)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Fill in the Equipment section and click Save. Check that coordinate values are separated by a comma. 


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes




---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-compliance-enforcement-510-frontend.apps.silver.devops.gov.bc.ca/api/) available
[Frontend](https://nr-compliance-enforcement-510-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge-main.yml)