### PR TITLE
fix: CE-909 Animal outcome drug forms reorder unexpectedly

### DIFF
--- a/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/create-outcome.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/create-outcome.tsx
@@ -307,7 +307,9 @@ export const CreateAnimalOutcome: FC<props> = ({ index, assignedOfficer: officer
     const { drugs: source } = data;
 
     const items = source.filter(({ id }) => id !== drug.id);
-    const update = [...items, drug];
+    const update = from([...items, drug])
+      .orderBy((item) => item.order)
+      .toArray();
 
     updateModel("drugs", update);
   };

--- a/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/create-outcome.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/create-outcome.tsx
@@ -25,6 +25,7 @@ import { DrugAuthorizedBy } from "./drug-authorized-by";
 import { REQUIRED } from "../../../../../constants/general";
 import { v4 as uuidv4 } from "uuid";
 import { ToggleError } from "../../../../../common/toast";
+import { getNextOrderNumber } from "../hwcr-outcome-by-animal-v2";
 
 type props = {
   index: number;
@@ -252,6 +253,7 @@ export const CreateAnimalOutcome: FC<props> = ({ index, assignedOfficer: officer
 
   const addDrugUsed = () => {
     const { drugs } = data;
+    const nextOrder = getNextOrderNumber<DrugUsedV2>(drugs);
 
     let id = uuidv4().toString();
 
@@ -268,7 +270,7 @@ export const CreateAnimalOutcome: FC<props> = ({ index, assignedOfficer: officer
         injectionMethod: "",
         discardMethod: "",
         officer: officer ?? "",
-        order: 0,
+        order: nextOrder,
       },
     ];
     updateModel("drugs", update);

--- a/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/edit-outcome.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/edit-outcome.tsx
@@ -278,7 +278,9 @@ export const EditOutcome: FC<props> = ({ id, index, outcome, assignedOfficer: of
     const { drugs: source } = data;
 
     const items = source.filter(({ id }) => id !== drug.id);
-    const update = [...items, drug];
+    const update = from([...items, drug])
+      .orderBy((item) => item.order)
+      .toArray();
 
     updateModel("drugs", update);
   };


### PR DESCRIPTION
Addresses [CE-909](https://env-ceds.atlassian.net/browse/CE-909). Addresses issue where data entered into one animal outcome drug field would swap around to other drugs. 

## Changes 🚧

- Drug items now use an ordering function to ensure consistent order, and therefore entries. 

## How Has This Been Tested? 🔬

- [x] Manual testing, matching replication procedure from issue report.

### To test 🔬

1. Run a local instance of the application, log in and create a new issue. 
2. Under _'Outcome by Animal'_, click _'Add animal'_.
3. In animal outcome form, click 'Add drug' multiple times.
4. In the first record, enter information in the fields. Information entered should stay in that record. Information entered into other records should stay in their respective record.

### Checklist 📃

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

[CE-1120]: https://env-ceds.atlassian.net/browse/CE-1120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Addresses #issue_number. brief_description_of_change 

[CE-909]: https://env-ceds.atlassian.net/browse/CE-909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-713-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-713-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)