### PR TITLE
fix: CE-984 - Bullet Separators Show Up With Empty Spaces When No Values Entered for Sex and/or Age

### DIFF
--- a/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/animal-outcome.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/animal-outcome.tsx
@@ -140,8 +140,8 @@ export const AnimalOutcome: FC<props> = ({ index, data, agency, edit, remove }) 
           <h4>Animal {pad(animalNumber.toString(), 2)}</h4>
           <div className="comp-card-header-metadata fw-bold text-muted">
             <span>{animal}</span>
-            {data?.sex === "U" ? <span>Sex unknown</span> : <span>{animalSex}</span>}
-            {data?.age === "UNKN" ? <span>Age unknown</span> : <span>{animalAge}</span>}
+            {data?.sex && <>{data?.sex === "U" ? <span>Sex unknown</span> : <span>{animalSex}</span>}</>}
+            {data?.age && <>{data?.age === "UNKN" ? <span>Age unknown</span> : <span>{animalAge}</span>}</>}
           </div>
         </div>
         <div className="comp-card-header-actions">


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Fixed an issue where the animal title information would show bullet separators when no sex and/or age was defined.

Fixes # (issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manually Verified
- [ ] Test B


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-577-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-577-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)