### PR TITLE
fix: CE-1143-apply-scroll-bar-to-assign-modal

### DIFF
--- a/frontend/src/app/components/containers/complaints/outcomes/ceeb/authorization-outcome/authorization-outcome.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/ceeb/authorization-outcome/authorization-outcome.tsx
@@ -47,7 +47,7 @@ export const AuthoizationOutcome: FC = () => {
         modalSize: "md",
         modalType: DELETE_CONFIRM,
         data: {
-          title: "Delete Authorization?",
+          title: "Delete authorization?",
           description: "Your changes will be lost.",
           confirmText: "delete authorization",
           deleteConfirmed: () => {

--- a/frontend/src/app/components/modal/instances/assign-officer-modal.tsx
+++ b/frontend/src/app/components/modal/instances/assign-officer-modal.tsx
@@ -215,7 +215,7 @@ export const AssignOfficerModal: FC<AssignOfficerModalProps> = ({ close, submit,
         </section>
         <section>
           <h4 style={{ marginBottom: "8px", fontSize: "16px", fontWeight: 700 }}>{renderHeading()}</h4>
-          <ListGroup>{renderOfficers()}</ListGroup>
+          <ListGroup className="modal-scroll">{renderOfficers()}</ListGroup>
         </section>
       </Modal.Body>
       <Modal.Footer>

--- a/frontend/src/assets/sass/layout.scss
+++ b/frontend/src/assets/sass/layout.scss
@@ -374,6 +374,13 @@ button.modal-buttons {
   background-color: $gray-100;
 }
 
+.modal-scroll {
+  min-height: 70px;
+  max-height: 264px;
+  overflow-y: scroll;
+  overflow-x: hidden;
+}
+
 .self-assign {
   margin-bottom: 10px;
   &:hover {


### PR DESCRIPTION
# Description

This PR is to apply a scroll bar to the Assign modal

Fixes # (CE-1143)
CE-1142

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Navigate to the assign modal where there are several officers available for assignment. Check if the assign modal is a fixed size and only the suggested officer section can scroll via a scrollbar when the list of officers exceeds the provided space.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-710-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-710-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-710-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-710-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)