### PR TITLE
fix: CE-1142-apply-sentence-case-to-delete-authorization-modal

### DIFF
--- a/frontend/src/app/components/containers/complaints/outcomes/ceeb/authorization-outcome/authorization-outcome.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/ceeb/authorization-outcome/authorization-outcome.tsx
@@ -47,7 +47,7 @@ export const AuthoizationOutcome: FC = () => {
         modalSize: "md",
         modalType: DELETE_CONFIRM,
         data: {
-          title: "Delete Authorization?",
+          title: "Delete authorization?",
           description: "Your changes will be lost.",
           confirmText: "delete authorization",
           deleteConfirmed: () => {


### PR DESCRIPTION
# Description

This PR is to apply sentence case to a Delete Authorization modal

Fixes # (CE-1142)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Navigate to a CEEB complaint with a completed Authorization section. Attempt to delete the section. Check if the title text reads ‘Delete authorization" consistently sentence case with other modals

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes



---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-709-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-709-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)