### PR TITLE
feat: CE-941 attempt3

### DIFF
--- a/frontend/src/app/components/containers/complaints/complaints.tsx
+++ b/frontend/src/app/components/containers/complaints/complaints.tsx
@@ -9,7 +9,7 @@ import { ComplaintFilterBar } from "./complaint-filter-bar";
 import { ComplaintFilterContext, ComplaintFilterProvider } from "../../../providers/complaint-filter-provider";
 import { resetFilters, ComplaintFilterPayload } from "../../../store/reducers/complaint-filters";
 
-import { selectDefaultZone, selectOfficerAgency } from "../../../store/reducers/app";
+import { selectDefaultZone } from "../../../store/reducers/app";
 import { ComplaintMap } from "./complaint-map";
 import { useNavigate } from "react-router-dom";
 import { ComplaintListTabs } from "./complaint-list-tabs";
@@ -159,7 +159,7 @@ export const ComplaintsWrapper: FC<Props> = ({ defaultComplaintType }) => {
   );
 };
 
-export const getFilters = (currentOfficer: any, defaultZone: any) => {
+const getFilters = (currentOfficer: any, defaultZone: any) => {
   let filters: any = {};
 
   if (UserService.hasRole([Roles.CEEB]) && !UserService.hasRole([Roles.CEEB_COMPLIANCE_COORDINATOR])) {

--- a/frontend/src/app/components/containers/complaints/complaints.tsx
+++ b/frontend/src/app/components/containers/complaints/complaints.tsx
@@ -17,6 +17,7 @@ import COMPLAINT_TYPES from "../../../types/app/complaint-types";
 import { selectCurrentOfficer } from "../../../store/reducers/officer";
 import UserService from "../../../service/user-service";
 import Roles from "../../../types/app/roles";
+import Option from "../../../types/app/option";
 
 type Props = {
   defaultComplaintType: string;
@@ -33,32 +34,23 @@ export const Complaints: FC<Props> = ({ defaultComplaintType }) => {
 
   const defaultZone = useAppSelector(selectDefaultZone);
 
-  const userAgency = useAppSelector(selectOfficerAgency, shallowEqual);
-
   //-- this is used to apply the search to the pager component
   const [search, setSearch] = useState("");
 
   const handleComplaintTabChange = (complaintType: string) => {
     setComplaintType(complaintType);
 
-    //-- apply default filters, if more need to be set they can be added as needed
-    let payload: Array<ComplaintFilterPayload> = [];
-    // for CEEB default filter includes current user
-    if (userAgency === "EPO") {
-      if (currentOfficer) {
-        let {
-          person: { id, firstName, lastName },
-        } = currentOfficer;
-        payload = [{ filter: "officer", value: { value: id, label: `${lastName}, ${firstName}` } }];
-      }
-    } else if (defaultZone) {
-      payload = [{ filter: "zone", value: defaultZone }];
-    }
+    let filters = getFilters(currentOfficer, defaultZone);
 
-    payload = [...payload, { filter: "status", value: { value: "OPEN", label: "Open" } }];
+    const payload: Array<ComplaintFilterPayload> = [
+      ...Object.entries(filters).map(([filter, value]) => ({
+        filter,
+        value: value as Option | Date | null, // Explicitly casting value to the correct type
+      })),
+      { filter: "status", value: { value: "OPEN", label: "Open" } as Option },
+    ];
 
     setSearch("");
-
     filterDispatch(resetFilters(payload));
   };
 
@@ -154,22 +146,7 @@ export const Complaints: FC<Props> = ({ defaultComplaintType }) => {
 export const ComplaintsWrapper: FC<Props> = ({ defaultComplaintType }) => {
   const defaultZone = useAppSelector(selectDefaultZone, shallowEqual);
   const currentOfficer = useAppSelector(selectCurrentOfficer(), shallowEqual);
-
-  let filters: any = {};
-  if (UserService.hasRole([Roles.CEEB]) && !UserService.hasRole([Roles.CEEB_COMPLIANCE_COORDINATOR])) {
-    if (currentOfficer) {
-      let {
-        person: { firstName, lastName, id },
-      } = currentOfficer;
-      const officer = { label: `${lastName}, ${firstName}`, value: id };
-
-      filters = { ...filters, officer };
-    }
-  }
-  if (UserService.hasRole([Roles.CEEB, Roles.CEEB_COMPLIANCE_COORDINATOR])) {
-  } else if (defaultZone) {
-    filters = { ...filters, zone: defaultZone };
-  }
+  const filters = getFilters(currentOfficer, defaultZone);
 
   return (
     <>
@@ -180,4 +157,27 @@ export const ComplaintsWrapper: FC<Props> = ({ defaultComplaintType }) => {
       )}
     </>
   );
+};
+
+export const getFilters = (currentOfficer: any, defaultZone: any) => {
+  let filters: any = {};
+
+  if (UserService.hasRole([Roles.CEEB]) && !UserService.hasRole([Roles.CEEB_COMPLIANCE_COORDINATOR])) {
+    if (currentOfficer) {
+      let {
+        person: { firstName, lastName, id },
+      } = currentOfficer;
+      const officer = { label: `${lastName}, ${firstName}`, value: id };
+
+      filters = { ...filters, officer };
+    }
+  }
+
+  if (UserService.hasRole([Roles.CEEB, Roles.CEEB_COMPLIANCE_COORDINATOR])) {
+    // No additional filters needed, default will apply
+  } else if (defaultZone) {
+    filters = { ...filters, zone: defaultZone };
+  }
+
+  return filters;
 };


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

The default CEEB filters would fail when users switched complaint tabs.  For example, prior to this change, the default filters would work when a user accesses the application; however, as soon as the user switched tabs, the defaults were wrong.

Fixes # (CE-941

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-594-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-594-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)