### PR TITLE
fix: switch to bearer token val

### DIFF
--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -71,7 +71,7 @@ jobs:
     uses: bcgov/quickstart-openshift-helpers/.github/workflows/.deployer.yml@v0.8.3
     secrets:
       oc_namespace: ${{ vars.OC_NAMESPACE }}
-      oc_token: ${{ secrets.OC_TOKEN }}
+      oc_token: ${{ secrets.OC_BEARER_TOKEN }}
     with:
       environment: prod
       tag: ${{ needs.vars.outputs.pr }}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

This shouldn't be needed but it appears githhub is not respecting the code of the pulled deployer action. As v0.8.3 has the correct curl command. https://github.com/bcgov/nr-compliance-enforcement/actions/runs/12224172977/job/34096599350
https://github.com/bcgov/quickstart-openshift-helpers/blob/main/.github/workflows/.deployer.yml#L125
# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-806-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-806-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)