### PR TITLE
fix: CE-1009-enforcement-tex-on-tab-instead-of-waste-and-pesticides-in-ceeb-officer-view

### DIFF
--- a/frontend/src/app/components/containers/complaints/complaint-list-tabs.tsx
+++ b/frontend/src/app/components/containers/complaints/complaint-list-tabs.tsx
@@ -44,7 +44,7 @@ export const ComplaintListTabs: FC<props> = ({ complaintType, viewType, complain
 
       switch (item) {
         case COMPLAINT_TYPES.ERS:
-          if (UserService.hasRole(Roles.CEEB_COMPLIANCE_COORDINATOR)) {
+          if (UserService.hasRole(Roles.CEEB)) {
             name = "Waste and Pesticides";
           } else {
             name = "Enforcement";


### PR DESCRIPTION
# Description

This PR is to fix an issue when a tab label for "Waste and Pesticides" incorrectly displayed as "Enforcement"

Fixes # (CE-1009)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Log in as CEEB officer. Check that the tabs sections contains a "Waste and Pesticides" tab
- [x] Log in as COS officer. Check that the tabs section contains a "Enforcement" tab


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes



---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-595-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-595-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)