### PR TITLE
fix: CE-1383 Change WebEOC Jan 1 Behavior

### DIFF
--- a/frontend/cypress/e2e/complaint-export.cy.ts
+++ b/frontend/cypress/e2e/complaint-export.cy.ts
@@ -21,16 +21,21 @@ describe("Export Complaint Functionality", () => {
     it(`Can export complaint: ${index === 0 ? "HWCR" : "ERS"}`, () => {
       let fileName = "";
 
-      const date = fns.format(new Date(), "yyMMdd");
-
       if ("#hwcr-tab".includes(complaintTypes[index])) {
-        fileName = `HWC_23-000076_${date}.pdf`;
         cy.navigateToDetailsScreen(COMPLAINT_TYPES.HWCR, "23-000076", true);
+        const date = cy.get("div#complaint-date-logged");
+        date.invoke("text").then((dateText) => {
+          const formattedDate = fns.format(new Date(dateText), "yyMMdd");
+          fileName = `HWC_23-000076_${formattedDate}.pdf`;
+        });
       } else {
-        fileName = `EC_23-006888_${date}.pdf`;
         cy.navigateToDetailsScreen(COMPLAINT_TYPES.ERS, "23-006888", true);
+        const date = cy.get("div#complaint-date-logged");
+        date.invoke("text").then((dateText) => {
+          const formattedDate = fns.format(new Date(dateText), "yyMMdd");
+          fileName = `EC_23-006888_${formattedDate}.pdf`;
+        });
       }
-
       cy.get("#details-screen-export-complaint-button").click({ force: true });
       cy.verifyDownload(fileName, { timeout: 10000 });
     });

--- a/frontend/src/app/components/containers/complaints/details/complaint-header.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-header.tsx
@@ -295,7 +295,7 @@ export const ComplaintHeader: FC<ComplaintHeaderProps> = ({
               <dl className="comp-details-date-logged">
                 <dt>Date logged</dt>
                 <dd className="comp-date-time-value">
-                  <div>
+                  <div id="complaint-date-logged">
                     <i className="bi bi-calendar"></i>
                     {formatDate(loggedDate)}
                   </div>

--- a/webeoc/src/webeoc-scheduler/webeoc-scheduler.service.ts
+++ b/webeoc/src/webeoc-scheduler/webeoc-scheduler.service.ts
@@ -243,7 +243,7 @@ export class WebEocScheduler {
           complaint.flag_COS === "Yes" ||
           complaint.violation_type === "Waste" ||
           complaint.violation_type === "Pesticide"
-        ) || (complaint.flag_COS !== "Yes" && Date.parse(`${complaint.incident_datetime} PST`) > Date.parse(process.env.WEBEOC_DATE_FILTER))); // 2025-01-01T08:00:00Z is midnight PST
+        ) || (complaint.flag_COS !== "Yes" && Date.parse(`${complaint.created_by_datetime} PST`) > Date.parse(process.env.WEBEOC_DATE_FILTER))); // 2025-01-01T08:00:00Z is midnight PST
       } else {
         return true;
       }


### PR DESCRIPTION
Changes WebEOC logic to import based on created date not logged date.

https://env-ceds.atlassian.net/browse/CE-1383



---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-904-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-904-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)