### PR TITLE
feat: CE-202-Complaint-Type-doesnt-automatically-reclassify-as-an-Enforcement-Complaint

### DIFF
--- a/frontend/src/app/components/containers/complaints/complaints.tsx
+++ b/frontend/src/app/components/containers/complaints/complaints.tsx
@@ -1,7 +1,7 @@
-import { FC, useState, useContext, useCallback } from "react";
+import { FC, useState, useContext, useCallback, useEffect } from "react";
 import { shallowEqual } from "react-redux";
 import { Button, Collapse, Offcanvas } from "react-bootstrap";
-import { useAppSelector } from "../../../hooks/hooks";
+import { useAppSelector, useAppDispatch } from "../../../hooks/hooks";
 import { ComplaintFilter } from "./complaint-filter";
 import { ComplaintList } from "./complaint-list";
 
@@ -18,6 +18,7 @@ import { selectCurrentOfficer } from "../../../store/reducers/officer";
 import UserService from "../../../service/user-service";
 import Roles from "../../../types/app/roles";
 import Option from "../../../types/app/option";
+import { setActiveTab } from "../../../store/reducers/app";
 
 type Props = {
   defaultComplaintType: string;
@@ -27,6 +28,7 @@ export const Complaints: FC<Props> = ({ defaultComplaintType }) => {
   const { dispatch: filterDispatch } = useContext(ComplaintFilterContext); //-- make sure to keep this dispatch renamed
   const [complaintType, setComplaintType] = useState(defaultComplaintType);
   const navigate = useNavigate();
+  const dispatch = useAppDispatch();
 
   const [viewType, setViewType] = useState<"map" | "list">("list");
 
@@ -36,6 +38,10 @@ export const Complaints: FC<Props> = ({ defaultComplaintType }) => {
 
   //-- this is used to apply the search to the pager component
   const [search, setSearch] = useState("");
+
+  useEffect(() => {
+    dispatch(setActiveTab(defaultComplaintType));
+  }, [dispatch, defaultComplaintType]);
 
   const handleComplaintTabChange = (complaintType: string) => {
     setComplaintType(complaintType);
@@ -52,6 +58,7 @@ export const Complaints: FC<Props> = ({ defaultComplaintType }) => {
 
     setSearch("");
     filterDispatch(resetFilters(payload));
+    dispatch(setActiveTab(complaintType));
   };
 
   const handleCreateClick = () => {

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-create.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-create.tsx
@@ -94,7 +94,7 @@ export const CreateComplaint: FC = () => {
   if (agency === "EPO") {
     initialComplaintType = COMPLAINT_TYPES.ERS;
   } else if (agency === "COS") {
-    initialComplaintType = Object.keys(COMPLAINT_TYPES).find((item) => item === activeTab) ?? COMPLAINT_TYPES.HWCR;
+    initialComplaintType = activeTab === COMPLAINT_TYPES.ERS ? COMPLAINT_TYPES.ERS : COMPLAINT_TYPES.HWCR;
   }
 
   const [complaintType, setComplaintType] = useState<string>(initialComplaintType);

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-create.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-create.tsx
@@ -13,7 +13,7 @@ import { ValidationInput } from "../../../../common/validation-input";
 import Option from "../../../../types/app/option";
 import { Coordinates } from "../../../../types/app/coordinate-type";
 import { useAppDispatch, useAppSelector } from "../../../../hooks/hooks";
-import { openModal, selectOfficerAgency, userId } from "../../../../store/reducers/app";
+import { openModal, selectActiveTab, userId } from "../../../../store/reducers/app";
 import notificationInvalid from "../../../../../assets/images/notification-invalid.png";
 
 import {
@@ -68,6 +68,7 @@ export const CreateComplaint: FC = () => {
   const reportedByCodes = useAppSelector(selectReportedByDropdown) as Option[];
   const violationTypeCodes = useAppSelector(selectViolationCodeDropdown(agency)) as Option[];
   const [complaintAttachmentCount, setComplaintAttachmentCount] = useState<number>(0);
+  const activeTab = useAppSelector(selectActiveTab);
 
   const handleSlideCountChange = (count: number) => {
     setComplaintAttachmentCount(count);
@@ -89,9 +90,15 @@ export const CreateComplaint: FC = () => {
 
   const [complaintData, applyComplaintData] = useState<ComplaintAlias>();
 
-  const [complaintType, setComplaintType] = useState<string>(
-    agency == "EPO" ? COMPLAINT_TYPES.ERS : COMPLAINT_TYPES.HWCR,
-  );
+  let initialComplaintType: string = COMPLAINT_TYPES.HWCR;
+  if (agency === "EPO") {
+    initialComplaintType = COMPLAINT_TYPES.ERS;
+  } else if (agency === "COS") {
+    initialComplaintType = Object.keys(COMPLAINT_TYPES).find((item) => item === activeTab) ?? COMPLAINT_TYPES.HWCR;
+  }
+
+  const [complaintType, setComplaintType] = useState<string>(initialComplaintType);
+
   const [complaintTypeMsg, setComplaintTypeMsg] = useState<string>("");
   const [natureOfComplaintErrorMsg, setNatureOfComplaintErrorMsg] = useState<string>("");
   const [violationTypeErrorMsg, setViolationTypeErrorMsg] = useState<string>("");

--- a/frontend/src/app/store/migrations.ts
+++ b/frontend/src/app/store/migrations.ts
@@ -9,6 +9,7 @@ import { AddGirTypeCode } from "./migrations/migration-8";
 import { AddWebEOCChangeCount } from "./migrations/migration-9";
 import { RebuildCodeTable } from "./migrations/migration-11";
 import { AddFeatureFlag } from "./migrations/migration-12";
+import { AddActiveTab } from "./migrations/migration-13";
 
 const BaseMigration = {
   0: (state: any) => {
@@ -32,6 +33,7 @@ migration = {
   ...AddWebEOCChangeCount,
   ...RebuildCodeTable,
   ...AddFeatureFlag,
+  ...AddActiveTab,
 };
 
 export default migration;

--- a/frontend/src/app/store/migrations/migration-13.ts
+++ b/frontend/src/app/store/migrations/migration-13.ts
@@ -1,0 +1,11 @@
+export const AddActiveTab = {
+  13: (state: any) => {
+    return {
+      ...state,
+      app: {
+        ...state.app,
+        activeTab: "",
+      },
+    };
+  },
+};

--- a/frontend/src/app/store/reducers/app.ts
+++ b/frontend/src/app/store/reducers/app.ts
@@ -36,6 +36,7 @@ enum ActionTypes {
   SET_USER_AGENCY = "app/SET_USER_AGENCY",
   SET_CODE_TABLE_VERSION = "app/SET_CODE_TABLE_VERSION",
   SET_FEATURE_FLAG = "app/SET_FEATURE_FLAG",
+  SET_ACTIVE_TAB = "app/SET_ACTIVE_TAB",
 }
 //-- action creators
 
@@ -121,6 +122,11 @@ export const setOfficerDefaultZone = (name: string, description: string) => ({
 export const setOfficerAgency = (agency: string) => ({
   type: ActionTypes.SET_USER_AGENCY,
   payload: agency,
+});
+
+export const setActiveTab = (activeTab: string) => ({
+  type: ActionTypes.SET_ACTIVE_TAB,
+  payload: activeTab,
 });
 
 //-- selectors
@@ -249,6 +255,14 @@ export const selectOfficerAgency = (state: RootState): string => {
   } = state.app;
 
   return agency;
+};
+
+export const selectActiveTab = (state: RootState): string => {
+  const {
+    app: { activeTab },
+  } = state;
+
+  return activeTab;
 };
 
 export const isFeatureActive =
@@ -472,6 +486,7 @@ const initialState: AppState = {
     },
   },
   featureFlags: [],
+  activeTab: "HWCR",
 };
 
 const reducer = (state: AppState = initialState, action: any): AppState => {
@@ -587,6 +602,12 @@ const reducer = (state: AppState = initialState, action: any): AppState => {
       const { payload } = action;
       return { ...state, featureFlags: payload };
     }
+
+    case ActionTypes.SET_ACTIVE_TAB: {
+      const { payload } = action;
+      return { ...state, activeTab: payload };
+    }
+
     default:
       return state;
   }

--- a/frontend/src/app/store/store.ts
+++ b/frontend/src/app/store/store.ts
@@ -9,7 +9,7 @@ const persistConfig = {
   storage,
   blacklist: ["app"],
   whitelist: ["codeTables", "officers"],
-  version: 12, // This needs to be incremented every time a new migration is added
+  version: 13, // This needs to be incremented every time a new migration is added
   debug: true,
   migrate: createMigrate(migration, { debug: false }),
 };

--- a/frontend/src/app/types/app/app-state.ts
+++ b/frontend/src/app/types/app/app-state.ts
@@ -29,4 +29,6 @@ export interface AppState {
   codeTableVersion: CodeTableVersionState;
 
   featureFlags: Array<FeatureFlagState>;
+
+  activeTab: string;
 }


### PR DESCRIPTION
# Description

This PR is to set the complaint type default to the type that’s appropriate to the tab/view a user is creating it from.

Fixes # (CE-202)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Switch to Enforcement tab of the list/map view. Click ‘Create complaint’ button on the side bar. Check if the complaint type in the create form prepopulates to 'Enforcement'. 
- [ ] Switch to any other tab. Click ‘Create complaint’ button on the side bar. Check if the complaint type in the create form prepopulates to 'Human Wildlife Conflict'. 

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
