### PR TITLE
fix: CE-1330-Attachment-Sort-Order-on-Export

### DIFF
--- a/backend/src/v1/complaint/complaint.service.ts
+++ b/backend/src/v1/complaint/complaint.service.ts
@@ -2073,6 +2073,27 @@ export class ComplaintService {
       return outcomeData.getCaseFileByLeadId;
     };
 
+    const _multiFieldCompare = (first: any, second: any, compareInfo: { field: string; sort: string }[]): number => {
+      for (const item of compareInfo) {
+        if (item.sort === "asc") {
+          if (first[item.field] < second[item.field]) {
+            return -1;
+          }
+          if (first[item.field] > second[item.field]) {
+            return 1;
+          }
+        } else if (item.sort === "desc") {
+          if (first[item.field] > second[item.field]) {
+            return -1;
+          }
+          if (first[item.field] < second[item.field]) {
+            return 1;
+          }
+        }
+      }
+      return 0;
+    };
+
     try {
       if (complaintType) {
         builder = this._generateQueryBuilder(complaintType);
@@ -2196,10 +2217,16 @@ export class ComplaintService {
         .map((item) => {
           return {
             name: item.name,
-            date: _applyTimezone(item.date, tz, "datetime"),
+            date: item.date,
             fileType: getFileType(item.name),
           };
-        });
+        })
+        .sort((first, second) =>
+          _multiFieldCompare(first, second, [
+            { field: "fileType", sort: "asc" },
+            { field: "date", sort: "asc" },
+          ]),
+        );
       data.hasComplaintAttachments = data.cAtts?.length > 0;
 
       data.oAtts = attachments
@@ -2207,10 +2234,16 @@ export class ComplaintService {
         .map((item) => {
           return {
             name: item.name,
-            date: _applyTimezone(item.date, tz, "datetime"),
+            date: item.date,
             fileType: getFileType(item.name),
           };
-        });
+        })
+        .sort((first, second) =>
+          _multiFieldCompare(first, second, [
+            { field: "fileType", sort: "asc" },
+            { field: "date", sort: "asc" },
+          ]),
+        );
 
       data.hasOutcomeAttachments = data.oAtts?.length > 0;
 


### PR DESCRIPTION
# Description

This PR is to order attachments in the PDF export by a file type

Fixes # (CE-1330)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-838-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-838-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)