### PR TITLE
feat: CE-443 add COMS access request

### DIFF
--- a/backend/src/auth/decorators/token.decorator.ts
+++ b/backend/src/auth/decorators/token.decorator.ts
@@ -3,5 +3,13 @@ import { createParamDecorator, ExecutionContext } from "@nestjs/common";
 export const Token = createParamDecorator((_data: unknown, ctx: ExecutionContext) => {
   //Extract token from request
   const request = ctx.switchToHttp().getRequest();
-  return request.token;
+  if (request.token) {
+    return request.token;
+  }
+  // If the token is not directly accessible in the request object, take it from the headers
+  let token = request.headers.authorization;
+  if (token && token.indexOf("Bearer ") === 0) {
+    token = token.substring(7);
+  }
+  return token;
 });

--- a/backend/src/auth/decorators/user.decorator.ts
+++ b/backend/src/auth/decorators/user.decorator.ts
@@ -1,0 +1,8 @@
+import { createParamDecorator, ExecutionContext } from "@nestjs/common";
+
+// Returns the user off of the request object.
+// Sample usage: foo(@User() user) {...}
+export const User = createParamDecorator((data: unknown, ctx: ExecutionContext) => {
+  const request = ctx.switchToHttp().getRequest();
+  return request.user;
+});

--- a/backend/src/auth/jwtrole.guard.ts
+++ b/backend/src/auth/jwtrole.guard.ts
@@ -12,6 +12,9 @@ import { Role } from "../enum/role.enum";
 import { ROLES_KEY } from "./decorators/roles.decorator";
 import { IS_PUBLIC_KEY } from "./decorators/public.decorator";
 
