### PR TITLE
chore: remove limits (cpu and memory)

### DIFF
--- a/charts/app/templates/backend/templates/deployment.yaml
+++ b/charts/app/templates/backend/templates/deployment.yaml
@@ -46,9 +46,6 @@ spec:
             - name: FLYWAY_LOCATIONS
               value: "{{- if eq .Release.Namespace "c1c7ed-dev" -}}{{ .Values.global.secrets.flywayLocations.dev }}{{- else if eq .Release.Namespace "c1c7ed-test" -}}{{ .Values.global.secrets.flywayLocations.test }}{{- else if eq .Release.Namespace "c1c7ed-prod" -}}{{ .Values.global.secrets.flywayLocations.prod }}{{- else -}}filesystem:./flyway/sql{{- end }}"
           resources:
-            limits:
-              cpu: 200m
-              memory: 200Mi
             requests:
               cpu: 50m
               memory: 100Mi
@@ -93,9 +90,6 @@ spec:
             periodSeconds: 30
             timeoutSeconds: 5
           resources: # this is optional
-            limits:
-              cpu: 450m
-              memory: 150Mi
             requests:
               cpu: 50m
               memory: 75Mi

--- a/charts/app/templates/frontend/templates/deployment.yaml
+++ b/charts/app/templates/frontend/templates/deployment.yaml
@@ -91,9 +91,6 @@ spec:
             periodSeconds: 30
             timeoutSeconds: 5
           resources:
-            limits:
-              cpu: 100m
-              memory: 150Mi
             requests:
               cpu: 30m
               memory: 50Mi

--- a/charts/app/templates/webeoc/templates/deployment.yaml
+++ b/charts/app/templates/webeoc/templates/deployment.yaml
@@ -75,10 +75,6 @@ spec:
             periodSeconds: 30
             timeoutSeconds: 5
           resources: # this is optional
-            limits:
-              ephemeral-storage: "25Mi"
-              cpu: 80m
-              memory: 150Mi
             requests:
               ephemeral-storage: "15Mi"
               cpu: 40m

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -101,9 +101,6 @@ backend:
       - prod/api-2
     #-- resources specific to vault initContainer. it is optional and is an object.
     resources:
-      limits:
-        cpu: 50m
-        memory: 50Mi
       requests:
         cpu: 50m
         memory: 25Mi
@@ -180,16 +177,10 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
     requests:
       cpu: 25m
       memory: 256Mi
-    limits:
-      cpu: 100m
-      memory: 512Mi
     replicaCertCopy:
       requests:
         cpu: 1m
         memory: 32Mi
-      limits:
-        cpu: 50m
-        memory: 64Mi
 
   pgBackRest:
     enabled: false
@@ -210,16 +201,10 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
       requests:
         cpu: 1m
         memory: 64Mi
-      limits:
-        cpu: 50m
-        memory: 128Mi
     sidecars:
       requests:
         cpu: 1m
         memory: 64Mi
-      limits:
-        cpu: 50m
-        memory: 128Mi
 
   patroni:
     postgresql:
@@ -238,9 +223,6 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
       requests:
         cpu: 1m
         memory: 64Mi
-      limits:
-        cpu: 50m
-        memory: 128Mi
 
   # Postgres Cluster resource values:
   pgmonitor:
@@ -250,9 +232,6 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
       requests:
         cpu: 1m
         memory: 64Mi
-      limits:
-        cpu: 50m
-        memory: 128Mi
 
 bitnami-pg:
   enabled: true
@@ -294,9 +273,6 @@ bitnami-pg:
       requests:
         cpu: 100m
         memory: 250Mi
-      limits:
-        cpu: 200m
-        memory: 500Mi
 
 backup:
   enabled: false # save quota in dev environment, see gha for override
@@ -324,9 +300,6 @@ backup:
   failedHistoryLimit: 2 # "The number of failed jobs that will be retained"
   backoffLimit: 0 # "The number of attempts to try for a successful job outcome"
   resources:
-    limits:
-      cpu: 150m
-      memory: 256Mi
     requests:
       cpu: 10m
       memory: 128Mi
@@ -339,9 +312,6 @@ nats:
       requests:
         cpu: 100m
         memory: 100Mi
-      limits:
-        cpu: 200m
-        memory: 400Mi
     jetstream:
       enabled: true
       fileStore:
@@ -366,9 +336,6 @@ nats:
         requests:
           cpu: 100m
           memory: 100Mi
-        limits:
-          cpu: 200m
-          memory: 400Mi
 
 #-- WebEOC Container
 webeoc:
