### PR TITLE
fix: CE-1360 Hide inactive HWCR Nature of Complaint options

### DIFF
--- a/frontend/src/app/components/common/comp-select.tsx
+++ b/frontend/src/app/components/common/comp-select.tsx
@@ -16,6 +16,7 @@ type Props = {
   onChange?: (selectedOption: Option | null) => void;
   isDisabled?: boolean;
   isClearable?: boolean;
+  showInactive?: boolean;
 };
 
 export const CompSelect: FC<Props> = ({
@@ -32,13 +33,17 @@ export const CompSelect: FC<Props> = ({
   errorMessage,
   isDisabled,
   isClearable,
+  showInactive = true,
 }) => {
   let styles: StylesConfig = {};
 
   let items: Option[] = [];
 
   if (options) {
-    items = [...options];
+    items = [...options.filter((o) => (showInactive ? true : o.isActive))];
+    if (value && !items.find((o) => o.value === value.value)) {
+      items.push(value);
+    }
   }
 
   // If "none" is an option, lighten the colour a bit so that it doesn't appear the same as the other selectable options

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-create.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-create.tsx
@@ -740,6 +740,7 @@ export const CreateComplaint: FC = () => {
                     onChange={(e) => handleNatureOfComplaintChange(e)}
                     className="comp-details-input"
                     options={hwcrNatureOfComplaintCodes}
+                    showInactive={false}
                     placeholder="Select"
                     enableValidation={true}
                     errorMessage={natureOfComplaintErrorMsg}

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
@@ -868,6 +868,7 @@ export const ComplaintDetailsEdit: FC = () => {
                       onChange={(e) => handleNatureOfComplaintChange(e)}
                       className="comp-details-input full-width"
                       options={hwcrNatureOfComplaintCodes}
+                      showInactive={false}
                       defaultOption={selectedNatureOfComplaint}
                       placeholder="Select"
                       enableValidation={true}

--- a/frontend/src/app/store/reducers/code-table.ts
+++ b/frontend/src/app/store/reducers/code-table.ts
@@ -898,8 +898,8 @@ export const selectHwcrNatureOfComplaintCodeDropdown = (state: RootState): Array
     codeTables: { "nature-of-complaint": natureOfComplaints },
   } = state;
 
-  const data = natureOfComplaints.map(({ natureOfComplaint, longDescription }) => {
-    const item: Option = { label: longDescription, value: natureOfComplaint };
+  const data = natureOfComplaints.map(({ natureOfComplaint, longDescription, isActive }) => {
+    const item: Option = { label: longDescription, value: natureOfComplaint, isActive };
     return item;
   });
   return data;

--- a/frontend/src/app/types/app/option.ts
+++ b/frontend/src/app/types/app/option.ts
@@ -1,4 +1,5 @@
 export default interface Option {
   value: string | undefined;
   label: string | undefined;
+  isActive?: boolean;
 }

--- a/migrations/migrations/V0.35.3__CE-1360.sql
+++ b/migrations/migrations/V0.35.3__CE-1360.sql
@@ -1,0 +1,1 @@
+UPDATE hwcr_complaint_nature_code set active_ind = false WHERE hwcr_complaint_nature_code = 'COUGARN';

--- a/migrations/migrations/V0.35.3__CE-1360.sql
+++ b/migrations/migrations/V0.35.3__CE-1360.sql
@@ -1,1 +1,4 @@
 UPDATE hwcr_complaint_nature_code set active_ind = false WHERE hwcr_complaint_nature_code = 'COUGARN';
+UPDATE configuration 
+SET    configuration_value = configuration_value::int + 1
+WHERE  configuration_code = 'CDTABLEVER';


### PR DESCRIPTION
# Description

https://env-ceds.atlassian.net/browse/CE-1360

Hides inactive HWCR Nature of Complaint options by adding an optional behaviour to the comp-select component.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Do dropdown select components still function as expected
- [ ] Are the options described in CE-1360 unavailable to select
- [ ] (Ideally) does a complaint that previously had an inactivated option still function as expected (viewing / editing)


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-889-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-889-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)