### PR TITLE
fix: Modifies how the contstraint is added to the feature_agency_xref

### DIFF
--- a/migrations/migrations/V0.25.1__CE-892.sql
+++ b/migrations/migrations/V0.25.1__CE-892.sql
@@ -47,8 +47,7 @@ CREATE TABLE
     update_utc_timestamp timestamp NOT NULL,
     CONSTRAINT "PK_featagcyxr" PRIMARY KEY (feature_agency_xref_guid),
     CONSTRAINT "FK_featurecd" FOREIGN KEY (feature_code) REFERENCES public.feature_code (feature_code),
-    CONSTRAINT "FK_agencycode" FOREIGN KEY (agency_code) REFERENCES public.agency_code (agency_code),
-    CONSTRAINT "UK_unique" UNIQUE (feature_code, agency_code)
+    CONSTRAINT "FK_agencycode" FOREIGN KEY (agency_code) REFERENCES public.agency_code (agency_code)
   );
 
 -- Comments for Feature / Agency XREF table

--- a/migrations/migrations/V0.26.2__CE-1017.sql
+++ b/migrations/migrations/V0.26.2__CE-1017.sql
@@ -1,0 +1,10 @@
+--
+-- alter the feature_agency_xref table to add a uniqueness constraint between feature and agency
+-- this is to avoid the repeatable scripts re-adding new entries into the XREF that already exist
+--
+ALTER TABLE feature_agency_xref
+ADD CONSTRAINT "UK_unique_feature_agency" UNIQUE (feature_code, agency_code);
+
+UPDATE configuration 
+SET    configuration_value = configuration_value::int + 1
+WHERE  configuration_code = 'CDTABLEVER';


### PR DESCRIPTION
Changes now are done by using a new versioned script rather than making modifications to the earlier script that created the table.

<!-- Provide a general summary of your changes in the Title above -->

# Description

Please provide a summary of the change and the issue fixed. Please include relevant context. List dependency changes.

Fixes # (issue)
Identified as part of the deploy process.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Re-run the migrations and confirm no errors are thrown.
- [ ] Test B


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-627-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-627-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)