### PR TITLE
feat: Add GIR outcome report with additional notes

### DIFF
--- a/frontend/cypress/e2e/general_incident-details.cy.ts
+++ b/frontend/cypress/e2e/general_incident-details.cy.ts
@@ -69,7 +69,7 @@ describe("COMPENF-37 Display ECR Details", () => {
     cy.get(".comp-nav-item-name-inverted > a").should("have.css", "color").should("include", "rgb(255, 255, 255)");
   });
 
-  it.only("allows users to add additional notes", function () {
+  it("allows users to add additional notes", function () {
     cy.navigateToDetailsScreen(COMPLAINT_TYPES.GIR, "23-900001", true);
 
     cy.get("#outcome-report-add-note").click({ force: true });

--- a/frontend/cypress/e2e/general_incident-details.cy.ts
+++ b/frontend/cypress/e2e/general_incident-details.cy.ts
@@ -68,4 +68,18 @@ describe("COMPENF-37 Display ECR Details", () => {
     cy.get(".comp-nav-item-name-inverted > a").should("have.css", "text-decoration").should("include", "underline");
     cy.get(".comp-nav-item-name-inverted > a").should("have.css", "color").should("include", "rgb(255, 255, 255)");
   });
+
+  it.only("allows users to add additional notes", function () {
+    cy.navigateToDetailsScreen(COMPLAINT_TYPES.GIR, "23-900001", true);
+
+    cy.get("#outcome-report-add-note").click({ force: true });
+    cy.get("#supporting-notes-textarea-id").click({ force: true }).clear().type("A");
+    cy.get("#supporting-notes-save-button").click({ force: true });
+    cy.waitForSpinner();
+    cy.get("#additional-notes-text").should("have.text", "A");
+    cy.get("#notes-delete-button").click({ force: true });
+    cy.get("#confirm-delete-note-button").click({ force: true });
+    cy.waitForSpinner();
+    cy.get("#outcome-report-add-note").should("exist");
+  });
 });

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
@@ -76,6 +76,7 @@ import { LinkedComplaintList } from "./linked-complaint-list";
 import { CompCoordinateInput } from "@components/common/comp-coordinate-input";
 import { ExternalFileReference } from "@components/containers/complaints/outcomes/external-file-reference";
 import { getCaseFile } from "@/app/store/reducers/case-thunks";
+import { GIROutcomeReport } from "@/app/components/containers/complaints/outcomes/gir-outcome-report";
 
 export type ComplaintParams = {
   id: string;
@@ -1404,6 +1405,8 @@ export const ComplaintDetailsEdit: FC = () => {
           <ExternalFileReference />
         </FeatureFlag>
       )}
+
+      {readOnly && complaintType === COMPLAINT_TYPES.GIR && <GIROutcomeReport />}
     </div>
   );
 };

--- a/frontend/src/app/components/containers/complaints/outcomes/gir-outcome-report.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/gir-outcome-report.tsx
@@ -1,0 +1,14 @@
+import { FC } from "react";
+import { SupplementalNote } from "./supplemental-note";
+
+export const GIROutcomeReport: FC = () => {
+  return (
+    <section className="comp-details-body comp-container comp-gir-outcome-report">
+      <hr className="comp-details-body-spacer"></hr>
+      <div className="comp-details-section-header">
+        <h2>Outcome report</h2>
+      </div>
+      <SupplementalNote />
+    </section>
+  );
+};

--- a/frontend/src/app/components/containers/complaints/outcomes/supplemental-notes/supplemental-notes-item.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/supplemental-notes/supplemental-notes-item.tsx
@@ -52,7 +52,7 @@ export const SupplementalNotesItem: FC<props> = ({ notes, action, enableEditMode
               <div>
                 <dt>Notes</dt>
                 <dd>
-                  <pre>{notes}</pre>
+                  <pre id="additional-notes-text">{notes}</pre>
                 </dd>
               </div>
               <div>

--- a/frontend/src/app/components/modal/instances/delete-note-modal.tsx
+++ b/frontend/src/app/components/modal/instances/delete-note-modal.tsx
@@ -45,7 +45,12 @@ export const DeleteNoteModal: FC<props> = ({ close, submit }) => {
         >
           {cancel}
         </Button>
-        <Button onClick={() => handleSubmit()}>{ok}</Button>
+        <Button
+          id="confirm-delete-note-button"
+          onClick={() => handleSubmit()}
+        >
+          {ok}
+        </Button>
       </Modal.Footer>
     </>
   );


### PR DESCRIPTION
Add additional notes section to GIR

# Description

GIR complaints have been given an outcome report allowing users to add additional notes. Doing so will  open a case in CM.

Fixes # 1138
https://env-ceds.atlassian.net/jira/software/c/projects/CE/boards/4?selectedIssue=CE-1138

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Manually tested and verified data in CM
- [ ] Test scenario added to GIR Cypress test to add and delete notes from GIR complaint


## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Further comments
Sibling branch in CM: https://github.com/bcgov/nr-compliance-enforcement-cm/pull/119

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-897-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-897-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)