### PR TITLE
chore: Fix mapSearch agency check for CEEB users

### DIFF
--- a/backend/src/v1/complaint/complaint.service.ts
+++ b/backend/src/v1/complaint/complaint.service.ts
@@ -129,7 +129,7 @@ export class ComplaintService {
 
     const result = await builder.getOne();
     //-- pull the user's agency from the query results and return the agency code
-    if (result.office_guid && result.office_guid.agency_code) {
+    if (result.office_guid?.agency_code) {
       const {
         office_guid: { agency_code },
       } = result;


### PR DESCRIPTION
# Description

Complaints service's `mapSearch` function uses the local function `_getAgencyByUser` to determine a users agency. This function identifies a users agency through the office they are assigned to. CEEB users have no office assigned, thus `_getAgencyByUser` fails. To get around this, `mapSearch` now uses the `hasCEEBRole` variable already included to determine if `_getAgencyByUser` should be called, or "EPO" should be assigned (as is the case for CEEB users). Current implementation of tests do not address the problem, and there was an existing false positive in the tests for the complaints service. This will be addressed separately.

Fixes # (issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-735-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-735-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)