### PR TITLE
chore: CE-1103 cleanup warnings in frontend

### DIFF
--- a/frontend/src/app/common/validation-phone-input.tsx
+++ b/frontend/src/app/common/validation-phone-input.tsx
@@ -28,13 +28,11 @@ export const ValidationPhoneInput: FC<ValidationPhoneInputProps> = ({
         <PhoneInput
           id={id}
           country="CA"
-          displayInitialValueAsLocalNumber
           className={calulatedClass}
           value={defaultValue}
           onChange={(e) => onChange(e)}
           maxLength={maxLength} //phone input counts () - space, so this is actually a 10 character number
           international={international}
-          initialValueFormat="national"
         />
       </div>
       <div className={errClass}>{errMsg}</div>

--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-file-review.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-file-review.tsx
@@ -44,7 +44,7 @@ export const HWCRFileReview: FC = () => {
   }, [dispatch, componentState, reviewRequired]);
 
   useEffect(() => {
-    setReviewRequired(isReviewRequired);
+    setReviewRequired(isReviewRequired ?? false);
     if (isReviewRequired) setComponentState(DISPLAY_STATE);
   }, [isReviewRequired]);
 

--- a/frontend/src/app/components/modal/instances/assign-officer-modal.tsx
+++ b/frontend/src/app/components/modal/instances/assign-officer-modal.tsx
@@ -137,8 +137,6 @@ export const AssignOfficerModal: FC<AssignOfficerModalProps> = ({ close, submit,
               </div>
             </ListGroupItem>
           );
-        } else {
-          return <></>;
         }
       });
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Remove red warnings in browser console in development mode

Fixes # (issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Check if no warnings when in create complaint page, complaint detail page, open assign officer modal 
- [ ] Check if updated fields are working as normal: phone fields in create/edit complaint pages, file review   


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-811-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-811-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)