### PR TITLE
fix: CE-917 enable autoscaling for test

### DIFF
--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -85,6 +85,7 @@ jobs:
         --set backend.pdb.enabled=true
         --set webeoc.pdb.enabled=true
         --set nats.config.cluster.replicas=3
+        --set nats.config.cluster.enabled=true
 
   promote:
     name: Promote Images

--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -79,9 +79,13 @@ jobs:
       tag: ${{ needs.vars.outputs.pr }}
       params: --set backend.deploymentStrategy=RollingUpdate
         --set frontend.deploymentStrategy=RollingUpdate
+        --set webeoc.deploymentStrategy=RollingUpdate
         --set global.autoscaling=true
         --set frontend.pdb.enabled=true
         --set backend.pdb.enabled=true
+        --set webeoc.pdb.enabled=true
+        --set nats.config.cluster.replicas=3
+
   promote:
     name: Promote Images
     needs: [deploy-prod, vars]

--- a/.github/workflows/merge-release.yml
+++ b/.github/workflows/merge-release.yml
@@ -54,6 +54,7 @@ jobs:
         --set frontend.pdb.enabled=true
         --set backend.pdb.enabled=true
         --set webeoc.pdb.enabled=true
+        --set nats.config.cluster.replicas=3
 
   promote:
     name: Promote Images

--- a/.github/workflows/merge-release.yml
+++ b/.github/workflows/merge-release.yml
@@ -47,6 +47,13 @@ jobs:
     with:
       environment: test
       tag: ${{ needs.vars.outputs.pr }}
+      params: --set backend.deploymentStrategy=RollingUpdate
+        --set frontend.deploymentStrategy=RollingUpdate
+        --set webeoc.deploymentStrategy=RollingUpdate
+        --set global.autoscaling=true
+        --set frontend.pdb.enabled=true
+        --set backend.pdb.enabled=true
+        --set webeoc.pdb.enabled=true
 
   promote:
     name: Promote Images

--- a/.github/workflows/merge-release.yml
+++ b/.github/workflows/merge-release.yml
@@ -55,6 +55,7 @@ jobs:
         --set backend.pdb.enabled=true
         --set webeoc.pdb.enabled=true
         --set nats.config.cluster.replicas=3
+        --set nats.config.cluster.enabled=true
 
   promote:
     name: Promote Images

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -377,7 +377,7 @@ nats:
         enabled: true
         maxSize: 250Mi
     cluster:
-      enabled: true
+      enabled: false
       replicas: 1
   natsBox:
     enabled: false

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -378,7 +378,7 @@ nats:
         maxSize: 250Mi
     cluster:
       enabled: true
-      replicas: 3
+      replicas: 1
   natsBox:
     enabled: false
   persistence:

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -361,7 +361,7 @@ backup:
 nats:
   enabled: true
   config:
-    replicaCount: 1
+    replicaCount: 2
     resources:
       requests:
         cpu: 100m
@@ -407,9 +407,9 @@ webeoc:
     #-- enable or disable autoscaling.
     enabled: true
     #-- the minimum number of replicas.
-    minReplicas: 1
+    minReplicas: 2
     #-- the maximum number of replicas.
-    maxReplicas: 2
+    maxReplicas: 3
     #-- the target cpu utilization percentage, is from request cpu and NOT LIMIT CPU.
     targetCPUUtilizationPercentage: 80
   service:

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -361,7 +361,6 @@ backup:
 nats:
   enabled: true
   config:
-    replicaCount: 2
     resources:
       requests:
         cpu: 100m
@@ -377,8 +376,9 @@ nats:
       memoryStore:
         enabled: true
         maxSize: 250Mi
-  cluster:
-    enabled: true
+    cluster:
+      enabled: true
+      replicas: 3
   natsBox:
     enabled: false
   persistence:

--- a/migrations/migrations/R__reset-templates.sql
+++ b/migrations/migrations/R__reset-templates.sql
@@ -1,0 +1,14 @@
+---------------------
+-- Resets the CDOGS template hashes on every migration to ensure we always upload a new one
+--
+-- The last line of the comment is where the magic happens, it will refresh the date -
+-- even if no changes are made.
+--
+-- Last Run on: ${flyway:timestamp}
+----------------------
+
+UPDATE "configuration"
+SET
+  configuration_value = ''
+WHERE
+  configuration_code IN ('ERSTMPLATE', 'HWCTMPLATE');


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

enable autoscaling for test and bump NATS replicas

Fixes # (CE-917)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Successful infra deploy

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-702-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-702-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)