### PR TITLE
fix: CE-1108

### DIFF
--- a/frontend/src/app/store/reducers/documents-thunks.ts
+++ b/frontend/src/app/store/reducers/documents-thunks.ts
@@ -3,7 +3,7 @@ import { RootState } from "../store";
 import config from "../../../config";
 import { format } from "date-fns";
 import axios, { AxiosRequestConfig } from "axios";
-import { AUTH_TOKEN } from "../../service/user-service";
+import { AUTH_TOKEN, getUserAgency } from "../../service/user-service";
 
 //--
 //-- exports a complaint as a pdf document
@@ -12,7 +12,14 @@ export const exportComplaint =
   (type: string, id: string): ThunkAction<Promise<string | undefined>, RootState, unknown, Action<string>> =>
   async (dispatch) => {
     try {
-      const fileName = `Complaint-${id}-${type}-${format(new Date(), "yyyy-MM-dd")}.pdf`;
+      const agency = getUserAgency();
+      let tailored_filename = "";
+      if (agency != null && agency === "COS") {
+        tailored_filename = `${type}_${id}_${format(new Date(), "yyMMdd")}.pdf`;
+      } else {
+        tailored_filename = `Complaint-${id}-${type}-${format(new Date(), "yyyy-MM-dd")}.pdf`;
+      }
+
       const tz: string = encodeURIComponent(Intl.DateTimeFormat().resolvedOptions().timeZone);
 
       const axiosConfig: AxiosRequestConfig = {
@@ -33,7 +40,7 @@ export const exportComplaint =
       let link = document.createElement("a");
       link.id = "hidden-details-screen-export-complaint";
       link.href = fileURL;
-      link.download = fileName;
+      link.download = tailored_filename;
 
       document.body.appendChild(link);
       link.click();

--- a/frontend/src/app/store/reducers/documents-thunks.ts
+++ b/frontend/src/app/store/reducers/documents-thunks.ts
@@ -4,6 +4,7 @@ import config from "../../../config";
 import { format } from "date-fns";
 import axios, { AxiosRequestConfig } from "axios";
 import { AUTH_TOKEN, getUserAgency } from "../../service/user-service";
+import { AgencyType } from "../../types/app/agency-types";
 
 //--
 //-- exports a complaint as a pdf document
@@ -16,11 +17,11 @@ export const exportComplaint =
       let tailored_filename = "";
       if (agency != null) {
         switch (agency) {
-          case "CEEB": {
+          case AgencyType.CEEB: {
             tailored_filename = `${format(new Date(), "yyyy-MM-dd")} Complaint ${id}.pdf`;
             break;
           }
-          case "COS":
+          case AgencyType.COS:
           default: {
             let typeName = type;
             if (type === "ERS") {

--- a/frontend/src/app/store/reducers/documents-thunks.ts
+++ b/frontend/src/app/store/reducers/documents-thunks.ts
@@ -14,9 +14,26 @@ export const exportComplaint =
     try {
       const agency = getUserAgency();
       let tailored_filename = "";
-      if (agency != null && agency === "COS") {
-        tailored_filename = `${type}_${id}_${format(new Date(), "yyMMdd")}.pdf`;
+      if (agency != null) {
+        switch (agency) {
+          case "CEEB": {
+            tailored_filename = `${format(new Date(), "yyyy-MM-dd")} Complaint ${id}.pdf`;
+            break;
+          }
+          case "COS":
+          default: {
+            let typeName = type;
+            if (type === "ERS") {
+              typeName = "EC";
+            } else if (type === "HWCR") {
+              typeName = "HWC";
+            }
+            tailored_filename = `${typeName}_${id}_${format(new Date(), "yyMMdd")}.pdf`;
+            break;
+          }
+        }
       } else {
+        // Can't find any agency information - use previous standard
         tailored_filename = `Complaint-${id}-${type}-${format(new Date(), "yyyy-MM-dd")}.pdf`;
       }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Modifies how the filenames are generated for exports when the users are from different agencies.

Fixes # CE-1108

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] As a COS user export a HWCR and confirm that the filename for the PDF generated is in the correct format.
- [ ] As a COS user export a ERS and confirm that the filename for the PDF generated is in the correct format.
- [ ] As a COS user export a GIR and confirm that the filename for the PDF generated is in the correct format.

- [ ] As a CEEB user export a ERS and confirm that the filename for the PDF generated is in the correct format.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
