### PR TITLE
fix: CE-1306-Update-validation-for-CEEB-Authorization-number-field-to-accept-Pesticide-related-authorizations

### DIFF
--- a/frontend/src/app/components/containers/complaints/outcomes/ceeb/authorization-outcome/authorization-outcome-form.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/ceeb/authorization-outcome/authorization-outcome-form.tsx
@@ -61,8 +61,8 @@ export const AuthoizationOutcomeForm: FC<props> = ({ id, type, value, leadIdenti
       return false;
     }
 
-    if (!authorized.match(/^\d{1,10}$/) && !unauthorized) {
-      setAuthorizedErrorMessage("Invalid format. Please only include numbers.");
+    if (!authorized.match(/^[\d-/]{1,20}$/) && !unauthorized) {
+      setAuthorizedErrorMessage("Invalid format. Please only include numbers and ‘-' and '/’ characters.");
       return false;
     }
 
@@ -146,7 +146,7 @@ export const AuthoizationOutcomeForm: FC<props> = ({ id, type, value, leadIdenti
               inputClass="comp-form-control"
               value={authorized}
               error={authorizedErrorMessage}
-              maxLength={10}
+              maxLength={20}
               onChange={(evt: any) => {
                 const {
                   target: { value },


### PR DESCRIPTION
This PR is to address CEEB  IPM  team request to update validation in the authorization number field. Now it accepts up to 20 characters including ‘-' and '/’ 

# Description

Please provide a summary of the change and the issue fixed. Please include relevant context. List dependency changes.

Fixes # (CE-1306)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-840-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-840-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)