### PR TITLE
fix: Changes the phone number returned to be only 14 digits max.

### DIFF
--- a/migrations/migrations/R__0.25.0__CE-965.sql
+++ b/migrations/migrations/R__0.25.0__CE-965.sql
@@ -1,0 +1,27 @@
+CREATE OR REPLACE FUNCTION public.format_phone_number(phone_number text)
+ RETURNS text
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+    formatted_phone_number TEXT;
+BEGIN
+    -- Remove all non-digit characters
+    formatted_phone_number := regexp_replace(phone_number, '[^0-9]', '', 'g');
+    IF (formatted_phone_number IS NULL or (length(formatted_phone_number) = 0)) then
+		return null;
+    END IF;
+    -- Check if the first character is '1'
+    IF left(formatted_phone_number, 1) = '1' THEN
+        -- Add '+' in front of the phone number
+        RETURN '+' || left(formatted_phone_number, 14);
+    ELSE
+        -- Add '+1' in front of the phone number
+        RETURN '+1' || formatted_phone_number;
+    END IF;
+END;
+$function$
+;
+UPDATE configuration 
+SET    configuration_value = configuration_value::int + 1
+WHERE  configuration_code = 'CDTABLEVER';
+

--- a/migrations/migrations/R__0.25.0__CE-965.sql
+++ b/migrations/migrations/R__0.25.0__CE-965.sql
@@ -16,7 +16,7 @@ BEGIN
         RETURN '+' || left(formatted_phone_number, 14);
     ELSE
         -- Add '+1' in front of the phone number
-        RETURN '+1' || formatted_phone_number;
+        RETURN '+1' || left(formatted_phone_number,13);
     END IF;
 END;
 $function$

--- a/migrations/migrations/R__0.25.0__CE-965.sql
+++ b/migrations/migrations/R__0.25.0__CE-965.sql
@@ -21,7 +21,3 @@ BEGIN
 END;
 $function$
 ;
-UPDATE configuration 
-SET    configuration_value = configuration_value::int + 1
-WHERE  configuration_code = 'CDTABLEVER';
-


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
As per title - reduces the number of digits returned in the phone number to a + followed by 14 rather than 15 digits. The second execution path where the number doesn't start with a 1 is included and it reduces the number down to a +1 and 13 digits.

Please provide a summary of the change and the issue fixed. Please include relevant context. List dependency changes.

Fixes # (issue)
CE-965
# How Has This Been Tested?
Created a number of records with problematic numbers included and confirmed they appear as expected in the app.

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-585-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-585-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)