### PR TITLE
chore: CE-1354 Add new roles to list in edit user

### DIFF
--- a/frontend/src/app/constants/ceeb-roles.ts
+++ b/frontend/src/app/constants/ceeb-roles.ts
@@ -7,6 +7,8 @@ export const ROLE_OPTIONS: Array<Option> = [
   { value: "COS Officer", label: "COS Officer" },
   { value: "COS Administrator", label: "COS Administrator" },
   { value: "READ ONLY", label: "Read Only" },
+  { value: "Inspector", label: "Inspector" },
+  { value: "Province-wide", label: "Province-wide" },
 ];
 
 export const CEEB_ROLE_OPTIONS: Array<Option> = [
@@ -14,10 +16,13 @@ export const CEEB_ROLE_OPTIONS: Array<Option> = [
   { value: "CEEB Section Head", label: "Section Head" },
   { value: "CEEB Compliance Coordinator", label: "Compliance Coordinator" },
   { value: "READ ONLY", label: "Read Only" },
+  { value: "Province-wide", label: "Province-wide" },
 ];
 
 export const COS_ROLE_OPTIONS: Array<Option> = [
   { value: "COS Officer", label: "COS Officer" },
   { value: "COS Administrator", label: "COS Administrator" },
   { value: "READ ONLY", label: "Read Only" },
+  { value: "Inspector", label: "Inspector" },
+  { value: "Province-wide", label: "Province-wide" },
 ];


### PR DESCRIPTION
# Description

Added the new roles Inspector and Province-wide to the list of roles used by the edit users page.

Fixes # (issue)

# How Has This Been Tested?

Verified that both Inspector and Province-wide are available in the dropdown menu when editing a users roles.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-859-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-859-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)