### PR TITLE
chore: CE-1400

### DIFF
--- a/frontend/src/app/components/common/comp-coordinate-input.tsx
+++ b/frontend/src/app/components/common/comp-coordinate-input.tsx
@@ -410,6 +410,7 @@ export const CompCoordinateInput: FC<Props> = ({
 
             <CompSelect
               id="utm-zone-id"
+              showInactive={false}
               classNamePrefix="comp-select"
               className="comp-details-input coordinate-zone-select"
               placeholder="Zone"

--- a/frontend/src/app/components/common/comp-select.tsx
+++ b/frontend/src/app/components/common/comp-select.tsx
@@ -4,6 +4,7 @@ import Option from "@apptypes/app/option";
 
 type Props = {
   id: string;
+  showInactive: boolean;
   className?: string;
   classNames?: {};
   options?: Array<Option>;
@@ -16,11 +17,11 @@ type Props = {
   onChange?: (selectedOption: Option | null) => void;
   isDisabled?: boolean;
   isClearable?: boolean;
-  showInactive?: boolean;
 };
 
 export const CompSelect: FC<Props> = ({
   id,
+  showInactive,
   className,
   classNames,
   options,
@@ -33,14 +34,17 @@ export const CompSelect: FC<Props> = ({
   errorMessage,
   isDisabled,
   isClearable,
-  showInactive = true,
 }) => {
   let styles: StylesConfig = {};
 
   let items: Option[] = [];
 
   if (options) {
-    items = [...options.filter((o) => (showInactive ? true : o.isActive))];
+    if (options.length > 0 && !("isActive" in options[0])) {
+      items = [...options];
+    } else {
+      items = [...options.filter((o) => (showInactive ? true : o.isActive))];
+    }
     if (value && !items.find((o) => o.value === value.value)) {
       items.push(value);
     }

--- a/frontend/src/app/components/common/comp-select.tsx
+++ b/frontend/src/app/components/common/comp-select.tsx
@@ -40,6 +40,7 @@ export const CompSelect: FC<Props> = ({
   let items: Option[] = [];
 
   if (options) {
+    // If the options do not have the field isActive, then show all options
     if (options.length > 0 && !("isActive" in options[0])) {
       items = [...options];
     } else {

--- a/frontend/src/app/components/containers/admin/user-management/edit-user.tsx
+++ b/frontend/src/app/components/containers/admin/user-management/edit-user.tsx
@@ -469,6 +469,7 @@ export const EditUser: FC<EditUserProps> = ({
           <div className="comp-details-edit-input">
             <CompSelect
               id="agency-select-id"
+              showInactive={false}
               classNamePrefix="comp-select"
               onChange={(evt) => handleAgencyChange(evt)}
               classNames={{
@@ -490,6 +491,7 @@ export const EditUser: FC<EditUserProps> = ({
             {currentAgency?.value === "EPO" || selectedAgency?.value === "EPO" ? (
               <CompSelect
                 id="team-select-id"
+                showInactive={false}
                 classNamePrefix="comp-select"
                 onChange={(e) => handleTeamChange(e)}
                 classNames={{
@@ -505,6 +507,7 @@ export const EditUser: FC<EditUserProps> = ({
             ) : (
               <CompSelect
                 id="species-select-id"
+                showInactive={false}
                 classNamePrefix="comp-select"
                 onChange={(evt) => handleOfficeChange(evt)}
                 classNames={{

--- a/frontend/src/app/components/containers/admin/user-management/edit-user.tsx
+++ b/frontend/src/app/components/containers/admin/user-management/edit-user.tsx
@@ -497,6 +497,7 @@ export const EditUser: FC<EditUserProps> = ({
               {currentAgency?.value === "EPO" || selectedAgency?.value === "EPO" ? (
                 <CompSelect
                   id="team-select-id"
+                  showInactive={false}
                   classNamePrefix="comp-select"
                   onChange={(e) => handleTeamChange(e)}
                   classNames={{
@@ -512,6 +513,7 @@ export const EditUser: FC<EditUserProps> = ({
               ) : (
                 <CompSelect
                   id="species-select-id"
+                  showInactive={false}
                   classNamePrefix="comp-select"
                   onChange={(evt) => handleOfficeChange(evt)}
                   classNames={{

--- a/frontend/src/app/components/containers/admin/user-management/select-user.tsx
+++ b/frontend/src/app/components/containers/admin/user-management/select-user.tsx
@@ -74,6 +74,7 @@ export const SelectUser: FC<SelectUserProps> = ({
               <dd>
                 <CompSelect
                   id="species-select-id"
+                  showInactive={false}
                   classNamePrefix="comp-select"
                   onChange={(evt) => handleOfficerChange(evt)}
                   classNames={{

--- a/frontend/src/app/components/containers/complaints/complaint-filter.tsx
+++ b/frontend/src/app/components/containers/complaints/complaint-filter.tsx
@@ -131,6 +131,7 @@ export const ComplaintFilter: FC<Props> = ({ type }) => {
                 <div className="filter-select-padding">
                   <CompSelect
                     id="nature-of-complaint-select-id"
+                    showInactive={true}
                     classNamePrefix="comp-select"
                     onChange={(option) => {
                       setFilter("natureOfComplaint", option);
@@ -152,6 +153,7 @@ export const ComplaintFilter: FC<Props> = ({ type }) => {
                 <div className="filter-select-padding">
                   <CompSelect
                     id="species-select-id"
+                    showInactive={true}
                     classNamePrefix="comp-select"
                     onChange={(option) => {
                       setFilter("species", option);
@@ -178,6 +180,7 @@ export const ComplaintFilter: FC<Props> = ({ type }) => {
               <div className="filter-select-padding">
                 <CompSelect
                   id="violation-type-select-id"
+                  showInactive={true}
                   classNamePrefix="comp-select"
                   onChange={(option) => {
                     setFilter("violationType", option);
@@ -202,6 +205,7 @@ export const ComplaintFilter: FC<Props> = ({ type }) => {
               <div className="filter-select-padding">
                 <CompSelect
                   id="gir-type-select-id"
+                  showInactive={true}
                   classNamePrefix="comp-select"
                   onChange={(option) => {
                     setFilter("girType", option);
@@ -235,6 +239,7 @@ export const ComplaintFilter: FC<Props> = ({ type }) => {
             <div className="filter-select-padding">
               <CompSelect
                 id="status-select-id"
+                showInactive={true}
                 classNamePrefix="comp-select"
                 onChange={(option) => {
                   setFilter("status", option);
@@ -258,6 +263,7 @@ export const ComplaintFilter: FC<Props> = ({ type }) => {
             <div className="filter-select-padding">
               <CompSelect
                 id="complaint-method-select-id"
+                showInactive={true}
                 classNamePrefix="comp-select"
                 onChange={(option) => {
                   setFilter("complaintMethod", option);
@@ -281,6 +287,7 @@ export const ComplaintFilter: FC<Props> = ({ type }) => {
             <div className="filter-select-padding">
               <CompSelect
                 id="action-taken-select-id"
+                showInactive={true}
                 classNamePrefix="comp-select"
                 onChange={(option) => {
                   setFilter("actionTaken", option);
@@ -304,6 +311,7 @@ export const ComplaintFilter: FC<Props> = ({ type }) => {
             <div className="filter-select-padding">
               <CompSelect
                 id="status-select-id"
+                showInactive={true}
                 classNamePrefix="comp-select"
                 onChange={(option) => {
                   setFilter("outcomeAnimal", option);
@@ -347,6 +355,7 @@ export const ComplaintFilter: FC<Props> = ({ type }) => {
               <div className="filter-select-padding">
                 <CompSelect
                   id="region-select-filter-id"
+                  showInactive={true}
                   classNamePrefix="comp-select"
                   onChange={(option) => {
                     setFilter("region", option);
@@ -369,6 +378,7 @@ export const ComplaintFilter: FC<Props> = ({ type }) => {
               <div className="filter-select-padding">
                 <CompSelect
                   id="zone-select-id"
+                  showInactive={true}
                   classNamePrefix="comp-select"
                   onChange={(option) => {
                     setFilter("zone", option);
@@ -392,6 +402,7 @@ export const ComplaintFilter: FC<Props> = ({ type }) => {
               <div className="filter-select-padding">
                 <CompSelect
                   id="community-select-id"
+                  showInactive={true}
                   classNamePrefix="comp-select"
                   onChange={(option) => {
                     setFilter("community", option);
@@ -414,6 +425,7 @@ export const ComplaintFilter: FC<Props> = ({ type }) => {
               <div className="filter-select-padding">
                 <CompSelect
                   id="officer-select-id"
+                  showInactive={true}
                   classNamePrefix="comp-select"
                   onChange={(option) => {
                     setFilter("officer", option);

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-create.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-create.tsx
@@ -659,6 +659,7 @@ export const CreateComplaint: FC = () => {
               <div className="comp-details-edit-input">
                 <CompSelect
                   id="complaint-type-select-id"
+                  showInactive={false}
                   classNamePrefix="comp-select"
                   onChange={(e) => handleComplaintChange(e)}
                   className="comp-details-input"
@@ -684,6 +685,7 @@ export const CreateComplaint: FC = () => {
             <div className="comp-details-edit-input">
               <CompSelect
                 id="officer-assigned-select-id"
+                showInactive={false}
                 classNamePrefix="comp-select"
                 onChange={(e) => handleAssignedOfficerChange(e)}
                 className="comp-details-input"
@@ -712,6 +714,7 @@ export const CreateComplaint: FC = () => {
                 <div className="comp-details-edit-input">
                   <CompSelect
                     id="species-select-id"
+                    showInactive={false}
                     classNamePrefix="comp-select"
                     onChange={(e) => handleSpeciesChange(e)}
                     className="comp-details-input"
@@ -735,11 +738,11 @@ export const CreateComplaint: FC = () => {
                 <div className="comp-details-edit-input">
                   <CompSelect
                     id="nature-of-complaint-select-id"
+                    showInactive={false}
                     classNamePrefix="comp-select"
                     onChange={(e) => handleNatureOfComplaintChange(e)}
                     className="comp-details-input"
                     options={hwcrNatureOfComplaintCodes}
-                    showInactive={false}
                     placeholder="Select"
                     enableValidation={true}
                     errorMessage={natureOfComplaintErrorMsg}
@@ -761,6 +764,7 @@ export const CreateComplaint: FC = () => {
               <div className="comp-details-edit-input">
                 <CompSelect
                   id="violation-type-select-id"
+                  showInactive={false}
                   classNamePrefix="comp-select"
                   onChange={(e) => handleViolationTypeChange(e)}
                   className="comp-details-input"
@@ -929,6 +933,7 @@ export const CreateComplaint: FC = () => {
             <div className="comp-details-edit-input">
               <CompSelect
                 id="community-select-id"
+                showInactive={false}
                 classNamePrefix="comp-select"
                 onChange={(e) => handleCommunityChange(e)}
                 className="comp-details-input"
@@ -991,6 +996,7 @@ export const CreateComplaint: FC = () => {
             <div className="comp-details-edit-input">
               <CompSelect
                 id="complaint-received-method-select-id"
+                showInactive={false}
                 classNamePrefix="comp-select"
                 className="comp-details-input"
                 defaultOption={selectedComplaintMethodReceivedCode}
@@ -1157,6 +1163,7 @@ export const CreateComplaint: FC = () => {
             <div className="comp-details-edit-input">
               <CompSelect
                 id="reported-select-id"
+                showInactive={false}
                 classNamePrefix="comp-select"
                 className="comp-details-edit-input"
                 options={reportedByCodes}

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-create.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-create.tsx
@@ -827,6 +827,7 @@ export const CreateComplaint: FC = () => {
                   placeholder="Select"
                   enableValidation={true}
                   errorMessage={generalIncidentTypeErrorMsg}
+                  showInactive={false}
                 />
               </div>
             </div>

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
@@ -828,6 +828,7 @@ export const ComplaintDetailsEdit: FC = () => {
                 <label id="officer-assigned-select-label-id">Officer assigned</label>
                 <CompSelect
                   id="officer-assigned-select-id"
+                  showInactive={false}
                   classNamePrefix="comp-select"
                   onChange={(e) => handleAssignedOfficerChange(e)}
                   className="comp-details-input full-width"
@@ -853,6 +854,7 @@ export const ComplaintDetailsEdit: FC = () => {
                     </label>
                     <CompSelect
                       id="species-select-id"
+                      showInactive={false}
                       classNamePrefix="comp-select"
                       onChange={(e) => handleSpeciesChange(e)}
                       className="comp-details-input full-width"
@@ -872,11 +874,11 @@ export const ComplaintDetailsEdit: FC = () => {
                     </label>
                     <CompSelect
                       id="nature-of-complaint-select-id"
+                      showInactive={false}
                       classNamePrefix="comp-select"
                       onChange={(e) => handleNatureOfComplaintChange(e)}
                       className="comp-details-input full-width"
                       options={hwcrNatureOfComplaintCodes}
-                      showInactive={false}
                       defaultOption={selectedNatureOfComplaint}
                       placeholder="Select"
                       enableValidation={true}
@@ -1083,6 +1085,7 @@ export const ComplaintDetailsEdit: FC = () => {
                 <div className="comp-details-edit-input">
                   <CompSelect
                     id="community-select-id"
+                    showInactive={false}
                     classNamePrefix="comp-select"
                     onChange={(e) => handleCommunityChange(e)}
                     className="comp-details-input"
@@ -1143,6 +1146,7 @@ export const ComplaintDetailsEdit: FC = () => {
                 <div className="comp-details-edit-input">
                   <CompSelect
                     id="complaint-received-method-select-id"
+                    showInactive={false}
                     classNamePrefix="comp-select"
                     className="comp-details-input"
                     defaultOption={selectedComplaintMethodReceivedCode}
@@ -1325,6 +1329,7 @@ export const ComplaintDetailsEdit: FC = () => {
                 <div className="comp-details-edit-input">
                   <CompSelect
                     id="reported-select-id"
+                    showInactive={false}
                     classNamePrefix="comp-select"
                     className="comp-details-input"
                     defaultOption={selectedReportedByCode}

--- a/frontend/src/app/components/containers/complaints/outcomes/ceeb/ceeb-decision/decision-form.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/ceeb/ceeb-decision/decision-form.tsx
@@ -284,6 +284,7 @@ export const DecisionForm: FC<props> = ({
           <div className="comp-details-input full-width">
             <CompSelect
               id="outcome-decision-schedule-sector"
+              showInactive={false}
               className="comp-details-input"
               classNamePrefix="comp-select"
               options={schedulesOptions}
@@ -310,6 +311,7 @@ export const DecisionForm: FC<props> = ({
           <div className="comp-details-input full-width">
             <CompSelect
               id="outcome-decision-sector-category"
+              showInactive={false}
               className="comp-details-input"
               classNamePrefix="comp-select"
               options={sectorList}
@@ -334,6 +336,7 @@ export const DecisionForm: FC<props> = ({
           <div className="comp-details-input full-width">
             <CompSelect
               id="outcome-decision-discharge"
+              showInactive={false}
               className="comp-details-input"
               classNamePrefix="comp-select"
               options={dischargesOptions}
@@ -357,6 +360,7 @@ export const DecisionForm: FC<props> = ({
           <div className="comp-details-input full-width">
             <CompSelect
               id="outcome-decision-action-taken"
+              showInactive={false}
               className="comp-details-input"
               classNamePrefix="comp-select"
               options={decisionTypeOptions}
@@ -381,6 +385,7 @@ export const DecisionForm: FC<props> = ({
             <div className="comp-details-input full-width">
               <CompSelect
                 id="outcome-decision-lead-agency"
+                showInactive={false}
                 className="comp-details-input"
                 classNamePrefix="comp-select"
                 options={leadAgencyOptions}
@@ -429,6 +434,7 @@ export const DecisionForm: FC<props> = ({
           <div className="comp-details-input full-width">
             <CompSelect
               id="outcome-decision-non-compliance"
+              showInactive={false}
               className="comp-details-input"
               classNamePrefix="comp-select"
               options={nonComplianceOptions}

--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-complaint-assessment.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-complaint-assessment.tsx
@@ -617,6 +617,7 @@ export const HWCRComplaintAssessment: FC<Props> = ({
                   ) : (
                     <CompSelect
                       id="action-required"
+                      showInactive={false}
                       className="comp-details-input"
                       classNamePrefix="comp-select"
                       options={actionRequiredList}
@@ -640,6 +641,7 @@ export const HWCRComplaintAssessment: FC<Props> = ({
                 <div className="comp-details-input full-width">
                   <CompSelect
                     id="justification"
+                    showInactive={false}
                     classNamePrefix="comp-select"
                     options={justificationList}
                     enableValidation={true}
@@ -779,6 +781,7 @@ export const HWCRComplaintAssessment: FC<Props> = ({
                     </label>
                     <CompSelect
                       id="select-location-type"
+                      showInactive={false}
                       classNamePrefix="comp-select"
                       className="comp-details-input"
                       options={locationOptions}
@@ -805,6 +808,7 @@ export const HWCRComplaintAssessment: FC<Props> = ({
                     </label>
                     <CompSelect
                       id="select-conflict-history"
+                      showInactive={false}
                       classNamePrefix="comp-select"
                       className="comp-details-input"
                       options={conflictHistoryOptions}
@@ -830,6 +834,7 @@ export const HWCRComplaintAssessment: FC<Props> = ({
                     </label>
                     <CompSelect
                       id="select-category-level"
+                      showInactive={false}
                       classNamePrefix="comp-select"
                       className="comp-details-input"
                       options={threatLevelOptions}
@@ -855,6 +860,7 @@ export const HWCRComplaintAssessment: FC<Props> = ({
                 <div className="comp-details-input full-width">
                   <CompSelect
                     id="outcome-officer"
+                    showInactive={false}
                     className="comp-details-input"
                     classNamePrefix="comp-select"
                     options={assignableOfficers}

--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-equipment/equipment-form.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-equipment/equipment-form.tsx
@@ -338,6 +338,7 @@ export const EquipmentForm: FC<EquipmentFormProps> = ({ equipment, assignedOffic
               <div className="comp-details-input full-width">
                 <CompSelect
                   id="equipment-type-select"
+                  showInactive={false}
                   classNamePrefix="comp-select"
                   className="comp-details-input"
                   placeholder="Select"
@@ -460,6 +461,7 @@ export const EquipmentForm: FC<EquipmentFormProps> = ({ equipment, assignedOffic
               <div className="comp-details-input full-width">
                 <CompSelect
                   id="equipment-officer-set-select"
+                  showInactive={false}
                   classNamePrefix="comp-select"
                   placeholder="Select"
                   options={assignableOfficers}
@@ -504,6 +506,7 @@ export const EquipmentForm: FC<EquipmentFormProps> = ({ equipment, assignedOffic
                   <div className="comp-details-input full-width">
                     <CompSelect
                       id="equipment-officer-removed-select"
+                      showInactive={false}
                       classNamePrefix="comp-select"
                       placeholder="Select"
                       options={assignableOfficers}

--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-file-review.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-file-review.tsx
@@ -230,6 +230,7 @@ export const HWCRFileReview: FC = () => {
                     <div className="comp-details-input full-width">
                       <CompSelect
                         id="officer-file-review-select-id"
+                        showInactive={false}
                         classNamePrefix="comp-select"
                         isDisabled={true}
                         enableValidation={false}

--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-prevention-education.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-prevention-education.tsx
@@ -298,6 +298,7 @@ export const HWCRComplaintPrevention: FC = () => {
                   <div className="comp-details-input full-width">
                     <CompSelect
                       id="prev-educ-outcome-officer"
+                      showInactive={false}
                       classNamePrefix="comp-select"
                       options={assignableOfficers}
                       enableValidation={true}

--- a/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/create-outcome.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/create-outcome.tsx
@@ -393,6 +393,7 @@ export const CreateAnimalOutcome: FC<props> = ({
               <div className="comp-details-input full-width">
                 <CompSelect
                   id="select-species"
+                  showInactive={false}
                   classNamePrefix="comp-select"
                   className="comp-details-input"
                   options={speciesList}
@@ -410,6 +411,7 @@ export const CreateAnimalOutcome: FC<props> = ({
                 {" "}
                 <CompSelect
                   id="select-sex"
+                  showInactive={false}
                   classNamePrefix="comp-select"
                   options={sexes}
                   enableValidation={false}
@@ -425,6 +427,7 @@ export const CreateAnimalOutcome: FC<props> = ({
               <div className="comp-details-input full-width">
                 <CompSelect
                   id="select-age"
+                  showInactive={false}
                   classNamePrefix="comp-select"
                   options={ages}
                   enableValidation={false}
@@ -457,6 +460,7 @@ export const CreateAnimalOutcome: FC<props> = ({
                 <label htmlFor="select-category-level">Category level</label>
                 <CompSelect
                   id="select-category-level"
+                  showInactive={false}
                   classNamePrefix="comp-select"
                   className="comp-details-input"
                   options={threatLevels}
@@ -516,6 +520,7 @@ export const CreateAnimalOutcome: FC<props> = ({
                 <div className="comp-details-input full-width">
                   <CompSelect
                     id="select-ears"
+                    showInactive={false}
                     classNamePrefix="comp-select"
                     className="comp-details-input"
                     options={outcomes}
@@ -539,6 +544,7 @@ export const CreateAnimalOutcome: FC<props> = ({
                 <div className="comp-details-input full-width">
                   <CompSelect
                     id="officer-assigned-select-id"
+                    showInactive={false}
                     classNamePrefix="comp-select"
                     className="comp-details-input"
                     options={officers}

--- a/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/drug-authorized-by.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/drug-authorized-by.tsx
@@ -96,6 +96,7 @@ export const DrugAuthorizedBy = forwardRef<refProps, props>((props, ref) => {
           <div className="comp-details-input full-width">
             <CompSelect
               id="officer-assigned-authorization-select-id"
+              showInactive={false}
               classNamePrefix="comp-select"
               onChange={(evt) => {
                 handleOfficerChange(evt);

--- a/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/drug-used.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/drug-used.tsx
@@ -192,6 +192,7 @@ export const DrugUsed = forwardRef<refProps, props>((props, ref) => {
           <div className="comp-details-input full-width">
             <CompSelect
               id={`select-drug-name-${id}`}
+              showInactive={false}
               classNamePrefix="comp-select"
               options={drugs}
               enableValidation={true}
@@ -212,6 +213,7 @@ export const DrugUsed = forwardRef<refProps, props>((props, ref) => {
           <div className="comp-details-input full-width">
             <CompSelect
               id={`injection-method-${id}`}
+              showInactive={false}
               classNamePrefix="comp-select"
               options={drugUseMethods}
               enableValidation={true}
@@ -252,6 +254,7 @@ export const DrugUsed = forwardRef<refProps, props>((props, ref) => {
           <div className="comp-details-input full-width">
             <CompSelect
               id={`remaining-drug-use-${id}`}
+              showInactive={false}
               classNamePrefix="comp-select"
               options={remainingDrugUse}
               enableValidation={false}

--- a/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/ear-tag.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/ear-tag.tsx
@@ -77,6 +77,7 @@ export const EarTag = forwardRef<{ isValid: Function }, props>((props, ref) => {
         </label>
         <CompSelect
           id={`comp-ear-tag-${id}`}
+          showInactive={false}
           classNamePrefix="comp-select"
           className="comp-details-input comp-ear-tag-side-input"
           options={ears}

--- a/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/edit-outcome.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/oucome-by-animal/edit-outcome.tsx
@@ -421,6 +421,7 @@ export const EditOutcome: FC<props> = ({ id, index, outcome, assignedOfficer: of
 
                 <CompSelect
                   id="select-species"
+                  showInactive={false}
                   classNamePrefix="comp-select"
                   className="comp-details-input full-width"
                   options={speciesList}
@@ -435,6 +436,7 @@ export const EditOutcome: FC<props> = ({ id, index, outcome, assignedOfficer: of
                 <label htmlFor="select-sex">Sex</label>
                 <CompSelect
                   id="select-sex"
+                  showInactive={false}
                   classNamePrefix="comp-select"
                   className="comp-details-input full-width"
                   options={sexes}
@@ -450,6 +452,7 @@ export const EditOutcome: FC<props> = ({ id, index, outcome, assignedOfficer: of
                 <label htmlFor="select-age">Age</label>
                 <CompSelect
                   id="select-age"
+                  showInactive={false}
                   classNamePrefix="comp-select"
                   className="comp-details-input full-width"
                   options={ages}
@@ -483,6 +486,7 @@ export const EditOutcome: FC<props> = ({ id, index, outcome, assignedOfficer: of
                   <label htmlFor="select-category-level">Category level</label>
                   <CompSelect
                     id="select-category-level"
+                    showInactive={false}
                     classNamePrefix="comp-select"
                     className="comp-details-input full-width"
                     options={threatLevels}
@@ -536,6 +540,7 @@ export const EditOutcome: FC<props> = ({ id, index, outcome, assignedOfficer: of
                 <div className="comp-details-input full-width">
                   <CompSelect
                     id="select-ears"
+                    showInactive={false}
                     classNamePrefix="comp-select"
                     className="comp-details-input"
                     options={outcomes}
@@ -567,6 +572,7 @@ export const EditOutcome: FC<props> = ({ id, index, outcome, assignedOfficer: of
                 </label>
                 <CompSelect
                   classNamePrefix="comp-select"
+                  showInactive={false}
                   className="comp-details-input full-width"
                   id="officer-assigned-select-id"
                   options={officers}

--- a/frontend/src/app/components/containers/complaints/outcomes/supplemental-notes/supplemental-notes-input.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/supplemental-notes/supplemental-notes-input.tsx
@@ -134,6 +134,7 @@ export const SupplementalNotesInput: FC<props> = ({ id, complaintType, notes, cu
               <div className="comp-details-input full-width">
                 <CompSelect
                   id="officer-supporting-notes-select-id"
+                  showInactive={false}
                   classNamePrefix="comp-select"
                   className="comp-details-input"
                   isDisabled={true}

--- a/frontend/src/app/store/reducers/code-table.ts
+++ b/frontend/src/app/store/reducers/code-table.ts
@@ -697,8 +697,8 @@ export const selectComplaintTypeDropdown = (state: RootState): Array<Option> => 
     codeTables: { "complaint-type": complaintTypes },
   } = state;
 
-  const data = complaintTypes.map(({ complaintType, longDescription }) => {
-    const item: Option = { label: longDescription, value: complaintType };
+  const data = complaintTypes.map(({ complaintType, longDescription, isActive }) => {
+    const item: Option = { label: longDescription, value: complaintType, isActive };
     return item;
   });
   return data;
@@ -726,8 +726,8 @@ export const selectAgencyDropdown = (state: RootState): Array<Option> => {
 
   const data = agency
     .filter(({ agency }) => agency !== "PARKS") //hide PARKS option for now
-    .map(({ agency, longDescription }) => {
-      const item: Option = { label: longDescription, value: agency };
+    .map(({ agency, longDescription, isActive }) => {
+      const item: Option = { label: longDescription, value: agency, isActive };
       return item;
     });
   return data;
@@ -738,8 +738,8 @@ export const selectLeadAgencyDropdown = (state: RootState): Array<Option> => {
     codeTables: { "lead-agency": leadAgency },
   } = state;
 
-  const data = leadAgency.map(({ agency, longDescription }) => {
-    const item: Option = { label: longDescription, value: agency };
+  const data = leadAgency.map(({ agency, longDescription, isActive }) => {
+    const item: Option = { label: longDescription, value: agency, isActive };
     return item;
   });
   return data;
@@ -750,8 +750,8 @@ export const selectTeamDropdown = (state: RootState): Array<Option> => {
     codeTables: { team },
   } = state;
 
-  const data = team.map(({ team, longDescription }) => {
-    const item: Option = { label: longDescription, value: team };
+  const data = team.map(({ team, longDescription, isActive }) => {
+    const item: Option = { label: longDescription, value: team, isActive };
     return item;
   });
   return data;
@@ -762,8 +762,8 @@ export const selectReportedByDropdown = (state: RootState): Array<Option> => {
     codeTables: { "reported-by": reportedBy },
   } = state;
 
-  const data = reportedBy.map(({ reportedBy, longDescription }) => {
-    const item: Option = { label: longDescription, value: reportedBy };
+  const data = reportedBy.map(({ reportedBy, longDescription, isActive }) => {
+    const item: Option = { label: longDescription, value: reportedBy, isActive };
     return item;
   });
   return data;
@@ -778,8 +778,8 @@ export const selectComplaintStatusCodeDropdown = (state: RootState): Array<Optio
   // Filter out items where complaintStatus is "PENDREV" since it should only appear on the filter screen.
   const filteredStatus = complaintStatus.filter((status) => status.complaintStatus !== "PENDREV");
 
-  const data = filteredStatus.map(({ complaintStatus, longDescription }) => {
-    const item: Option = { label: longDescription, value: complaintStatus };
+  const data = filteredStatus.map(({ complaintStatus, longDescription, isActive }) => {
+    const item: Option = { label: longDescription, value: complaintStatus, isActive };
     return item;
   });
 
@@ -804,8 +804,8 @@ export const selectSpeciesCodeDropdown = (state: RootState): Array<Option> => {
     codeTables: { species },
   } = state;
 
-  const data = species.map(({ species, longDescription }) => {
-    const item: Option = { label: longDescription, value: species };
+  const data = species.map(({ species, longDescription, isActive }) => {
+    const item: Option = { label: longDescription, value: species, isActive };
     return item;
   });
   return data;
@@ -820,8 +820,8 @@ export const selectViolationCodeDropdown =
 
     const data = violation
       .filter(({ agencyCode }) => agencyCode === agency)
-      .map(({ violation, longDescription }) => {
-        const item: Option = { label: longDescription, value: violation };
+      .map(({ violation, longDescription, isActive }) => {
+        const item: Option = { label: longDescription, value: violation, isActive };
         return item;
       });
     return data;
@@ -832,8 +832,8 @@ export const selectGirTypeCodeDropdown = (state: RootState): Array<Option> => {
     codeTables: { "gir-type": girType },
   } = state;
 
-  const data = girType.map(({ girType, longDescription }) => {
-    const item: Option = { label: longDescription, value: girType };
+  const data = girType.map(({ girType, longDescription, isActive }) => {
+    const item: Option = { label: longDescription, value: girType, isActive };
     return item;
   });
   return data;
@@ -844,8 +844,8 @@ export const selectComplaintReceivedMethodDropdown = (state: RootState): Array<O
     codeTables: { "complaint-method-received-codes": complaintMethodReceivedType },
   } = state;
 
-  const data = complaintMethodReceivedType.map(({ complaintMethodReceivedCode, longDescription }) => {
-    const item: Option = { label: longDescription, value: complaintMethodReceivedCode };
+  const data = complaintMethodReceivedType.map(({ complaintMethodReceivedCode, longDescription, isActive }) => {
+    const item: Option = { label: longDescription, value: complaintMethodReceivedCode, isActive };
     return item;
   });
   return data;
@@ -856,8 +856,8 @@ export const selectJustificationCodeDropdown = (state: RootState): Array<Option>
     codeTables: { justification },
   } = state;
 
-  const data = justification.map(({ justification, longDescription }) => {
-    const item: Option = { label: longDescription, value: justification };
+  const data = justification.map(({ justification, longDescription, isActive }) => {
+    const item: Option = { label: longDescription, value: justification, isActive };
     return item;
   });
   return data;
@@ -868,8 +868,8 @@ export const selectAssessmentTypeCodeDropdown = (state: RootState): Array<Option
     codeTables: { "assessment-type": assessmentType },
   } = state;
 
-  const data = assessmentType.map(({ assessmentType, longDescription }) => {
-    const item: Option = { label: longDescription, value: assessmentType };
+  const data = assessmentType.map(({ assessmentType, longDescription, isActive }) => {
+    const item: Option = { label: longDescription, value: assessmentType, isActive };
     return item;
   });
   return data;
@@ -887,8 +887,8 @@ export const selectPreventionTypeCodeDropdown = (state: RootState): Array<Option
   const {
     codeTables: { "prevention-type": preventionType },
   } = state;
-  const data = preventionType.map(({ preventionType, longDescription }) => {
-    const item: Option = { label: longDescription, value: preventionType };
+  const data = preventionType.map(({ preventionType, longDescription, isActive }) => {
+    const item: Option = { label: longDescription, value: preventionType, isActive };
     return item;
   });
   return data;
@@ -924,8 +924,8 @@ export const selectAttractantCodeDropdown = (state: RootState): Array<Option> =>
     codeTables: { attractant },
   } = state;
 
-  const data = attractant.map(({ attractant, shortDescription }) => {
-    const item: Option = { label: shortDescription, value: attractant };
+  const data = attractant.map(({ attractant, shortDescription, isActive }) => {
+    const item: Option = { label: shortDescription, value: attractant, isActive };
     return item;
   });
 
@@ -1280,8 +1280,8 @@ export const selectSexDropdown = (state: RootState): Array<Option> => {
     codeTables: { sex: items },
   } = state;
 
-  const data = items.map(({ sex: value, shortDescription: label }) => {
-    const item: Option = { label, value };
+  const data = items.map(({ sex: value, shortDescription: label, isActive }) => {
+    const item: Option = { label, value, isActive };
     return item;
   });
 
@@ -1293,8 +1293,8 @@ export const selectAgeDropdown = (state: RootState): Array<Option> => {
     codeTables: { age: items },
   } = state;
 
-  const data = items.map(({ age: value, shortDescription: label }) => {
-    const item: Option = { label, value };
+  const data = items.map(({ age: value, shortDescription: label, isActive }) => {
+    const item: Option = { label, value, isActive };
     return item;
   });
 
@@ -1306,8 +1306,8 @@ export const selectThreatLevelDropdown = (state: RootState): Array<Option> => {
     codeTables: { "threat-level": items },
   } = state;
 
-  const data = items.map(({ threatLevel: value, shortDescription: label }) => {
-    const item: Option = { label, value };
+  const data = items.map(({ threatLevel: value, shortDescription: label, isActive }) => {
+    const item: Option = { label, value, isActive };
     return item;
   });
 
@@ -1319,8 +1319,8 @@ export const selectConflictHistoryDropdown = (state: RootState): Array<Option> =
     codeTables: { "conflict-history": items },
   } = state;
 
-  const data = items.map(({ conflictHistory: value, shortDescription: label }) => {
-    const item: Option = { label, value };
+  const data = items.map(({ conflictHistory: value, shortDescription: label, isActive }) => {
+    const item: Option = { label, value, isActive };
     return item;
   });
 
@@ -1332,8 +1332,8 @@ export const selectEarDropdown = (state: RootState): Array<Option> => {
     codeTables: { "ear-tag": items },
   } = state;
 
-  const data = items.map(({ earTag: value, shortDescription: label }) => {
-    const item: Option = { label, value };
+  const data = items.map(({ earTag: value, shortDescription: label, isActive }) => {
+    const item: Option = { label, value, isActive };
     return item;
   });
 
@@ -1348,6 +1348,8 @@ export const selectActiveWildlifeComplaintOutcome = (state: RootState): Array<Op
 
   let filteredItems = items.filter((item) => item.isActive === true); // Only items with active_ind = true
 
+  // isActive was left out of the options for this since the compselect component will display all options
+  // if they have no isActive field on them, so this prevents the list from getting checked twice.
   // Map the filtered and sorted items to the Option format
   const data = filteredItems.map(({ outcome: value, shortDescription: label }) => {
     const item: Option = { label, value };
@@ -1363,8 +1365,8 @@ export const selectAllWildlifeComplaintOutcome = (state: RootState): Array<Optio
     codeTables: { "wildlife-outcomes": items },
   } = state;
 
-  const data = items.map(({ outcome: value, shortDescription: label }) => {
-    const item: Option = { label, value };
+  const data = items.map(({ outcome: value, shortDescription: label, isActive }) => {
+    const item: Option = { label, value, isActive };
     return item;
   });
 
@@ -1376,8 +1378,8 @@ export const selectDrugs = (state: RootState): Array<Option> => {
     codeTables: { drugs: items },
   } = state;
 
-  const data = items.map(({ drug: value, shortDescription: label }) => {
-    const item: Option = { label, value };
+  const data = items.map(({ drug: value, shortDescription: label, isActive }) => {
+    const item: Option = { label, value, isActive };
     return item;
   });
 
@@ -1389,8 +1391,8 @@ export const selectDrugUseMethods = (state: RootState): Array<Option> => {
     codeTables: { "drug-methods": items },
   } = state;
 
-  const data = items.map(({ method: value, shortDescription: label }) => {
-    const item: Option = { label, value };
+  const data = items.map(({ method: value, shortDescription: label, isActive }) => {
+    const item: Option = { label, value, isActive };
     return item;
   });
 
@@ -1402,8 +1404,8 @@ export const selectRemainingDrugUse = (state: RootState): Array<Option> => {
     codeTables: { "drug-remaining-outcomes": items },
   } = state;
 
-  const data = items.map(({ outcome: value, shortDescription: label }) => {
-    const item: Option = { label, value };
+  const data = items.map(({ outcome: value, shortDescription: label, isActive }) => {
+    const item: Option = { label, value, isActive };
     return item;
   });
 
@@ -1427,9 +1429,10 @@ export const selectAllEquipmentDropdown = createSelector(
   (state: RootState) => state.codeTables.equipment,
   (items) => {
     // Map the filtered items to the Option format
-    return items.map(({ equipment: value, shortDescription: label }) => ({
+    return items.map(({ equipment: value, shortDescription: label, isActive }) => ({
       label,
       value,
+      isActive,
     }));
   },
 );
@@ -1439,8 +1442,8 @@ export const selectLocationDropdown = (state: RootState): Array<Option> => {
     codeTables: { "case-location-type": items },
   } = state;
 
-  const data = items.map(({ caseLocationType: value, shortDescription: label }) => {
-    const item: Option = { label, value };
+  const data = items.map(({ caseLocationType: value, shortDescription: label, isActive }) => {
+    const item: Option = { label, value, isActive };
     return item;
   });
 
@@ -1452,8 +1455,8 @@ export const selectAssessmentCat1Dropdown = (state: RootState): Array<Option> =>
     codeTables: { "assessment-cat1-type": items },
   } = state;
 
-  const data = items.map(({ assessmentType: value, shortDescription: label }) => {
-    const item: Option = { label, value };
+  const data = items.map(({ assessmentType: value, shortDescription: label, isActive }) => {
+    const item: Option = { label, value, isActive };
     return item;
   });
 


### PR DESCRIPTION
Refactor Comp Select making showInactive required.

# Description

The `showInactive` prop on CompSelect is now required. For options that don't have the `isActive` field, all options will be shown. The PR has no change on the current frontend behaviour.

Fixes # 1400
https://env-ceds.atlassian.net/jira/software/c/projects/CE/boards/4?selectedIssue=CE-1400

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ensured that all dropdowns are populated
- [ ] Checked that inactive entries are present in the filters list
- [ ] Checked that inactive entries are not present in the complaint details and creation pages
- [ ] Ensured that all dropdowns on the admin page are populated


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-935-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-935-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)