@@ -416,9 +383,6 @@ metabase:
     port: 80
     targetPort: 3000
   resources:
-    limits:
-      cpu: 750m
-      memory: 1250Mi
     requests:
       cpu: 150m
       memory: 500Mi
@@ -472,7 +436,4 @@ metabase-pg:
       requests:
         cpu: 100m
         memory: 250Mi
-      limits:
-        cpu: 200m
-        memory: 500Mi
 #-- End Metabase Values

--- a/database/openshift.deploy.yml
+++ b/database/openshift.deploy.yml
@@ -103,8 +103,6 @@ objects:
         requests:
           storage: ${DB_PVC_SIZE}
           cpu: "50m"
-        limits:
-          cpu: "100m"
       storageClassName: netapp-file-standard
   - kind: ImageStream
     apiVersion: v1
@@ -168,9 +166,6 @@ objects:
                 requests:
                   cpu: ${CPU_REQUEST}
                   memory: ${MEMORY_REQUEST}
-                limits:
-                  cpu: ${CPU_LIMIT}
-                  memory: ${MEMORY_LIMIT}
               readinessProbe:
                 exec:
                   command:

--- a/webeoc/src/publishers/actions-taken-publisher.service.ts
+++ b/webeoc/src/publishers/actions-taken-publisher.service.ts
@@ -17,6 +17,7 @@ export class ActionsTakenPublisherService {
   private async initializeNATS() {
     const nc = await connect({
       servers: [process.env.NATS_HOST],
+      waitOnFirstConnect: true,
     });
     this.jsClient = nc.jetstream();
   }

--- a/webeoc/src/publishers/complaints-publisher.service.ts
+++ b/webeoc/src/publishers/complaints-publisher.service.ts
@@ -16,6 +16,7 @@ export class ComplaintsPublisherService {
   private async initializeNATS() {
     const nc = await connect({
       servers: [process.env.NATS_HOST],
+      waitOnFirstConnect: true,
     });
     this.jsClient = nc.jetstream();
   }

--- a/webeoc/src/subscribers/actions-taken-subscriber.service.ts
+++ b/webeoc/src/subscribers/actions-taken-subscriber.service.ts
@@ -19,7 +19,7 @@ export class ActionsTakenSubscriberService implements OnModuleInit {
 
   async onModuleInit() {
     try {
-      this.natsConnection = await connect({ servers: process.env.NATS_HOST });
+      this.natsConnection = await connect({ servers: process.env.NATS_HOST, waitOnFirstConnect: true });
       this.jsm = await this.natsConnection.jetstreamManager();
       await this.setupStream();
       await this.subscribeToTopics();

--- a/webeoc/src/subscribers/complaints-subscriber.service.ts
+++ b/webeoc/src/subscribers/complaints-subscriber.service.ts
@@ -19,7 +19,7 @@ export class ComplaintsSubscriberService implements OnModuleInit {
 
   async onModuleInit() {
     try {
-      this.natsConnection = await connect({ servers: process.env.NATS_HOST });
+      this.natsConnection = await connect({ servers: process.env.NATS_HOST, waitOnFirstConnect: true });
       this.jsm = await this.natsConnection.jetstreamManager();
       await this.setupStream();
       await this.subscribeToTopics();


### PR DESCRIPTION
Dear OpenShift Project Teams,
We’re excited to share that as of this morning, December 10, 2024, we’ve made updates to the Quota section to enhance its flexibility and usability:
Removal of Resource Limits - The concept of limit has been removed. OpenShift now uses only request values configured by the OpenShift Provisioner.
What this means: Resource requests configured for a namespace are always guaranteed, while additional resources are only available when node capacity allows.
Why limits were removed: Setting CPU limits on Kubernetes can lead to inefficiencies and CPU throttling, even when additional resources are available. By relying on requests, we ensure that resources are reserved for critical workloads without unnecessary constraints, enabling optimal resource utilization and preventing CPU starvation.
Enhanced Numeric Input Options
To provide greater flexibility, the UI now features numeric inputs instead of dropdowns, enabling more precise resource allocation:
CPU: Adjustable from 0 to 64 cores in 0.5-core increments.
Memory: Adjustable from 0 to 128 GB in 1 GB increments.
Storage: Adjustable from 0 to 512 GB in 1 GB increments.

If you have any concerns or questions, please reach out to us via [platformservicesteam@gov.bc.ca](mailto:platformservicesteam@gov.bc.ca).

Regards,
Platform Services Team

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-842-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-842-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)