### PR TITLE
fix: Creates new filter for Creatable Types - filters out GIR.

### DIFF
--- a/frontend/src/app/components/containers/complaints/details/complaint-details-create.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-create.tsx
@@ -19,7 +19,7 @@ import notificationInvalid from "../../../../../assets/images/notification-inval
 import {
   selectAttractantCodeDropdown,
   selectCommunityCodeDropdown,
-  selectComplaintTypeDropdown,
+  selectCreatableComplaintTypeDropdown,
   selectHwcrNatureOfComplaintCodeDropdown,
   selectReportedByDropdown,
   selectSpeciesCodeDropdown,
@@ -61,7 +61,7 @@ export const CreateComplaint: FC = () => {
   const officerList = useAppSelector(selectOfficersByAgency(agency));
   const speciesCodes = useAppSelector(selectSpeciesCodeDropdown) as Option[];
   const hwcrNatureOfComplaintCodes = useAppSelector(selectHwcrNatureOfComplaintCodeDropdown) as Option[];
-  const complaintTypeCodes = useAppSelector(selectComplaintTypeDropdown) as Option[];
+  const complaintTypeCodes = useAppSelector(selectCreatableComplaintTypeDropdown) as Option[];
   const areaCodes = useAppSelector(selectCommunityCodeDropdown);
   const attractantCodes = useAppSelector(selectAttractantCodeDropdown) as Option[];
   const reportedByCodes = useAppSelector(selectReportedByDropdown) as Option[];

--- a/frontend/src/app/store/reducers/code-table.ts
+++ b/frontend/src/app/store/reducers/code-table.ts
@@ -570,6 +570,20 @@ export const selectComplaintTypeDropdown = (state: RootState): Array<Option> => 
   });
   return data;
 };
+export const selectCreatableComplaintTypeDropdown = (state: RootState): Array<Option> => {
+  const {
+    codeTables: { "complaint-type": complaintTypes },
+  } = state;
+
+  // Filter out complaintType is "GIR" since it should not appear as a createable type.
+  const filteredTypes = complaintTypes.filter((complaintType) => complaintType.complaintType !== "GIR");
+
+  const data = filteredTypes.map(({ complaintType, longDescription }) => {
+    const item: Option = { label: longDescription, value: complaintType };
+    return item;
+  });
+  return data;
+};
 
 export const selectAgencyDropdown = (state: RootState): Array<Option> => {
   const {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Creates a new dropdown listing which is limited to those types that are createable which is in turn used to populate the options in the Create page.

Fixes # (issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-561-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-561-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)