### PR TITLE
fix: CE-1276 1277 stored filter fixes

### DIFF
--- a/frontend/src/app/components/containers/complaints/complaint-filter.tsx
+++ b/frontend/src/app/components/containers/complaints/complaint-filter.tsx
@@ -82,7 +82,6 @@ export const ComplaintFilter: FC<Props> = ({ type }) => {
 
   const handleDateRangeChange = (dates: [Date, Date]) => {
     const [start, end] = dates;
-    setFilter("startDate", start);
     //set the time to be end of day to ensure that we also search for records after the beginning of the selected day.
     if (start) {
       start.setHours(0, 0, 0);
@@ -93,6 +92,7 @@ export const ComplaintFilter: FC<Props> = ({ type }) => {
       end.setMilliseconds(999);
     }
 
+    setFilter("startDate", start);
     setFilter("endDate", end);
   };
 

--- a/frontend/src/app/providers/complaint-filter-provider.tsx
+++ b/frontend/src/app/providers/complaint-filter-provider.tsx
@@ -55,7 +55,8 @@ const mapFilters = (complaintFilters: Partial<ComplaintFilters>) => {
 
   // Parse the start and end date filters into Date objects if they exist.
   const parsedStartDate = startDateFilter ? new Date(startDateFilter) : undefined;
-  const parsedEndDate = endDateFilter ? new Date(endDateFilter) : undefined;
+  // If start date is set and end date is not, default to current date for end date.
+  const parsedEndDate = endDateFilter ? new Date(endDateFilter) : parsedStartDate ? new Date() : undefined;
 
   const allFilters: Partial<ComplaintFilters> = {
     region: regionCodeFilter,

--- a/frontend/src/app/providers/complaint-filter-provider.tsx
+++ b/frontend/src/app/providers/complaint-filter-provider.tsx
@@ -52,13 +52,18 @@ const mapFilters = (complaintFilters: Partial<ComplaintFilters>) => {
     natureOfComplaintFilter,
     outcomeAnimalFilter,
   } = complaintFilters;
+
+  // Parse the start and end date filters into Date objects if they exist.
+  const parsedStartDate = startDateFilter ? new Date(startDateFilter) : undefined;
+  const parsedEndDate = endDateFilter ? new Date(endDateFilter) : undefined;
+
   const allFilters: Partial<ComplaintFilters> = {
     region: regionCodeFilter,
     zone: zoneCodeFilter,
     community: areaCodeFilter,
     officer: officerFilter,
-    startDate: startDateFilter,
-    endDate: endDateFilter,
+    startDate: parsedStartDate,
+    endDate: parsedEndDate,
     status: complaintStatusFilter,
     species: speciesCodeFilter,
     complaintMethod: complaintMethodFilter,

--- a/frontend/src/app/providers/complaint-filter-provider.tsx
+++ b/frontend/src/app/providers/complaint-filter-provider.tsx
@@ -56,7 +56,12 @@ const mapFilters = (complaintFilters: Partial<ComplaintFilters>) => {
   // Parse the start and end date filters into Date objects if they exist.
   const parsedStartDate = startDateFilter ? new Date(startDateFilter) : undefined;
   // If start date is set and end date is not, default to current date for end date.
-  const parsedEndDate = endDateFilter ? new Date(endDateFilter) : parsedStartDate ? new Date() : undefined;
+  let parsedEndDate = undefined;
+  if (endDateFilter) {
+    parsedEndDate = new Date(endDateFilter);
+  } else if (parsedStartDate) {
+    parsedEndDate = new Date();
+  }
 
   const allFilters: Partial<ComplaintFilters> = {
     region: regionCodeFilter,

--- a/frontend/src/app/store/reducers/complaints.ts
+++ b/frontend/src/app/store/reducers/complaints.ts
@@ -371,6 +371,7 @@ export const getMappedComplaints =
 
     try {
       dispatch(setComplaint(null));
+      dispatch(setComplaintSearchParameters(payload));
 
       let parameters = generateApiParameters(`${config.API_BASE_URL}/v1/complaint/map/search/${complaintType}`, {
         sortBy: sortColumn,


### PR DESCRIPTION
Fixed persistence bugs in the search when returning to the complaints page.

# Description

Fixed the date filters to get parsed into state in the complaint filters provider. This prevents the app from entering a broken state when loading a fresh complaint filter context with stored start or end date filters in the search params.
Fixed the map search function to now set the complaint search parameters in state. This fixes the bug of filters set in map not setting the complaint search parameters.

Fixes:
https://env-ceds.atlassian.net/jira/software/c/projects/CE/boards/4?selectedIssue=CE-1276
https://env-ceds.atlassian.net/jira/software/c/projects/CE/boards/4?selectedIssue=CE-1277

# How Has This Been Tested?

Tested by following the steps to reproduce in the bug cards and ensuring that the site remained in a functional state.


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-778-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-778-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)