### PR TITLE
feat: CE-750 Display Current Date in Filter when only one date selected

### DIFF
--- a/frontend/src/app/components/containers/complaints/complaint-filter-bar.tsx
+++ b/frontend/src/app/components/containers/complaints/complaint-filter-bar.tsx
@@ -44,12 +44,13 @@ export const ComplaintFilterBar: FC<Props> = ({
   } = state;
 
   const dateRangeLabel = (): string | undefined => {
+    const currentDate = new Date().toLocaleDateString();
     if (startDate !== null && endDate !== null) {
       return `${startDate?.toLocaleDateString()} - ${endDate?.toLocaleDateString()}`;
     } else if (startDate !== null) {
-      return `${startDate?.toLocaleDateString()} - `;
+      return `${startDate?.toLocaleDateString()} - ${currentDate}`;
     } else if (endDate !== null) {
-      return ` - ${endDate?.toLocaleDateString()}`;
+      return `${currentDate} - ${endDate?.toLocaleDateString()}`;
     } else {
       return undefined;
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Please provide a summary of the change and the issue fixed. Please include relevant context. List dependency changes.

Fixes CE=750

Updates Date Filter pill to display the current date when only one date is selected instead of a range.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Validated Date Range Still works <start date> - <end date>
- [X] Validated that selecting a date in the past displays <date> - <current date>
- [X] Validated that selecting a date in the past twice displays (date range of 1) <date> - <date>


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-697-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-697-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)