### PR TITLE
feat: Mandatory Field Indicators for Outcome Report Sections

### DIFF
--- a/frontend/src/app/components/common/comp-coordinate-input.tsx
+++ b/frontend/src/app/components/common/comp-coordinate-input.tsx
@@ -16,6 +16,7 @@ type Props = {
   sourceXCoordinate?: string;
   sourceYCoordinate?: string;
   enableCopyCoordinates: boolean;
+  validationRequired: boolean;
 };
 
 const COORDINATE_TYPES = {
@@ -33,6 +34,7 @@ export const CompCoordinateInput: FC<Props> = ({
   syncCoordinates,
   throwError,
   enableCopyCoordinates,
+  validationRequired,
 }) => {
   const [coordinateType, setCoordinateType] = useState(COORDINATE_TYPES.LatLong);
   const [xCoordinate, setXCoordinate] = useState<string | undefined>("");
@@ -283,7 +285,12 @@ export const CompCoordinateInput: FC<Props> = ({
       className="comp-details-form-row"
       id={id}
     >
-      <label htmlFor="coordinate-type-radio-group">Coordinates</label>
+      <label
+        className={validationRequired ? "validation-group-label" : ""}
+        htmlFor="coordinate-type-radio-group"
+      >
+        Coordinates
+      </label>
       <div
         id="coordinate-input-div"
         className="comp-details-input full-width"
@@ -299,7 +306,11 @@ export const CompCoordinateInput: FC<Props> = ({
               enableValidation={true}
               errorMessage=""
               itemClassName="comp-radio-btn"
-              groupClassName="comp-coordinate-type-radio-group"
+              groupClassName={
+                validationRequired
+                  ? "comp-coordinate-type-radio-group validation-group-sub-label"
+                  : "comp-coordinate-type-radio-group"
+              }
               value={coordinateType}
               onChange={(option: any) => handleChangeCoordinateType(option.target.value)}
               isDisabled={false}
@@ -315,7 +326,11 @@ export const CompCoordinateInput: FC<Props> = ({
                 aria-label="Latitude"
                 type="text"
                 id="input-y-coordinate"
-                className={yCoordinateErrorMsg ? "comp-form-control error-border" : "comp-form-control"}
+                className={`
+                  comp-form-control
+                  ${yCoordinateErrorMsg ? "error-border" : ""}
+                  ${validationRequired ? "validation-group-input" : ""}
+                `}
                 onChange={(evt: any) => handleGeoPointChange(evt.target.value, xCoordinate ?? "")}
                 value={yCoordinate ?? ""}
                 maxLength={120}
@@ -334,7 +349,11 @@ export const CompCoordinateInput: FC<Props> = ({
                 aria-label="Longitude"
                 type="text"
                 id="input-x-coordinate"
-                className={xCoordinateErrorMsg ? "comp-form-control error-border" : "comp-form-control"}
+                className={`
+                  comp-form-control
+                  ${xCoordinateErrorMsg ? "error-border" : ""}
+                  ${validationRequired ? "validation-group-input" : ""}
+                `}
                 onChange={(evt: any) => handleGeoPointChange(yCoordinate ?? "", evt.target.value)}
                 value={xCoordinate ?? ""}
                 maxLength={120}
@@ -420,7 +439,10 @@ export const CompCoordinateInput: FC<Props> = ({
           <Button
             variant="outline-primary"
             size="sm"
-            className="btn-txt svg-icon mt-2"
+            className={`
+              btn-txt svg-icon mt-2
+              ${validationRequired ? "validation-group-sub-label" : ""}
+            `}
             id="copy-coordinates-button"
             onClick={() => {
               if (coordinateType === COORDINATE_TYPES.LatLong) {

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-create.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-create.tsx
@@ -916,6 +916,7 @@ export const CreateComplaint: FC = () => {
             syncCoordinates={syncCoordinates}
             throwError={throwError}
             enableCopyCoordinates={false}
+            validationRequired={false}
           />
 
           <div

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
@@ -1070,6 +1070,7 @@ export const ComplaintDetailsEdit: FC = () => {
                 syncCoordinates={syncCoordinates}
                 throwError={throwError}
                 enableCopyCoordinates={false}
+                validationRequired={false}
               />
               <div
                 className="comp-details-form-row"

--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-complaint-assessment.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-complaint-assessment.tsx
@@ -589,7 +589,7 @@ export const HWCRComplaintAssessment: FC<Props> = ({
                 id="action-required-div"
               >
                 <label htmlFor="action-required">
-                  Action required?<span className="required-ind">*</span>
+                  Action required? {!quickClose && <span className="required-ind">*</span>}
                 </label>
                 <div className="comp-details-input full-width">
                   {quickClose ? (

--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-complaint-assessment.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-complaint-assessment.tsx
@@ -588,7 +588,9 @@ export const HWCRComplaintAssessment: FC<Props> = ({
                 className="comp-details-form-row"
                 id="action-required-div"
               >
-                <label htmlFor="action-required">Action required?</label>
+                <label htmlFor="action-required">
+                  Action required?<span className="required-ind">*</span>
+                </label>
                 <div className="comp-details-input full-width">
                   {quickClose ? (
                     <span>{selectedActionRequired?.value}</span>
@@ -612,7 +614,9 @@ export const HWCRComplaintAssessment: FC<Props> = ({
                 className={`comp-details-form-row ${justificationEditClass}`}
                 id="justification-div"
               >
-                <label htmlFor="justification">Justification</label>
+                <label htmlFor="justification">
+                  Justification<span className="required-ind">*</span>
+                </label>
                 <div className="comp-details-input full-width">
                   <CompSelect
                     id="justification"
@@ -649,7 +653,9 @@ export const HWCRComplaintAssessment: FC<Props> = ({
                   className="comp-details-form-row"
                   id="linked-complaint-div"
                 >
-                  <label htmlFor="linkedComplaint">Link current complaint to:</label>
+                  <label htmlFor="linkedComplaint">
+                    Link current complaint to:<span className="required-ind">*</span>
+                  </label>
                   <div className="comp-details-input full-width">
                     <HWCRComplaintAssessmentLinkComplaintSearch
                       id="linkedComplaint"
@@ -666,7 +672,9 @@ export const HWCRComplaintAssessment: FC<Props> = ({
                 className={assessmentDivClass}
                 id="assessment-contacted-complainant-div"
               >
-                <label htmlFor="assessment-contacted-complainant-div">Contacted complainant</label>
+                <label htmlFor="assessment-contacted-complainant-div">
+                  Contacted complainant<span className="required-ind">*</span>
+                </label>
                 <div className="comp-details-input full-width">
                   <CompRadioGroup
                     id="assessment-contacted-complainant-radiogroup"
@@ -687,7 +695,9 @@ export const HWCRComplaintAssessment: FC<Props> = ({
                 className={assessmentDivClass}
                 id="assessment-attended-div"
               >
-                <label htmlFor="assessment-attended-div">Attended</label>
+                <label htmlFor="assessment-attended-div">
+                  Attended<span className="required-ind">*</span>
+                </label>
                 <div className="comp-details-input full-width">
                   <CompRadioGroup
                     id="assessment-attended-radiogroup"
@@ -710,7 +720,9 @@ export const HWCRComplaintAssessment: FC<Props> = ({
               >
                 <div className="muliline-label">
                   <div>
-                    <div>Animal actions</div>
+                    <div>
+                      Animal actions<span className="required-ind">*</span>
+                    </div>
                     <div>(Select all applicable boxes)</div>
                   </div>
                 </div>
@@ -743,7 +755,7 @@ export const HWCRComplaintAssessment: FC<Props> = ({
                       className="mb-2"
                       htmlFor="select-location-type"
                     >
-                      Location type
+                      Location type<span className="required-ind">*</span>
                     </label>
                     <CompSelect
                       id="select-location-type"
@@ -817,7 +829,9 @@ export const HWCRComplaintAssessment: FC<Props> = ({
                 className="comp-details-form-row"
                 id="outcome-officer-div"
               >
-                <label htmlFor="outcome-officer">Officer</label>
+                <label htmlFor="outcome-officer">
+                  Officer<span className="required-ind">*</span>
+                </label>
                 <div className="comp-details-input full-width">
                   <CompSelect
                     id="outcome-officer"
@@ -837,7 +851,9 @@ export const HWCRComplaintAssessment: FC<Props> = ({
                 className="comp-details-form-row"
                 id="complaint-outcome-date-div"
               >
-                <label htmlFor="complaint-outcome-date">Date</label>
+                <label htmlFor="complaint-outcome-date">
+                  Date<span className="required-ind">*</span>
+                </label>
                 <div className="comp-details-input">
                   <ValidationDatePicker
                     id="complaint-outcome-date"

--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-equipment/equipment-form.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-equipment/equipment-form.tsx
@@ -308,7 +308,9 @@ export const EquipmentForm: FC<EquipmentFormProps> = ({ equipment, assignedOffic
               className="comp-details-form-row"
               id="equipment-type-div"
             >
-              <label htmlFor="equipment-type-select">Equipment type</label>
+              <label htmlFor="equipment-type-select">
+                Equipment type<span className="required-ind">*</span>
+              </label>
               <div className="comp-details-input full-width">
                 <CompSelect
                   id="equipment-type-select"
@@ -326,6 +328,14 @@ export const EquipmentForm: FC<EquipmentFormProps> = ({ equipment, assignedOffic
             </div>
 
             {/* ADDRESS */}
+            <div
+              id="equipment-address-coordinates-header"
+              className="comp-details-form-row"
+            >
+              <label htmlFor="equipment-address">
+                Location (Address or Coordinates)<span className="required-ind">*</span>
+              </label>
+            </div>
             <div
               id="equipment-address-div"
               className="comp-details-form-row"
@@ -386,7 +396,9 @@ export const EquipmentForm: FC<EquipmentFormProps> = ({ equipment, assignedOffic
               className="comp-details-form-row"
               id="equipment-officer-set-div"
             >
-              <label htmlFor="equipment-officer-set-select">Set/used by</label>
+              <label htmlFor="equipment-officer-set-select">
+                Set/used by<span className="required-ind">*</span>
+              </label>
               <div className="comp-details-input full-width">
                 <CompSelect
                   id="equipment-officer-set-select"
@@ -406,7 +418,9 @@ export const EquipmentForm: FC<EquipmentFormProps> = ({ equipment, assignedOffic
               className="comp-details-form-row"
               id="equipment-date-set-div"
             >
-              <label htmlFor="equipment-day-set">Set/used date</label>
+              <label htmlFor="equipment-day-set">
+                Set/used date<span className="required-ind">*</span>
+              </label>
               <div className="comp-details-input">
                 <ValidationDatePicker
                   id="equipment-day-set"
@@ -470,7 +484,9 @@ export const EquipmentForm: FC<EquipmentFormProps> = ({ equipment, assignedOffic
                 className="comp-details-form-row"
                 id="reported-pair-id"
               >
-                <label htmlFor="equipment-animal-captured-radiogroup-1">Was an animal captured?</label>
+                <label htmlFor="equipment-animal-captured-radiogroup-1">
+                  Was an animal captured?<span className="required-ind">*</span>
+                </label>
                 <div className="comp-details-input full-width">
                   {
                     <CompRadioGroup

--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-equipment/equipment-form.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-equipment/equipment-form.tsx
@@ -329,23 +329,32 @@ export const EquipmentForm: FC<EquipmentFormProps> = ({ equipment, assignedOffic
 
             {/* ADDRESS */}
             <div
-              id="equipment-address-coordinates-header"
+              id="equipment-address-coordinates-div"
               className="comp-details-form-row"
             >
               <label htmlFor="equipment-address">
-                Location (Address or Coordinates)<span className="required-ind">*</span>
+                Location info (choose one)<span className="required-ind">*</span>
               </label>
             </div>
             <div
               id="equipment-address-div"
               className="comp-details-form-row"
             >
-              <label htmlFor="equipment-address">Location/address</label>
+              <label
+                className="validation-group-label"
+                htmlFor="equipment-address"
+              >
+                Location/address
+              </label>
               <div className="comp-details-input full-width">
                 <input
                   type="text"
                   id="equipment-address"
-                  className={equipmentAddressErrorMsg ? "comp-form-control error-border" : "comp-form-control"}
+                  className={
+                    equipmentAddressErrorMsg
+                      ? "comp-form-control error-border validation-group-input"
+                      : "comp-form-control validation-group-input"
+                  }
                   onChange={(e) => setAddress(e.target.value)}
                   maxLength={120}
                   value={address}
@@ -390,6 +399,7 @@ export const EquipmentForm: FC<EquipmentFormProps> = ({ equipment, assignedOffic
               sourceXCoordinate={complaintData?.location?.coordinates[0].toString() ?? ""}
               sourceYCoordinate={complaintData?.location?.coordinates[1].toString() ?? ""}
               enableCopyCoordinates={true}
+              validationRequired={true}
             />
             {/* SET BY */}
             <div

--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-prevention-education.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-prevention-education.tsx
@@ -275,7 +275,9 @@ export const HWCRComplaintPrevention: FC = () => {
                   className="comp-details-form-row"
                   id="prev-educ-checkbox-div"
                 >
-                  <label htmlFor="checkbox-div">Actions</label>
+                  <label htmlFor="checkbox-div">
+                    Actions<span className="required-ind">*</span>
+                  </label>
                   <div className="comp-details-input full-width">
                     <ValidationCheckboxGroup
                       errMsg={preventionRequiredErrorMessage}
@@ -289,7 +291,9 @@ export const HWCRComplaintPrevention: FC = () => {
                   className="comp-details-form-row"
                   id="prev-educ-outcome-officer-div"
                 >
-                  <label htmlFor="prev-educ-outcome-officer">Officer</label>
+                  <label htmlFor="prev-educ-outcome-officer">
+                    Officer<span className="required-ind">*</span>
+                  </label>
                   <div className="comp-details-input full-width">
                     <CompSelect
                       id="prev-educ-outcome-officer"
@@ -307,7 +311,9 @@ export const HWCRComplaintPrevention: FC = () => {
                   className="comp-details-form-row"
                   id="prev-educ-outcome-date-div"
                 >
-                  <label htmlFor="prev-educ-outcome-date">Date</label>
+                  <label htmlFor="prev-educ-outcome-date">
+                    Date<span className="required-ind">*</span>
+                  </label>
                   <div className="comp-details-input">
                     <ValidationDatePicker
                       id="prev-educ-outcome-date"

--- a/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/drug-authorized-by.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/drug-authorized-by.tsx
@@ -91,7 +91,7 @@ export const DrugAuthorizedBy = forwardRef<refProps, props>((props, ref) => {
             id="officer-assigned-authorization-select-label-id"
             htmlFor="officer-assigned-authorization-select-id"
           >
-            Officer
+            Officer<span className="required-ind">*</span>
           </label>
           <div className="comp-details-input full-width">
             <CompSelect
@@ -117,7 +117,7 @@ export const DrugAuthorizedBy = forwardRef<refProps, props>((props, ref) => {
             id="drug-authorization-incident-time-label-id"
             htmlFor="drug-authorization-incident-time"
           >
-            Date
+            Date<span className="required-ind">*</span>
           </label>
           <div className="comp-details-input">
             <ValidationDatePicker

--- a/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/drug-used.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/drug-used.tsx
@@ -85,7 +85,7 @@ export const DrugUsed = forwardRef<refProps, props>((props, ref) => {
     return result;
   };
 
-   const updateModel = (property: string, value: string | Date | number | null | undefined) => {
+  const updateModel = (property: string, value: string | Date | number | null | undefined) => {
     const source = {
       id,
       vial,
@@ -164,7 +164,9 @@ export const DrugUsed = forwardRef<refProps, props>((props, ref) => {
       </Card.Header>
       <Card.Body className="pt-0">
         <div className="comp-details-form-row">
-          <label htmlFor={`vial-number-${id}`}>Vial number</label>
+          <label htmlFor={`vial-number-${id}`}>
+            Vial number<span className="required-ind">*</span>
+          </label>
           <div className="comp-details-input">
             <CompInput
               id={`vial-number-${id}`}
@@ -184,7 +186,9 @@ export const DrugUsed = forwardRef<refProps, props>((props, ref) => {
           </div>
         </div>
         <div className="comp-details-form-row">
-          <label htmlFor={`select-drug-name-${id}`}>Drug name</label>
+          <label htmlFor={`select-drug-name-${id}`}>
+            Drug name<span className="required-ind">*</span>
+          </label>
           <div className="comp-details-input full-width">
             <CompSelect
               id={`select-drug-name-${id}`}
@@ -202,7 +206,9 @@ export const DrugUsed = forwardRef<refProps, props>((props, ref) => {
         </div>
 
         <div className="comp-details-form-row">
-          <label htmlFor={`injection-method-${id}`}>Injection method</label>
+          <label htmlFor={`injection-method-${id}`}>
+            Injection method<span className="required-ind">*</span>
+          </label>
           <div className="comp-details-input full-width">
             <CompSelect
               id={`injection-method-${id}`}
@@ -219,7 +225,9 @@ export const DrugUsed = forwardRef<refProps, props>((props, ref) => {
           </div>
         </div>
         <div className="comp-details-form-row">
-          <label htmlFor={`amount-used-${id}`}>Amount used (mL)</label>
+          <label htmlFor={`amount-used-${id}`}>
+            Amount used (mL)<span className="required-ind">*</span>
+          </label>
           <div className="comp-details-input">
             <CompInput
               id={`amount-used-${id}`}

--- a/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/ear-tag.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/ear-tag.tsx
@@ -49,7 +49,9 @@ export const EarTag = forwardRef<{ isValid: Function }, props>((props, ref) => {
   return (
     <div className="comp-ear-tag">
       <div className="comp-ear-tag-form-item">
-        <label htmlFor={`comp-ear-tag-value-${id}`}>Identifier</label>
+        <label htmlFor={`comp-ear-tag-value-${id}`}>
+          Identifier<span className="required-ind">*</span>
+        </label>
         <CompInput
           id={`comp-ear-tag-value-${id}`}
           divid="comp-ear-tag-value"
@@ -70,7 +72,9 @@ export const EarTag = forwardRef<{ isValid: Function }, props>((props, ref) => {
         />
       </div>
       <div className="comp-ear-tag-form-item">
-        <label htmlFor={`comp-ear-tag-${id}`}>Side</label>
+        <label htmlFor={`comp-ear-tag-${id}`}>
+          Side<span className="required-ind">*</span>
+        </label>
         <CompSelect
           id={`comp-ear-tag-${id}`}
           classNamePrefix="comp-select"

--- a/frontend/src/app/components/containers/complaints/outcomes/supplemental-notes/supplemental-notes-input.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/supplemental-notes/supplemental-notes-input.tsx
@@ -106,7 +106,9 @@ export const SupplementalNotesInput: FC<props> = ({ id, complaintType, notes, cu
 
           <div className="comp-details-form">
             <div className="comp-details-form-row">
-              <label htmlFor="supporting-notes-textarea-id">Notes</label>
+              <label htmlFor="supporting-notes-textarea-id">
+                Notes<span className="required-ind">*</span>
+              </label>
               <div className="comp-details-input full-width">
                 <ValidationTextArea
                   className="comp-form-control"

--- a/frontend/src/assets/sass/complaint.scss
+++ b/frontend/src/assets/sass/complaint.scss
@@ -746,6 +746,11 @@
     margin-bottom: 16px;
     font-size: 14px;
   }
+
+  .section-legend-no-mb {
+    color: $gray-500;
+    font-size: 14px;
+  }
 }
 
 .comp-details-form-row {

--- a/frontend/src/assets/sass/form.scss
+++ b/frontend/src/assets/sass/form.scss
@@ -70,6 +70,23 @@
   display: none;
 }
 
+.validation-group-label {
+  padding-left: 25px;
+}
+
+@media screen and (max-width: 1024px) {
+  .validation-group-sub-label {
+    padding-left: 25px;
+  }
+}
+
+@media screen and (max-width: 1024px) {
+  .validation-group-input {
+    margin-left: 25px;
+    max-width: calc(100% - 25px); /* Prevent overflow by reducing the width */
+  }
+}
+
 // LAT/LONG INPUTS
 .comp-lat-long-input {
   display: grid;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Please provide a summary of the change and the issue fixed. Please include relevant context. List dependency changes.

- Any field that is required for the outcome report section to saved is marked with an Asterisk
- There are two cases where special handling was required:
     - On the quick close modal 'Action Required?' does not have an indicator as it is forced to be 'No'
     - On the equipment section either Location/address or Coordinates are required so a title has been added and the labels are indented.   On smaller screens where the labels/inputs stack the inputs are also indented.

Fixes # CE-1270

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Tested all sections


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-910-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-910-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)