+// A list of routes that are exceptions to the READ_ONLY role only being allowed to make get requests
+const READ_ONLY_EXCEPTIONS = ["/api/v1/officer/request-coms-access/:officer_guid"];
+
 @Injectable()
 /**
  * An API guard used to authorize controller methods.  This guard checks for othe @Roles decorator, and compares it against the role_names of the authenticated user's jwt.
@@ -57,8 +60,8 @@ export class JwtRoleGuard extends AuthGuard("jwt") implements CanActivate {
     // Check if the user has the readonly role
     const hasReadOnlyRole = userRoles.includes(Role.READ_ONLY);
 
-    // If the user has readonly role, allow only GET requests
-    if (hasReadOnlyRole) {
+    // If the user has readonly role, allow only GET requests unless the route is in the list of exceptions
+    if (hasReadOnlyRole && !READ_ONLY_EXCEPTIONS.includes(request.route.path)) {
       if (request.method !== "GET") {
         this.logger.debug(`User with readonly role attempted ${request.method} method`);
         throw new ForbiddenException("Access denied: Read-only users cannot perform this action");

--- a/backend/src/helpers/axios-api.ts
+++ b/backend/src/helpers/axios-api.ts
@@ -27,3 +27,8 @@ export const post = async (apiToken: string, url: string, data: any, headers?: a
   const config = generateConfig(apiToken, headers);
   return axios.post(url, data, config);
 };
+
+export const put = async (apiToken: string, url: string, data: any, headers?: any) => {
+  const config = generateConfig(apiToken, headers);
+  return axios.put(url, data, config);
+};

--- a/backend/src/v1/officer/entities/officer.entity.ts
+++ b/backend/src/v1/officer/entities/officer.entity.ts
@@ -72,6 +72,13 @@ export class Officer {
   @Column()
   auth_user_guid: UUID;
 
+  @ApiProperty({
+    example: false,
+    description: "Indicates whether an officer has been enrolled in COMS",
+  })
+  @Column()
+  coms_enrolled_ind: boolean;
+
   user_roles: string[];
   @AfterLoad()
   updateUserRoles() {

--- a/backend/src/v1/officer/officer.controller.ts
+++ b/backend/src/v1/officer/officer.controller.ts
@@ -7,8 +7,8 @@ import { Role } from "../../enum/role.enum";
 import { JwtRoleGuard } from "../../auth/jwtrole.guard";
 import { ApiTags } from "@nestjs/swagger";
 import { UUID } from "crypto";
-import { User } from "src/auth/decorators/user.decorator";
-import { Token } from "src/auth/decorators/token.decorator";
+import { User } from "../../auth/decorators/user.decorator";
+import { Token } from "../../auth/decorators/token.decorator";
 
 @ApiTags("officer")
 @UseGuards(JwtRoleGuard)

--- a/backend/src/v1/officer/officer.controller.ts
+++ b/backend/src/v1/officer/officer.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete, UseGuards } from "@nestjs/common";
+import { Controller, Get, Post, Body, Patch, Param, Delete, UseGuards, Put } from "@nestjs/common";
 import { OfficerService } from "./officer.service";
 import { CreateOfficerDto } from "./dto/create-officer.dto";
 import { UpdateOfficerDto } from "./dto/update-officer.dto";
@@ -67,7 +67,7 @@ export class OfficerController {
     return this.officerService.update(id, updateOfficerDto);
   }
 
-  @Get("/request-coms-access/:officer_guid")
+  @Put("/request-coms-access/:officer_guid")
   @Roles(Role.CEEB, Role.COS_OFFICER, Role.READ_ONLY)
   requestComsAccess(@Token() token, @Param("officer_guid") officer_guid: UUID, @User() user) {
     return this.officerService.requestComsAccess(token, officer_guid, user);

--- a/backend/src/v1/officer/officer.controller.ts
+++ b/backend/src/v1/officer/officer.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete, UseGuards } from "@nestjs/common";
+import { Controller, Get, Post, Body, Patch, Param, Delete, UseGuards, Put } from "@nestjs/common";
 import { OfficerService } from "./officer.service";
 import { CreateOfficerDto } from "./dto/create-officer.dto";
 import { UpdateOfficerDto } from "./dto/update-officer.dto";
@@ -7,6 +7,8 @@ import { Role } from "../../enum/role.enum";
 import { JwtRoleGuard } from "../../auth/jwtrole.guard";
 import { ApiTags } from "@nestjs/swagger";
 import { UUID } from "crypto";
+import { User } from "src/auth/decorators/user.decorator";
+import { Token } from "src/auth/decorators/token.decorator";
 
 @ApiTags("officer")
 @UseGuards(JwtRoleGuard)
@@ -63,6 +65,12 @@ export class OfficerController {
   @Roles(Role.COS_OFFICER, Role.CEEB, Role.TEMPORARY_TEST_ADMIN)
   update(@Param("id") id: UUID, @Body() updateOfficerDto: UpdateOfficerDto) {
     return this.officerService.update(id, updateOfficerDto);
+  }
+
+  @Get("/request-coms-access/:officer_guid")
+  @Roles(Role.CEEB, Role.COS_OFFICER, Role.READ_ONLY)
+  requestComsAccess(@Token() token, @Param("officer_guid") officer_guid: UUID, @User() user) {
+    return this.officerService.requestComsAccess(token, officer_guid, user);
   }
 
   @Delete(":id")

--- a/backend/src/v1/officer/officer.controller.ts
+++ b/backend/src/v1/officer/officer.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete, UseGuards, Put } from "@nestjs/common";
+import { Controller, Get, Post, Body, Patch, Param, Delete, UseGuards } from "@nestjs/common";
 import { OfficerService } from "./officer.service";
 import { CreateOfficerDto } from "./dto/create-officer.dto";
 import { UpdateOfficerDto } from "./dto/update-officer.dto";

--- a/backend/src/v1/officer/officer.service.ts
+++ b/backend/src/v1/officer/officer.service.ts
@@ -184,8 +184,6 @@ export class OfficerService {
     try {
       const currentRoles = user.client_roles;
       const permissions = currentRoles.includes(Role.READ_ONLY) ? ["READ"] : ["READ", "CREATE", "UPDATE", "DELETE"];
-      if (currentRoles.includes(Role.READ_ONLY)) {
-      }
       const comsPayload = {
         accessKeyId: process.env.COMS_ACCESS_KEY_ID,
         bucket: process.env.COMS_BUCKET,

--- a/backend/src/v1/officer/officer.service.ts
+++ b/backend/src/v1/officer/officer.service.ts
@@ -185,15 +185,15 @@ export class OfficerService {
       const currentRoles = user.client_roles;
       const permissions = currentRoles.includes(Role.READ_ONLY) ? ["READ"] : ["READ", "CREATE", "UPDATE", "DELETE"];
       const comsPayload = {
-        accessKeyId: process.env.COMS_ACCESS_KEY_ID,
-        bucket: process.env.COMS_BUCKET,
-        bucketName: process.env.COMS_BUCKET_NAME,
-        key: process.env.COMS_KEY,
-        endpoint: process.env.COMS_ENDPOINT,
-        secretAccessKey: process.env.COMS_SECRET_KEY,
+        accessKeyId: process.env.OBJECTSTORE_ACCESS_KEY,
+        bucket: process.env.OBJECTSTORE_BUCKET,
+        bucketName: process.env.OBJECTSTORE_BUCKET_NAME,
+        key: process.env.OBJECTSTORE_KEY,
+        endpoint: process.env.OBJECTSTORE_HTTPS_URL,
+        secretAccessKey: process.env.OBJECTSTORE_SECRET_KEY,
         permCodes: permissions,
       };
-      const comsUrl = `${process.env.COMS_URL}/bucket`;
+      const comsUrl = `${process.env.OBJECTSTORE_API_URL}/bucket`;
       await put(token, comsUrl, comsPayload);
       const officerRes = await this.officerRepository
         .createQueryBuilder("officer")

--- a/backend/src/v1/officer/officer.service.ts
+++ b/backend/src/v1/officer/officer.service.ts
@@ -12,7 +12,7 @@ import { OfficeService } from "../office/office.service";
 import { UUID } from "crypto";
 import { CssService } from "../../external_api/css/css.service";
 import { Role } from "../../enum/role.enum";
-import { put } from "src/helpers/axios-api";
+import { put } from "../../helpers/axios-api";
 
 @Injectable()
 export class OfficerService {

--- a/backend/src/v1/officer/officer.service.ts
+++ b/backend/src/v1/officer/officer.service.ts
@@ -11,6 +11,8 @@ import { PersonService } from "../person/person.service";
 import { OfficeService } from "../office/office.service";
 import { UUID } from "crypto";
 import { CssService } from "../../external_api/css/css.service";
+import { Role } from "../../enum/role.enum";
+import { put } from "src/helpers/axios-api";
 
 @Injectable()
 export class OfficerService {
@@ -170,6 +172,42 @@ export class OfficerService {
     delete (updateOfficerDto as any).user_roles;
     await this.officerRepository.update({ officer_guid }, updateOfficerDto);
     return this.findOne(officer_guid);
+  }
+
+  /**
+   * This function requests the appropriate level of access to the storage bucket in COMS.
+   * If successful, the officer's record in the officer table has its `coms_enrolled_ind` indicator set to true.
+   * @param requestComsAccessDto An object containing the officer guid
+   * @returns the updated record of the officer who was granted access to COMS
+   */
+  async requestComsAccess(token: string, officer_guid: UUID, user: any): Promise<Officer> {
+    try {
+      const currentRoles = user.client_roles;
+      const permissions = currentRoles.includes(Role.READ_ONLY) ? ["READ"] : ["READ", "CREATE", "UPDATE", "DELETE"];
+      if (currentRoles.includes(Role.READ_ONLY)) {
+      }
+      const comsPayload = {
+        accessKeyId: process.env.COMS_ACCESS_KEY_ID,
+        bucket: process.env.COMS_BUCKET,
+        bucketName: process.env.COMS_BUCKET_NAME,
+        key: process.env.COMS_KEY,
+        endpoint: process.env.COMS_ENDPOINT,
+        secretAccessKey: process.env.COMS_SECRET_KEY,
+        permCodes: permissions,
+      };
+      const comsUrl = `${process.env.COMS_URL}/bucket`;
+      await put(token, comsUrl, comsPayload);
+      const officerRes = await this.officerRepository
+        .createQueryBuilder("officer")
+        .update()
+        .set({ coms_enrolled_ind: true })
+        .where({ officer_guid: officer_guid })
+        .returning("*")
+        .execute();
+      return officerRes.raw[0];
+    } catch (error) {
+      this.logger.error("An error occurred while requesting COMS access.", error);
+    }
   }
 
   remove(id: number) {

--- a/charts/app/templates/secret.yaml
+++ b/charts/app/templates/secret.yaml
@@ -46,6 +46,7 @@
 {{- $objectstoreBackupDirectory := (get $secretData "objectstoreBackupDirectory" | b64dec | default "") }}
 {{- $objectstoreKey := (get $secretData "objectstoreKey" | b64dec | default "") }}
 {{- $objectstoreBucket := (get $secretData "objectstoreBucket" | b64dec | default "") }}
+{{- $objectstoreBucketName := (get $secretData "objectstoreBucketName" | b64dec | default "") }}
 {{- $objectstoreSecretKey := (get $secretData "objectstoreSecretKey" | b64dec | default "") }}
 {{- $objectstoreApiUrl := (get $secretData "objectstoreApiUrl" | b64dec | default "") }}
 {{- $jwksUri := (get $secretData "jwksUri" | b64dec | default "") }}
@@ -89,7 +90,6 @@ data:
   CSS_CLIENT_ID: {{ $cssClientId | b64enc | quote }}
   CSS_CLIENT_SECRET: {{ $cssClientSecret | b64enc | quote }}
   ENVIRONMENT: {{ $environment | b64enc | quote }}
-
   # BACKUP Secrets
   BACKUP_DIR: {{ $backupDir | b64enc | quote }}
   BACKUP_STRATEGY: {{ $backupStrategy | b64enc | quote }}
@@ -104,6 +104,7 @@ data:
   OBJECTSTORE_BACKUP_DIRECTORY: {{ $objectstoreBackupDirectory | b64enc | quote }}
   OBJECTSTORE_KEY: {{ $objectstoreKey | b64enc | quote }}
   OBJECTSTORE_BUCKET: {{ $objectstoreBucket | b64enc | quote }}
+  OBJECTSTORE_BUCKET_NAME: {{ $objectstoreBucketName | b64enc | quote }}
   OBJECTSTORE_SECRET_KEY: {{ $objectstoreSecretKey | b64enc | quote }}
   OBJECTSTORE_API_URL: {{ $objectstoreApiUrl | b64enc | quote }}
 {{- end }}

--- a/charts/app/templates/secret.yaml
+++ b/charts/app/templates/secret.yaml
@@ -26,6 +26,13 @@
 {{- $cssClientId := (get $secretData "cssClientId" | b64dec | default "") }}
 {{- $cssClientSecret := (get $secretData "cssClientSecret" | b64dec | default "") }}
 {{- $environment := (get $secretData "environment" | b64dec | default "") }}
+{{- $comsUrl := (get $secretData "comsUrl" | b64dec | default "") }}
+{{- $comsAccessKeyId := (get $secretData "comsAccessKeyId" | b64dec | default "") }}
+{{- $comsBucket := (get $secretData "comsBucket" | b64dec | default "") }}
+{{- $comsBucketName := (get $secretData "comsBucketName" | b64dec | default "") }}
+{{- $comsKey := (get $secretData "comsKey" | b64dec | default "") }}
+{{- $comsEndpoint := (get $secretData "comsEndpoint" | b64dec | default "") }}
+{{- $comsSecretKey := (get $secretData "comsSecretKey" | b64dec | default "") }}
 {{- $webeocUsername := (get $secretData "webeocUsername" | b64dec | default "") }}
 {{- $webeocPassword := (get $secretData "webeocPassword" | b64dec | default "") }}
 {{- $webeocPosition := (get $secretData "webeocPosition" | b64dec | default "") }}
@@ -87,6 +94,14 @@ data:
   CSS_CLIENT_ID: {{ $cssClientId | b64enc | quote }}
   CSS_CLIENT_SECRET: {{ $cssClientSecret | b64enc | quote }}
   ENVIRONMENT: {{ $environment | b64enc | quote }}
+  # COMS Secrets
+  COMS_URL: {{ $comsUrl | b64enc | quote }}
+  COMS_ACCESS_KEY_ID: {{ $comsAccessKeyId | b64enc | quote }}
+  COMS_BUCKET: {{ $comsBucket | b64enc | quote }}
+  COMS_BUCKET_NAME: {{ $comsBucketName | b64enc | quote }}
+  COMS_KEY: {{ $comsKey | b64enc | quote }}
+  COMS_ENDPOINT: {{ $comsEndpoint | b64enc | quote }}
+  COMS_SECRET_KEY: {{ $comsSecretKey | b64enc | quote }}
   # BACKUP Secrets
   BACKUP_DIR: {{ $backupDir | b64enc | quote }}
   BACKUP_STRATEGY: {{ $backupStrategy | b64enc | quote }}

--- a/charts/app/templates/secret.yaml
+++ b/charts/app/templates/secret.yaml
@@ -26,13 +26,6 @@
 {{- $cssClientId := (get $secretData "cssClientId" | b64dec | default "") }}
 {{- $cssClientSecret := (get $secretData "cssClientSecret" | b64dec | default "") }}
 {{- $environment := (get $secretData "environment" | b64dec | default "") }}
-{{- $comsUrl := (get $secretData "comsUrl" | b64dec | default "") }}
-{{- $comsAccessKeyId := (get $secretData "comsAccessKeyId" | b64dec | default "") }}
-{{- $comsBucket := (get $secretData "comsBucket" | b64dec | default "") }}
-{{- $comsBucketName := (get $secretData "comsBucketName" | b64dec | default "") }}
-{{- $comsKey := (get $secretData "comsKey" | b64dec | default "") }}
-{{- $comsEndpoint := (get $secretData "comsEndpoint" | b64dec | default "") }}
-{{- $comsSecretKey := (get $secretData "comsSecretKey" | b64dec | default "") }}
 {{- $webeocUsername := (get $secretData "webeocUsername" | b64dec | default "") }}
 {{- $webeocPassword := (get $secretData "webeocPassword" | b64dec | default "") }}
 {{- $webeocPosition := (get $secretData "webeocPosition" | b64dec | default "") }}
@@ -51,8 +44,10 @@
 {{- $objectstoreUrl := (get $secretData "objectstoreUrl" | b64dec | default "") }}
 {{- $objectstoreHttpsUrl := (get $secretData "objectstoreHttpsUrl" | b64dec | default "") }}
 {{- $objectstoreBackupDirectory := (get $secretData "objectstoreBackupDirectory" | b64dec | default "") }}
+{{- $objectstoreKey := (get $secretData "objectstoreKey" | b64dec | default "") }}
 {{- $objectstoreBucket := (get $secretData "objectstoreBucket" | b64dec | default "") }}
 {{- $objectstoreSecretKey := (get $secretData "objectstoreSecretKey" | b64dec | default "") }}
+{{- $objectstoreApiUrl := (get $secretData "objectstoreApiUrl" | b64dec | default "") }}
 {{- $jwksUri := (get $secretData "jwksUri" | b64dec | default "") }}
 {{- $jwtIssuer := (get $secretData "jwtIssuer" | b64dec | default "") }}
 {{- $keycloakClientId := (get $secretData "keycloakClientId" | b64dec | default "") }}
@@ -94,14 +89,7 @@ data:
   CSS_CLIENT_ID: {{ $cssClientId | b64enc | quote }}
   CSS_CLIENT_SECRET: {{ $cssClientSecret | b64enc | quote }}
   ENVIRONMENT: {{ $environment | b64enc | quote }}
-  # COMS Secrets
-  COMS_URL: {{ $comsUrl | b64enc | quote }}
-  COMS_ACCESS_KEY_ID: {{ $comsAccessKeyId | b64enc | quote }}
-  COMS_BUCKET: {{ $comsBucket | b64enc | quote }}
-  COMS_BUCKET_NAME: {{ $comsBucketName | b64enc | quote }}
-  COMS_KEY: {{ $comsKey | b64enc | quote }}
-  COMS_ENDPOINT: {{ $comsEndpoint | b64enc | quote }}
-  COMS_SECRET_KEY: {{ $comsSecretKey | b64enc | quote }}
+
   # BACKUP Secrets
   BACKUP_DIR: {{ $backupDir | b64enc | quote }}
   BACKUP_STRATEGY: {{ $backupStrategy | b64enc | quote }}
@@ -114,8 +102,10 @@ data:
   OBJECTSTORE_URL: {{ $objectstoreUrl | b64enc | quote }}
   OBJECTSTORE_HTTPS_URL: {{ $objectstoreHttpsUrl | b64enc | quote }}
   OBJECTSTORE_BACKUP_DIRECTORY: {{ $objectstoreBackupDirectory | b64enc | quote }}
+  OBJECTSTORE_KEY: {{ $objectstoreKey | b64enc | quote }}
   OBJECTSTORE_BUCKET: {{ $objectstoreBucket | b64enc | quote }}
   OBJECTSTORE_SECRET_KEY: {{ $objectstoreSecretKey | b64enc | quote }}
+  OBJECTSTORE_API_URL: {{ $objectstoreApiUrl | b64enc | quote }}
 {{- end }}
 {{- if not (lookup "v1" "Secret" .Release.Namespace (printf "%s-webeoc" .Release.Name)) }}
 ---

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -29,12 +29,6 @@ global:
     cssClientId: ~
     cssClientSecret: ~
     environment: ~
-    comsUrl: ~
-    comsAccessKeyId: ~
-    comsBucket: ~
-    comsBucketName: ~
-    comsKey: ~
-    comsEndpoint: ~
     webeocUsername: ~
     webeocPassword: ~
     webeocPosition: ~
@@ -52,8 +46,10 @@ global:
     objectstoreAccessKey: ~
     objectstoreUrl: ~
     objectstoreBackupDirectory: ~
+    objectstoreKey: ~
     objectstoreBucket: ~
     objectstoreSecretKey: ~
+    objectstoreApiUrl: ~
     jwksUri: ~
     jwtIssuer: ~
     keycloakClientId: ~

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -48,6 +48,7 @@ global:
     objectstoreBackupDirectory: ~
     objectstoreKey: ~
     objectstoreBucket: ~
+    objectstoreBucketName: ~
     objectstoreSecretKey: ~
     objectstoreApiUrl: ~
     jwksUri: ~

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -29,6 +29,12 @@ global:
     cssClientId: ~
     cssClientSecret: ~
     environment: ~
+    comsUrl: ~
+    comsAccessKeyId: ~
+    comsBucket: ~
+    comsBucketName: ~
+    comsKey: ~
+    comsEndpoint: ~
     webeocUsername: ~
     webeocPassword: ~
     webeocPosition: ~

--- a/frontend/src/app/store/migrations.ts
+++ b/frontend/src/app/store/migrations.ts
@@ -20,6 +20,7 @@ import { DrugAdministeredChanges } from "./migrations/migration-20";
 import { AddCat1TypeAndLocationType } from "./migrations/migration-21";
 import { AddActiveComplaintsViewType } from "./migrations/migration-22";
 import { AssessmentTypeUpdates } from "./migrations/migration-23";
+import { AddComsEnrolledInd } from "./migrations/migration-24";
 
 const BaseMigration = {
   0: (state: any) => {
@@ -54,6 +55,7 @@ migration = {
   ...AddCat1TypeAndLocationType,
   ...AddActiveComplaintsViewType,
   ...AssessmentTypeUpdates,
+  ...AddComsEnrolledInd,
 };
 
 export default migration;

--- a/frontend/src/app/store/migrations/migration-24.ts
+++ b/frontend/src/app/store/migrations/migration-24.ts
@@ -1,0 +1,12 @@
+// Refresh the profile for coms access indicator
+export const AddComsEnrolledInd = {
+  24: (state: any) => {
+    return {
+      ...state,
+      app: {
+        ...state.app,
+        profile: {},
+      },
+    };
+  },
+};

--- a/frontend/src/app/store/reducers/app.ts
+++ b/frontend/src/app/store/reducers/app.ts
@@ -6,7 +6,7 @@ import Profile from "@apptypes/app/profile";
 import { UUID } from "crypto";
 import { Officer } from "@apptypes/person/person";
 import config from "@/config";
-import { generateApiParameters, get, patch } from "@common/api";
+import { generateApiParameters, get, patch, put } from "@common/api";
 import { AUTH_TOKEN, getUserAgency } from "@service/user-service";
 
 import { DropdownOption } from "@apptypes/app/drop-down-option";
@@ -387,7 +387,7 @@ export const getTokenProfile = (): AppThunk => async (dispatch) => {
         const requestComsAccessParams = generateApiParameters(
           `${config.API_BASE_URL}/v1/officer/request-coms-access/${response.officer_guid}`,
         );
-        const res = await get<Officer>(dispatch, requestComsAccessParams);
+        const res = await put<Officer>(dispatch, requestComsAccessParams);
         comsEnrolledInd = res.coms_enrolled_ind;
       }
 

--- a/frontend/src/app/store/reducers/app.ts
+++ b/frontend/src/app/store/reducers/app.ts
@@ -367,6 +367,7 @@ export const getTokenProfile = (): AppThunk => async (dispatch) => {
       let zoneDescription = "";
       let agency = "";
       let personGuid = "";
+      let comsEnrolledInd = response.coms_enrolled_ind;
 
       if (response.office_guid !== null) {
         const {
@@ -382,6 +383,14 @@ export const getTokenProfile = (): AppThunk => async (dispatch) => {
         personGuid = person_guid;
       }
 
+      if (!comsEnrolledInd) {
+        const requestComsAccessParams = generateApiParameters(
+          `${config.API_BASE_URL}/v1/officer/request-coms-access/${response.officer_guid}`,
+        );
+        const res = await get<Officer>(dispatch, requestComsAccessParams);
+        comsEnrolledInd = res.coms_enrolled_ind;
+      }
+
       const profile: Profile = {
         givenName: given_name,
         surName: family_name,
@@ -394,6 +403,7 @@ export const getTokenProfile = (): AppThunk => async (dispatch) => {
         zoneDescription: zoneDescription,
         agency,
         personGuid,
+        comsEnrolledInd,
       };
 
       dispatch(setTokenProfile(profile));
@@ -528,6 +538,7 @@ const initialState: AppState = {
     zoneDescription: "",
     agency: "",
     personGuid: "",
+    comsEnrolledInd: null,
   },
   isSidebarOpen: true,
 
@@ -582,6 +593,7 @@ const reducer = (state: AppState = initialState, action: any): AppState => {
         zoneDescription: payload.zoneDescription,
         agency: payload.agency,
         personGuid: payload.personGuid,
+        comsEnrolledInd: payload.comsEnrolledInd,
       };
 
       return { ...state, profile };

--- a/frontend/src/app/store/store.ts
+++ b/frontend/src/app/store/store.ts
@@ -9,7 +9,7 @@ const persistConfig = {
   storage,
   blacklist: ["app"],
   whitelist: ["codeTables", "officers"],
-  version: 22, // This needs to be incremented every time a new migration is added
+  version: 24, // This needs to be incremented every time a new migration is added
   debug: true,
   migrate: createMigrate(migration, { debug: false }),
 };

--- a/frontend/src/app/types/app/profile.ts
+++ b/frontend/src/app/types/app/profile.ts
@@ -12,4 +12,5 @@ export default interface Profile {
   zoneDescription: string;
   agency: string;
   personGuid: string;
+  comsEnrolledInd: boolean | null;
 }

--- a/frontend/src/app/types/person/person.ts
+++ b/frontend/src/app/types/person/person.ts
@@ -25,6 +25,7 @@ export interface Officer {
   office_guid: OfficeGUID;
   person_guid: Person;
   user_roles: string[];
+  coms_enrolled_ind: boolean;
 }
 
 export interface OfficeGUID {

--- a/migrations/migrations/V0.32.0__CE-443.sql
+++ b/migrations/migrations/V0.32.0__CE-443.sql
@@ -1,0 +1,7 @@
+--
+-- alter officer table - add large_carnivore_ind 
+--
+ALTER TABLE officer ADD coms_enrolled_ind boolean DEFAULT false;
+
+comment on column species_code.large_carnivore_ind is
+  'A boolean indicator representing if an officer has been enrolled in COMS';


### PR DESCRIPTION
Add a check for COMS access on sign-in and request it if the user does not have it.

# Description

A field `coms_enrolled_ind` was added to the `officer` table to indicate whether a user has permissions to access the COMS bucket. When a user logs in, if the indicator is false a request is made to the COMS API provisioning permissions for the user based on their role. Currently, `READ_ONLY` users are only given "READ" permissions, all other roles are given full CRUD permissions. The COMS endpoint used (PUT to `/bucket` [docs](https://coms.api.gov.bc.ca/api/v1/docs#tag/Bucket/operation/createBucket) ) provisions the requested permissions to the user whose credentials are being used to make the request, with the `secretAccessKey` allowing them to perform actions on the given bucket. This `secretAccessKey` is not user based, and as such the call to COMS is being done in the backend to avoid exposing that secret. The user roles are stripped off of the user object on the request itself to prevent users from being able wrongly assign extra permissions to themselves. In order to access that information a new backend decorator `@User()` was created. The `@Token()` decorator was updated to grab the token out of the headers if the `authentication` property is not present on the request object itself (which it was not for the incoming request). The COMS request requires new secrets that have been added to the chart.

Developers will need to add the following block to their backend .env files, with the appropriate values:
```
OBJECTSTORE_API_URL=
OBJECTSTORE_ACCESS_KEY=
OBJECTSTORE_BUCKET=
OBJECTSTORE_BUCKET_NAME=
OBJECTSTORE_KEY=
OBJECTSTORE_HTTPS_URL=
OBJECTSTORE_SECRET_KEY=
```

Fixes # [(issue)](https://env-ceds.atlassian.net/jira/software/c/projects/CE/boards/4?selectedIssue=CE-443)

# How Has This Been Tested?

Testing was done by creating a new bucket in dev and logging in with the `coms_enrolled_ind` flag set to false, and ensuring that signing into the app resulted in the call to COMS, that the appropriate permissions being provisioned for the user on that bucket, and that the users `coms_enrolled_ind` was set to true. This was repeated with the COS_OFFICER, CEEB and READ_ONLY roles, removing permissions in between tests.
The standard `dev` bucket was not tested on as I did not have MANAGE rights on the bucket and couldn't remove my permissions to re-run tests.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Further comments

The COMS enrolled indicator value was added to the profile object in the store as requested in the ticket, however the flag in the store is not used for anything at this point. If there is no intent to use the check beyond login, it could likely be removed.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-797-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-797-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-797-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-797-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-797-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-797-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)