### PR TITLE
feat: CE-1261-add-warning-message-to-user-attempting-to-edit-the-outcome-or-outcome-date-in-a-hwc-file-v2

### DIFF
--- a/frontend/src/app/components/modal/instances/standalone-cancel-confirm-modal.tsx
+++ b/frontend/src/app/components/modal/instances/standalone-cancel-confirm-modal.tsx
@@ -10,11 +10,21 @@ type props = {
   show: boolean;
   title: string;
   description: string;
-  close: () => void | null;
-  closeAndCancel: () => void | null;
+  confirmText: string;
+  cancelText: string;
+  confirm: () => void | null;
+  cancel: () => void | null;
 };
 
-export const StandaloneConfirmCancelModal: FC<props> = ({ show, title, description, close, closeAndCancel }) => {
+export const StandaloneConfirmCancelModal: FC<props> = ({
+  show,
+  title,
+  description,
+  confirmText,
+  cancelText,
+  confirm,
+  cancel,
+}) => {
   return (
     <Modal
       show={show}
@@ -34,11 +44,11 @@ export const StandaloneConfirmCancelModal: FC<props> = ({ show, title, descripti
       <Modal.Footer>
         <Button
           variant="outline-primary"
-          onClick={close}
+          onClick={confirm}
         >
-          No, go back
+          {confirmText}
         </Button>
-        <Button onClick={closeAndCancel}>Yes, cancel changes</Button>
+        <Button onClick={cancel}>{cancelText}</Button>
       </Modal.Footer>
     </Modal>
   );


### PR DESCRIPTION
This PR is to address an issue when users edit outcome details after public reports have been published by showing a warning message.

# Description

Please provide a summary of the change and the issue fixed. Please include relevant context. List dependency changes.

Fixes # (CE-1261)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Add an animal outcome to a HWC complaint. 
             Click the Edit button and select new outcome or outcome date. Check if the warning message is displayed. Click No on the modal, check if the changes your have made are rolled back. 
             Select new outcome or outcome date again. When the modal is displayed click Yes, check if your changes are preserved. 


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-800-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-800-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)