### PR TITLE
fix: CE-1175-correct-error-message-text

### DIFF
--- a/frontend/src/app/components/common/comp-coordinate-input.tsx
+++ b/frontend/src/app/components/common/comp-coordinate-input.tsx
@@ -116,11 +116,12 @@ export const CompCoordinateInput: FC<Props> = ({
     let lat;
     let lng;
 
-    const errorTextSuffix = `The corresponding longitude value must be between ${bcBoundaries.minLongitude} and ${bcBoundaries.maxLongitude} degrees`;
+    const errorTextSuffixLat = `The corresponding latitude value must be between ${bcBoundaries.minLatitude} and ${bcBoundaries.maxLatitude} degrees`;
+    const errorTextSuffixLng = `The corresponding longitude value must be between ${bcBoundaries.minLongitude} and ${bcBoundaries.maxLongitude} degrees`;
     const eastingErrorText =
-      `Invalid Easting. Easting value must be between 290220.6 and 720184.9 metres.` + errorTextSuffix;
+      `Invalid Easting. Easting value must be between 290220.6 and 720184.9 metres. ` + errorTextSuffixLng;
     const northingErrorText =
-      `Invalid Northing. Northing value must be between 5346051.7 and 6655120.8 metres.` + errorTextSuffix;
+      `Invalid Northing. Northing value must be between 5346051.7 and 6655120.8 metres. ` + errorTextSuffixLat;
     const zoneErrorText = `Invalid Zone. Must be in 7-11 range`;
 
     let utm = new utmObj();


### PR DESCRIPTION
# Description

This PR is to fix the error message text when entering UTM coordinates.

Fixes # (CE-1175)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-728-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-728-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)