### PR TITLE
fix: CE-985 - Fix Inconsistent Label in Animal Outcome Read-only View

### DIFF
--- a/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/drug-item.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/drug-item.tsx
@@ -141,7 +141,7 @@ export const DrugItem: FC<props> = ({
           xs={12}
           md={6}
         >
-          <dt>Officer</dt>
+          <dt>Drug administred by</dt>
           <dd>{assignedOfficer()}</dd>
         </Col>
         <Col

--- a/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/drug-item.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/drug-item.tsx
@@ -141,7 +141,7 @@ export const DrugItem: FC<props> = ({
           xs={12}
           md={6}
         >
-          <dt>Drug administred by</dt>
+          <dt>Drug administered by</dt>
           <dd>{assignedOfficer()}</dd>
         </Col>
         <Col


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Updated/fixed the label in the read-only view of the animal form for 'Drugs administered by' so it's consistent with the edit/form view.

Fixes # (issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manually Verified
- [ ] Test B


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-576-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-576-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)