### PR TITLE
chore: add cleanup scan script for finding dangling / old resources

### DIFF
--- a/.github/scripts/cleanup_scan.sh
+++ b/.github/scripts/cleanup_scan.sh
@@ -24,7 +24,7 @@ trap 'echo "Error occurred at line $LINENO while executing function $FUNCNAME"' 
 help_str() {
     echo "Usage: SKIP_AUTH=true OC_NAMESPACE=<namespace> ./cleanup_scan.sh"
     echo ""
-    echo "Ensure you have curl, oc, and jq installed and available on your path."
+    echo "Ensure you have curl, oc, and jq installed and available on your path, and have performed a oc login."
     echo ""
     echo "The ALLOW_EXPR regex is passed to grep -E for resource filtering. To read more run: man grep"
     echo ""

--- a/.github/scripts/cleanup_scan.sh
+++ b/.github/scripts/cleanup_scan.sh
@@ -7,18 +7,23 @@
 # in order to see the names and perform the delete themselves.
 #
 set -e # failfast
+trap 'echo "Error occurred at line $LINENO while executing function $FUNCNAME"' ERR
 
 # ENV:
 # OC_NAMESPACE: namespace to scan
 # SKIP_AUTH: set to true to skip auth and use your existing local kubeconfig
 # OC_SERVER: OpenShift server URL
 # OC_TOKEN: OpenShift token
-# ALLOW_LIST: comma separated list of workloads to ignore
-if [ -z "$ALLOW_LIST" ]; then
-    ALLOW_LIST=""
+# ALLOW_EXPR: comma separated list of workloads to ignore
+
+# THIRTY_DAYS_IN_SECONDS=2592000 - variables in the jq dont play nice so we will just hardcode it
+
+# Configure globals
+if [ -z "$ALLOW_EXPR" ]; then
+    ALLOW_EXPR="placeholder"
 fi
-ALLOW_LIST=$(echo "$ALLOW_LIST" | tr "," "\n")
-echo "ALLOW_LIST: $ALLOW_LIST"
+echo "ALLOW_EXPR: $ALLOW_EXPR"
+
 OC_TEMP_TOKEN=""
 if [ -z "$OC_NAMESPACE" ]; then
     echo "OC_NAMESPACE is not set. Exiting..."
@@ -38,35 +43,62 @@ if [ "$SKIP_AUTH" != "true" ]; then
     oc login --token=$OC_TEMP_TOKEN --server=$OC_SERVER
     oc project $OC_NAMESPACE # Safeguard!
 fi
+OK=0
 
+# checks if the resource name appears in the allow expression
+# and removes it if found, preventing a false positive
+filter_items() {
+    local items="$1"
+    local filtered_items=()
+    # convert items to an array for easy manipulation
+    local iter_array_items=()
+    mapfile -t array_items < <(echo "$items")
+    for item in "${array_items[@]}"; do
+        if ! echo "$item" | grep -Eq "$ALLOW_EXPR"; then
+            iter_array_items+=("$item")
+        fi
+    done
+    # organize the filtered items
+    for item in "${iter_array_items[@]}"; do
+        if [[ -n "$item" ]]; then
+            filtered_items+=("$item")
+        fi
+    done
+    duplicates_result=$(printf "%s\n" "${filtered_items[@]}")
+    unique_result=$(echo "$duplicates_result" | sort | uniq)
+    echo "$unique_result"
+}
 
-ok=0
-touch /tmp/old_workloads.txt
-touch /tmp/secrets_to_delete.txt
-touch /tmp/pvcs_to_delete.txt
-touch /tmp/configmaps_to_delete.txt
+# standard function to output found deletions to a file, and set the OK flag
+# note that the message can contain NUM_ITEMS which will be replaced with the count found
+found_deletions() {
+    local file_name=$1
+    local err_message=$2
+    local ok_message=$3
+    local items=$4
+    local num_items
+    num_items=$(echo "$items" | grep -cve '^\s*$' || echo 0)
+    num_items=${num_items//[^0-9]/} # ensure num_items is an integer
+    if [ "$num_items" -gt 0 ]; then
+        echo -e "$items" > "/tmp/$file_name"
+        echo "${err_message//NUM_ITEMS/$num_items}"
+        OK=1
+    else
+        echo "$ok_message"
+    fi
+}
 
 # First, get workloads older than 30 days
 echo "Scanning for workloads older than 30 days in the targeted namespace"
 echo "..."
-# THIRTY_DAYS_IN_SECONDS=2592000
 old_workloads=$(oc get deploy,service,statefulset -n $OC_NAMESPACE -ojson | jq -r '.items[] | select(.metadata.creationTimestamp | fromdateiso8601 | (. + 2592000) < now) | "\(.kind)/\(.metadata.name)"')
-filtered_workloads=()
-for workload in $old_workloads; do
-    if ! echo "$ALLOW_LIST" | grep -q "^$workload$"; then
-        filtered_workloads+=("$workload")
-    fi
-done
-old_workloads="${filtered_workloads[*]}"
-num_old_workloads=$(echo $old_workloads | wc -w)
-if [ $num_old_workloads -gt 0 ]; then
-    echo -e "$old_workloads" > /tmp/old_workloads.txt
-    echo -e "\n" >> /tmp/old_workloads.txt
-    echo "Found $num_old_workloads workloads older than 30 days in the targeted namespace"
-    ok=1
-else
-    echo "Found no stale workloads in the targeted namespace"
-fi
+old_workloads=$(filter_items "$old_workloads")
+old_workloads_to_delete=$old_workloads
+found_deletions \
+    "old_workloads_to_delete.txt" \
+    "Found NUM_ITEMS workloads older than 30 days in the targeted namespace" \
+    "Found no stale workloads in the targeted namespace" \
+    "$old_workloads_to_delete"
 echo ""
 echo ""
 
@@ -82,21 +114,13 @@ for secret in $secret_names; do
         secrets_to_delete+=("secret/$secret\n")
     fi
 done
-filtered_secrets=()
-for secret in "${secrets_to_delete[@]}"; do
-    if ! echo "$ALLOW_LIST" | grep -q "$secret\n"; then
-        filtered_secrets+=("$secret")
-    fi
-done
-secrets_to_delete=("${filtered_secrets[@]}")
-num_secrets_to_delete=${#secrets_to_delete[@]}
-if [ $num_secrets_to_delete -gt 0 ]; then
-    echo "Found $num_secrets_to_delete secrets older than 30 days not used by any pod in the targeted namespace"
-    echo -e "${secrets_to_delete[@]}" > /tmp/secrets_to_delete.txt
-    ok=1
-else
-    echo "Found no stale and dangling secrets in the targeted namespace"
-fi
+secrets_list=$(echo -e "${secrets_to_delete[@]}")
+filtered_secrets=$(filter_items "$secrets_list")
+found_deletions \
+    "secrets_to_delete.txt" \
+    "Found NUM_ITEMS dangling secrets older than 30 days in the targeted namespace" \
+    "Found no stale and dangling secrets in the targeted namespace" \
+    "${filtered_secrets}"
 echo ""
 echo ""
 
@@ -107,27 +131,20 @@ echo "..."
 oc get pods -n $OC_NAMESPACE -ojson | jq -r '.items[] | "\(.metadata.name):\(.spec.volumes[]?.persistentVolumeClaim.claimName)"' > /tmp/in_use_pvc.txt
 in_use_pvcs=$(cat /tmp/in_use_pvc.txt | grep -v "null" | sort | uniq)
 echo -e "$in_use_pvcs" > /tmp/in_use_pvc.txt
+pvc_list=$(oc get pvc -n $OC_NAMESPACE -ojson | jq -r '.items[] | select(.metadata.creationTimestamp | fromdateiso8601 | (. + 2592000) < now) | .metadata.name')
 pvcs_to_delete=()
-for pvc in $(oc get pvc -n $OC_NAMESPACE -ojson | jq -r '.items[] | select(.metadata.creationTimestamp | fromdateiso8601 | (. + 2592000) < now) | .metadata.name'); do
+for pvc in $pvc_list; do
     if ! grep -q $pvc /tmp/in_use_pvc.txt; then
         pvcs_to_delete+=("pvc/$pvc\n")
     fi
 done
-filtered_pvcs=()
-for pvc in "${pvcs_to_delete[@]}"; do
-    if ! echo "$ALLOW_LIST" | grep -q "^$pvc\n$"; then
-        filtered_pvcs+=("$pvc")
-    fi
-done
-pvcs_to_delete=("${filtered_pvcs[@]}")
-num_pvcs_to_delete=${#pvcs_to_delete[@]}
-if [ $num_pvcs_to_delete -gt 0 ]; then
-    echo "Found $num_pvcs_to_delete pvcs older than 30 days not used by any pod in the targeted namespace"
-    echo -e "${pvcs_to_delete[@]}" > /tmp/pvcs_to_delete.txt
-    ok=1
-else
-    echo "Found no stale and dangling pvcs in the targeted namespace"
-fi
+pvc_list=$(echo -e "${pvcs_to_delete[@]}")
+filtered_pvcs=$(filter_items "$pvc_list")
+found_deletions \
+    "pvcs_to_delete.txt" \
+    "Found NUM_ITEMS dangling PVCs older than 30 days in the targeted namespace" \
+    "Found no stale and dangling PVCs in the targeted namespace" \
+    "${filtered_pvcs}"
 echo ""
 echo ""
 
@@ -142,31 +159,23 @@ for configmap in $configmap_names; do
         configmaps_to_delete+=("configmap/$configmap\n")
     fi
 done
-filtered_configmaps=()
-for configmap in "${configmaps_to_delete[@]}"; do
-    if ! echo "$ALLOW_LIST" | grep -q "^$configmap\n$"; then
-        filtered_configmaps+=("$configmap")
-    fi
-done
-configmaps_to_delete=("${filtered_configmaps[@]}")
-num_configmaps_to_delete=${#configmaps_to_delete[@]}
-if [ $num_configmaps_to_delete -gt 0 ]; then
-    echo "Found $num_configmaps_to_delete configmaps older than 30 days not used by any pod in the targeted namespace"
-    echo -e "${configmaps_to_delete[@]}" > /tmp/configmaps_to_delete.txt
-    ok=1
-else
-    echo "Found no stale and dangling configmaps in the targeted namespace"
-fi
+configmap_list=$(echo -e "${configmaps_to_delete[@]}")
+filtered_configmaps=$(filter_items "$configmap_list")
+found_deletions \
+    "configmaps_to_delete.txt" \
+    "Found NUM_ITEMS dangling configmaps older than 30 days in the targeted namespace" \
+    "Found no stale and dangling configmaps in the targeted namespace" \
+    "${filtered_configmaps}"
 echo ""
 echo ""
 
-if [ $ok -eq 1 ]; then
+if [ $OK -eq 1 ]; then
     echo "To delete these found workloads, locally run the following to see them:"
     echo "Note: skip flag uses your existing oc authentication"
     echo ""
     echo "SKIP_AUTH=true ./.github/scripts/cleanup_scan.sh"
-    echo "cat /tmp/old_workloads.txt && cat /tmp/secrets_to_delete.txt && cat /tmp/pvcs_to_delete.txt && cat /tmp/configmaps_to_delete.txt"
+    echo "cat /tmp/old_workloads_to_delete.txt && cat /tmp/secrets_to_delete.txt && cat /tmp/pvcs_to_delete.txt && cat /tmp/configmaps_to_delete.txt"
 
 fi
 
-exit $ok
+exit $OK

--- a/.github/scripts/cleanup_scan.sh
+++ b/.github/scripts/cleanup_scan.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+# Cleanup Scan
+#
+# Performs a scan of workloads older than 30s, checks for dangling secrets, pvcs, and configmaps
+# This script only lists findings and returns a 0/1 (pass/fail) and does not perform a delete.
+# For CI/CD safety, only the counts are output, and users are encouraged to run this locally 
+# in order to see the names and perform the delete themselves.
+#
+set -e # failfast
+
+# ENV:
+# OC_NAMESPACE: namespace to scan
+# SKIP_AUTH: set to true to skip auth and use your existing local kubeconfig
+# OC_SERVER: OpenShift server URL
+# OC_TOKEN: OpenShift token
+# ALLOW_LIST: comma separated list of workloads to ignore
+if [ -z "$ALLOW_LIST" ]; then
+    ALLOW_LIST=""
+fi
+ALLOW_LIST=$(echo "$ALLOW_LIST" | tr "," "\n")
+echo "ALLOW_LIST: $ALLOW_LIST"
+OC_TEMP_TOKEN=""
+if [ -z "$OC_NAMESPACE" ]; then
+    echo "OC_NAMESPACE is not set. Exiting..."
+    exit 1
+fi
+if [ "$SKIP_AUTH" != "true" ]; then
+    if [ -z "$OC_SERVER" ]; then
+        echo "OC_SERVER is not set. Exiting..."
+        exit 1
+    fi
+    if [ -z "$OC_TOKEN" ]; then
+        echo "OC_TOKEN is not set. Exiting..."
+        exit 1
+    fi
+    # Auth flow
+    OC_TEMP_TOKEN=$(curl -k -X POST $OC_SERVER/api/v1/namespaces/$OC_NAMESPACE/serviceaccounts/pipeline/token --header "Authorization: Bearer $OC_TOKEN" -d '{"spec": {"expirationSeconds": 600}}' -H 'Content-Type: application/json; charset=utf-8' | jq -r '.status.token' )
+    oc login --token=$OC_TEMP_TOKEN --server=$OC_SERVER
+    oc project $OC_NAMESPACE # Safeguard!
+fi
+
+
+ok=0
+touch /tmp/old_workloads.txt
+touch /tmp/secrets_to_delete.txt
+touch /tmp/pvcs_to_delete.txt
+touch /tmp/configmaps_to_delete.txt
+
+# First, get workloads older than 30 days
+echo "Scanning for workloads older than 30 days in the targeted namespace"
+echo "..."
+# THIRTY_DAYS_IN_SECONDS=2592000
+old_workloads=$(oc get deploy,service,statefulset -n $OC_NAMESPACE -ojson | jq -r '.items[] | select(.metadata.creationTimestamp | fromdateiso8601 | (. + 2592000) < now) | "\(.kind)/\(.metadata.name)"')
+filtered_workloads=()
+for workload in $old_workloads; do
+    if ! echo "$ALLOW_LIST" | grep -q "^$workload$"; then
+        filtered_workloads+=("$workload")
+    fi
+done
+old_workloads="${filtered_workloads[*]}"
+num_old_workloads=$(echo $old_workloads | wc -w)
+if [ $num_old_workloads -gt 0 ]; then
+    echo -e "$old_workloads" > /tmp/old_workloads.txt
+    echo -e "\n" >> /tmp/old_workloads.txt
+    echo "Found $num_old_workloads workloads older than 30 days in the targeted namespace"
+    ok=1
+else
+    echo "Found no stale workloads in the targeted namespace"
+fi
+echo ""
+echo ""
+
+# next get all secrets not used by a pod older than 30 days
+# Get all secret names used by pods and write to a file
+echo "Scanning for dangling secrets not used by workloads"
+echo "..."
+oc get pods -n $OC_NAMESPACE -ojson | jq -r '.items[] | "\(.metadata.name):\(.spec.containers[].envFrom[]?.secretRef.name)"' > /tmp/in_use_secrets.txt
+secret_names=$(oc get secret -n $OC_NAMESPACE -ojson | jq -r '.items[] | select(.metadata.creationTimestamp | fromdateiso8601 | (. + 2592000) < now) | .metadata.name')
+secrets_to_delete=()
+for secret in $secret_names; do
+    if ! grep -q $secret /tmp/in_use_secrets.txt; then
+        secrets_to_delete+=("secret/$secret\n")
+    fi
+done
+filtered_secrets=()
+for secret in "${secrets_to_delete[@]}"; do
+    if ! echo "$ALLOW_LIST" | grep -q "$secret\n"; then
+        filtered_secrets+=("$secret")
+    fi
+done
+secrets_to_delete=("${filtered_secrets[@]}")
+num_secrets_to_delete=${#secrets_to_delete[@]}
+if [ $num_secrets_to_delete -gt 0 ]; then
+    echo "Found $num_secrets_to_delete secrets older than 30 days not used by any pod in the targeted namespace"
+    echo -e "${secrets_to_delete[@]}" > /tmp/secrets_to_delete.txt
+    ok=1
+else
+    echo "Found no stale and dangling secrets in the targeted namespace"
+fi
+echo ""
+echo ""
+
+# next get all pvcs not used by a pod
+# Get all pvc names used by pods and write to a file
+echo "Scanning for dangling pvcs not used by workloads"
+echo "..."
+oc get pods -n $OC_NAMESPACE -ojson | jq -r '.items[] | "\(.metadata.name):\(.spec.volumes[]?.persistentVolumeClaim.claimName)"' > /tmp/in_use_pvc.txt
+in_use_pvcs=$(cat /tmp/in_use_pvc.txt | grep -v "null" | sort | uniq)
+echo -e "$in_use_pvcs" > /tmp/in_use_pvc.txt
+pvcs_to_delete=()
+for pvc in $(oc get pvc -n $OC_NAMESPACE -ojson | jq -r '.items[] | select(.metadata.creationTimestamp | fromdateiso8601 | (. + 2592000) < now) | .metadata.name'); do
+    if ! grep -q $pvc /tmp/in_use_pvc.txt; then
+        pvcs_to_delete+=("pvc/$pvc\n")
+    fi
+done
+filtered_pvcs=()
+for pvc in "${pvcs_to_delete[@]}"; do
+    if ! echo "$ALLOW_LIST" | grep -q "^$pvc\n$"; then
+        filtered_pvcs+=("$pvc")
+    fi
+done
+pvcs_to_delete=("${filtered_pvcs[@]}")
+num_pvcs_to_delete=${#pvcs_to_delete[@]}
+if [ $num_pvcs_to_delete -gt 0 ]; then
+    echo "Found $num_pvcs_to_delete pvcs older than 30 days not used by any pod in the targeted namespace"
+    echo -e "${pvcs_to_delete[@]}" > /tmp/pvcs_to_delete.txt
+    ok=1
+else
+    echo "Found no stale and dangling pvcs in the targeted namespace"
+fi
+echo ""
+echo ""
+
+# next get all configmaps not used by a pod
+echo "Scanning for dangling configmaps not used by workloads"
+echo "..."
+oc get pods -n $OC_NAMESPACE -ojson | jq -r '.items[] | "\(.metadata.name):\(.spec.volumes[]?.configMap.name)"' > /tmp/in_use_configmaps.txt
+configmap_names=$(oc get configmap -n $OC_NAMESPACE -ojson | jq -r '.items[] | select(.metadata.creationTimestamp | fromdateiso8601 | (. + 2592000) < now) | .metadata.name')
+configmaps_to_delete=()
+for configmap in $configmap_names; do
+    if ! grep -q $configmap /tmp/in_use_configmaps.txt; then
+        configmaps_to_delete+=("configmap/$configmap\n")
+    fi
+done
+filtered_configmaps=()
+for configmap in "${configmaps_to_delete[@]}"; do
+    if ! echo "$ALLOW_LIST" | grep -q "^$configmap\n$"; then
+        filtered_configmaps+=("$configmap")
+    fi
+done
+configmaps_to_delete=("${filtered_configmaps[@]}")
+num_configmaps_to_delete=${#configmaps_to_delete[@]}
+if [ $num_configmaps_to_delete -gt 0 ]; then
+    echo "Found $num_configmaps_to_delete configmaps older than 30 days not used by any pod in the targeted namespace"
+    echo -e "${configmaps_to_delete[@]}" > /tmp/configmaps_to_delete.txt
+    ok=1
+else
+    echo "Found no stale and dangling configmaps in the targeted namespace"
+fi
+echo ""
+echo ""
+
+if [ $ok -eq 1 ]; then
+    echo "To delete these found workloads, locally run the following to see them:"
+    echo "Note: skip flag uses your existing oc authentication"
+    echo ""
+    echo "SKIP_AUTH=true ./.github/scripts/cleanup_scan.sh"
+    echo "cat /tmp/old_workloads.txt && cat /tmp/secrets_to_delete.txt && cat /tmp/pvcs_to_delete.txt && cat /tmp/configmaps_to_delete.txt"
+
+fi
+
+exit $ok

--- a/.github/scripts/cleanup_scan.sh
+++ b/.github/scripts/cleanup_scan.sh
@@ -14,7 +14,7 @@ trap 'echo "Error occurred at line $LINENO while executing function $FUNCNAME"' 
 # SKIP_AUTH: set to true to skip auth and use your existing local kubeconfig
 # OC_SERVER: OpenShift server URL
 # OC_TOKEN: OpenShift token
-# ALLOW_EXPR: comma separated list of workloads to ignore
+# ALLOW_EXPR: expression passed into grep extended search to allow certain resources to be skipped
 
 # THIRTY_DAYS_IN_SECONDS=2592000 - variables in the jq dont play nice so we will just hardcode it
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Adds a script that can be used to find dangling resources in a given namespace. After we've done a few rounds of cleaning it'd be good to place this into CICD as a scheduled check.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Script accurately finds dangling resources and allows skipping based on a regex

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Further comments

NOTE: I'm running cleanup after demos are all done, here's a sample run of what it's finding:

```
jon-funk@Atlas:~/projects/nr-compliance-enforcement/.github/scripts$ ALLOW_EXPR="object-store" SKIP_AUTH=true ./cleanup_scan.sh 
ALLOW_EXPR: object-store
Scanning for workloads older than 30 days in the targeted namespace
...
Found 15 workloads older than 30 days in the targeted namespace


Scanning for dangling secrets not used by workloads
...
Found 57 dangling secrets older than 30 days in the targeted namespace


Scanning for dangling pvcs not used by workloads
...
Found no stale and dangling PVCs in the targeted namespace


Scanning for dangling configmaps not used by workloads
...
Found 8 dangling configmaps older than 30 days in the targeted namespace


To delete these found workloads, locally run the following to see them:
Note: skip flag uses your existing oc authentication

SKIP_AUTH=true ./.github/scripts/cleanup_scan.sh
cat /tmp/old_workloads_to_delete.txt && cat /tmp/secrets_to_delete.txt && cat /tmp/pvcs_to_delete.txt && cat /tmp/configmaps_to_delete.txt
```

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-731-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-731-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)