### PR TITLE
feat: Enable creating complaints for Parks users

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -54,6 +54,7 @@ import { OfficerTeamXrefModule } from "./v1/officer_team_xref/officer_team_xref.
 import { ComplaintMethodReceivedCodeModule } from "./v1/complaint_method_received_code/complaint_method_received_code.module";
 import { CompMthdRecvCdAgcyCdXrefModule } from "./v1/comp_mthd_recv_cd_agcy_cd_xref/comp_mthd_recv_cd_agcy_cd_xref.module";
 import { LinkedComplaintXrefModule } from "./v1/linked_complaint_xref/linked_complaint_xref.module";
+import { ViolationAgencyXrefModule } from "./v1/violation_agency_xref/violation_agency_xref.module";
 
 console.log("Var check - POSTGRESQL_HOST", process.env.POSTGRESQL_HOST);
 console.log("Var check - POSTGRESQL_DATABASE", process.env.POSTGRESQL_DATABASE);
@@ -130,6 +131,7 @@ if (process.env.POSTGRESQL_PASSWORD != null) {
     ComplaintMethodReceivedCodeModule,
     CompMthdRecvCdAgcyCdXrefModule,
     LinkedComplaintXrefModule,
+    ViolationAgencyXrefModule,
   ],
   controllers: [AppController],
   providers: [AppService, ComplaintSequenceResetScheduler],

--- a/backend/src/v1/agency_code/entities/agency_code.entity.ts
+++ b/backend/src/v1/agency_code/entities/agency_code.entity.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { Entity, Column, PrimaryColumn } from "typeorm";
+import { ViolationAgencyXref } from "../../violation_agency_xref/entities/violation_agency_entity_xref";
+import { Entity, Column, PrimaryColumn, OneToMany } from "typeorm";
 
 @Entity()
 export class AgencyCode {
@@ -53,6 +54,9 @@ export class AgencyCode {
   })
   @Column()
   update_utc_timestamp: Date;
+
+  @OneToMany(() => ViolationAgencyXref, (violationAgencyXref) => violationAgencyXref.agency_code)
+  violationAgencyXrefs: ViolationAgencyXref[];
 
   constructor(agency_code?: string) {
     this.agency_code = agency_code;

--- a/backend/src/v1/case_file/case_file.service.spec.ts
+++ b/backend/src/v1/case_file/case_file.service.spec.ts
@@ -43,7 +43,6 @@ import { GeoOrgUnitTypeCode } from "../geo_org_unit_type_code/entities/geo_org_u
 import { GeoOrganizationUnitCode } from "../geo_organization_unit_code/entities/geo_organization_unit_code.entity";
 import { PersonComplaintXrefCode } from "../person_complaint_xref_code/entities/person_complaint_xref_code.entity";
 import { SpeciesCode } from "../species_code/entities/species_code.entity";
-import { ViolationCode } from "../violation_code/entities/violation_code.entity";
 import { CosGeoOrgUnit } from "../cos_geo_org_unit/entities/cos_geo_org_unit.entity";
 import { ComplaintTypeCode } from "../complaint_type_code/entities/complaint_type_code.entity";
 import { ReportedByCode } from "../reported_by_code/entities/reported_by_code.entity";
@@ -77,6 +76,7 @@ import { OfficerTeamXrefService } from "../officer_team_xref/officer_team_xref.s
 import { Team } from "../team/entities/team.entity";
 import { OfficerTeamXref } from "../officer_team_xref/entities/officer_team_xref.entity";
 import { CacheModule } from "@nestjs/cache-manager";
+import { ViolationAgencyXref } from "../violation_agency_xref/entities/violation_agency_entity_xref";
 
 describe("Testing: Case File Service", () => {
   let service: CaseFileService;
@@ -146,7 +146,7 @@ describe("Testing: Case File Service", () => {
           useFactory: MockSpeciesCodeTableRepository,
         },
         {
-          provide: getRepositoryToken(ViolationCode),
+          provide: getRepositoryToken(ViolationAgencyXref),
           useFactory: MockViolationsCodeTableRepository,
         },
         {

--- a/backend/src/v1/code-table/code-table.controller.spec.ts
+++ b/backend/src/v1/code-table/code-table.controller.spec.ts
@@ -35,13 +35,13 @@ import { GeoOrgUnitTypeCode } from "../geo_org_unit_type_code/entities/geo_org_u
 import { GeoOrganizationUnitCode } from "../geo_organization_unit_code/entities/geo_organization_unit_code.entity";
 import { PersonComplaintXrefCode } from "../person_complaint_xref_code/entities/person_complaint_xref_code.entity";
 import { SpeciesCode } from "../species_code/entities/species_code.entity";
-import { ViolationCode } from "../violation_code/entities/violation_code.entity";
 import { CosGeoOrgUnit } from "../cos_geo_org_unit/entities/cos_geo_org_unit.entity";
 import { ComplaintTypeCode } from "../complaint_type_code/entities/complaint_type_code.entity";
 import { ReportedByCode } from "../reported_by_code/entities/reported_by_code.entity";
 import { GirTypeCode } from "../gir_type_code/entities/gir_type_code.entity";
 import { TeamCode } from "../team_code/entities/team_code.entity";
 import { CompMthdRecvCdAgcyCdXref } from "../comp_mthd_recv_cd_agcy_cd_xref/entities/comp_mthd_recv_cd_agcy_cd_xref";
+import { ViolationAgencyXref } from "../violation_agency_xref/entities/violation_agency_entity_xref";
 
 describe("Testing: CodeTable Controller", () => {
   let app: INestApplication;
@@ -85,7 +85,7 @@ describe("Testing: CodeTable Controller", () => {
           useFactory: MockSpeciesCodeTableRepository,
         },
         {
-          provide: getRepositoryToken(ViolationCode),
+          provide: getRepositoryToken(ViolationAgencyXref),
           useFactory: MockViolationsCodeTableRepository,
         },
         {

--- a/backend/src/v1/code-table/code-table.module.ts
+++ b/backend/src/v1/code-table/code-table.module.ts
@@ -10,13 +10,13 @@ import { GeoOrgUnitTypeCode } from "../geo_org_unit_type_code/entities/geo_org_u
 import { GeoOrganizationUnitCode } from "../geo_organization_unit_code/entities/geo_organization_unit_code.entity";
 import { PersonComplaintXrefCode } from "../person_complaint_xref_code/entities/person_complaint_xref_code.entity";
 import { SpeciesCode } from "../species_code/entities/species_code.entity";
-import { ViolationCode } from "../violation_code/entities/violation_code.entity";
 import { CosGeoOrgUnit } from "../cos_geo_org_unit/entities/cos_geo_org_unit.entity";
 import { ComplaintTypeCode } from "../complaint_type_code/entities/complaint_type_code.entity";
 import { ReportedByCode } from "../reported_by_code/entities/reported_by_code.entity";
 import { GirTypeCode } from "../gir_type_code/entities/gir_type_code.entity";
 import { TeamCode } from "../team_code/entities/team_code.entity";
 import { CompMthdRecvCdAgcyCdXref } from "../comp_mthd_recv_cd_agcy_cd_xref/entities/comp_mthd_recv_cd_agcy_cd_xref";
+import { ViolationAgencyXref } from "../violation_agency_xref/entities/violation_agency_entity_xref";
 
 @Module({
   imports: [
@@ -28,7 +28,7 @@ import { CompMthdRecvCdAgcyCdXref } from "../comp_mthd_recv_cd_agcy_cd_xref/enti
     TypeOrmModule.forFeature([GeoOrganizationUnitCode]),
     TypeOrmModule.forFeature([PersonComplaintXrefCode]),
     TypeOrmModule.forFeature([SpeciesCode]),
-    TypeOrmModule.forFeature([ViolationCode]),
+    TypeOrmModule.forFeature([ViolationAgencyXref]),
     TypeOrmModule.forFeature([CosGeoOrgUnit]),
     TypeOrmModule.forFeature([ComplaintTypeCode]),
     TypeOrmModule.forFeature([ReportedByCode]),

--- a/backend/src/v1/code-table/code-table.service.spec.ts
+++ b/backend/src/v1/code-table/code-table.service.spec.ts
@@ -30,13 +30,13 @@ import { GeoOrgUnitTypeCode } from "../geo_org_unit_type_code/entities/geo_org_u
 import { GeoOrganizationUnitCode } from "../geo_organization_unit_code/entities/geo_organization_unit_code.entity";
 import { PersonComplaintXrefCode } from "../person_complaint_xref_code/entities/person_complaint_xref_code.entity";
 import { SpeciesCode } from "../species_code/entities/species_code.entity";
-import { ViolationCode } from "../violation_code/entities/violation_code.entity";
 import { CosGeoOrgUnit } from "../cos_geo_org_unit/entities/cos_geo_org_unit.entity";
 import { ComplaintTypeCode } from "../complaint_type_code/entities/complaint_type_code.entity";
 import { ReportedByCode } from "../reported_by_code/entities/reported_by_code.entity";
 import { GirTypeCode } from "../gir_type_code/entities/gir_type_code.entity";
 import { TeamCode } from "../team_code/entities/team_code.entity";
 import { CompMthdRecvCdAgcyCdXref } from "../comp_mthd_recv_cd_agcy_cd_xref/entities/comp_mthd_recv_cd_agcy_cd_xref";
+import { ViolationAgencyXref } from "../violation_agency_xref/entities/violation_agency_entity_xref";
 
 describe("Testing: CodeTable Service", () => {
   let service: CodeTableService;
@@ -78,7 +78,7 @@ describe("Testing: CodeTable Service", () => {
           useFactory: MockSpeciesCodeTableRepository,
         },
         {
-          provide: getRepositoryToken(ViolationCode),
+          provide: getRepositoryToken(ViolationAgencyXref),
           useFactory: MockViolationsCodeTableRepository,
         },
         {
@@ -312,7 +312,7 @@ describe("Testing: CodeTable service", () => {
           useFactory: MockSpeciesCodeTableRepository,
         },
         {
-          provide: getRepositoryToken(ViolationCode),
+          provide: getRepositoryToken(ViolationAgencyXref),
           useFactory: MockViolationsCodeTableRepository,
         },
         {
@@ -403,7 +403,7 @@ describe("Testing: CodeTable service", () => {
           useFactory: MockSpeciesCodeTableRepository,
         },
         {
-          provide: getRepositoryToken(ViolationCode),
+          provide: getRepositoryToken(ViolationAgencyXref),
           useFactory: MockViolationsCodeTableRepository,
         },
         {
@@ -494,7 +494,7 @@ describe("Testing: CodeTable service", () => {
           useFactory: MockSpeciesCodeTableRepository,
         },
         {
-          provide: getRepositoryToken(ViolationCode),
+          provide: getRepositoryToken(ViolationAgencyXref),
           useFactory: MockViolationsCodeTableRepository,
         },
         {

--- a/backend/src/v1/code-table/code-table.service.ts
+++ b/backend/src/v1/code-table/code-table.service.ts
@@ -58,41 +58,42 @@ import { CompMthdRecvCdAgcyCdXref } from "../comp_mthd_recv_cd_agcy_cd_xref/enti
 import { ComplaintMethodReceivedType } from "src/types/models/code-tables/complaint-method-received-type";
 import { ScheduleSectorXref } from "src/types/models/code-tables/schedule-sector-xref";
 import { CaseLocationCode } from "src/types/models/code-tables/case-location-code";
+import { ViolationAgencyXref } from "../violation_agency_xref/entities/violation_agency_entity_xref";
 
 @Injectable()
 export class CodeTableService {
   private readonly logger = new Logger(CodeTableService.name);
 
   @InjectRepository(AgencyCode)
-  private _agencyRepository: Repository<AgencyCode>;
+  private readonly _agencyRepository: Repository<AgencyCode>;
   @InjectRepository(AttractantCode)
-  private _attractantRepository: Repository<AttractantCode>;
+  private readonly _attractantRepository: Repository<AttractantCode>;
   @InjectRepository(ComplaintStatusCode)
-  private _complaintStatusRepository: Repository<ComplaintStatusCode>;
+  private readonly _complaintStatusRepository: Repository<ComplaintStatusCode>;
   @InjectRepository(HwcrComplaintNatureCode)
-  private _natureOfComplaintRepository: Repository<HwcrComplaintNatureCode>;
+  private readonly _natureOfComplaintRepository: Repository<HwcrComplaintNatureCode>;
   @InjectRepository(GeoOrgUnitTypeCode)
-  private _organizationUnitTypeRepository: Repository<GeoOrgUnitTypeCode>;
+  private readonly _organizationUnitTypeRepository: Repository<GeoOrgUnitTypeCode>;
   @InjectRepository(GeoOrganizationUnitCode)
-  private _organizationUnitRepository: Repository<GeoOrganizationUnitCode>;
+  private readonly _organizationUnitRepository: Repository<GeoOrganizationUnitCode>;
   @InjectRepository(PersonComplaintXrefCode)
-  private _personComplaintTypeRepository: Repository<PersonComplaintXrefCode>;
+  private readonly _personComplaintTypeRepository: Repository<PersonComplaintXrefCode>;
   @InjectRepository(SpeciesCode)
-  private _speciesRepository: Repository<SpeciesCode>;
-  @InjectRepository(ViolationCode)
-  private _violationsRepository: Repository<ViolationCode>;
+  private readonly _speciesRepository: Repository<SpeciesCode>;
+  @InjectRepository(ViolationAgencyXref)
+  private readonly _violationAgencyXrefRepository: Repository<ViolationAgencyXref>;
   @InjectRepository(CosGeoOrgUnit)
-  private _cosOrganizationUnitRepository: Repository<CosGeoOrgUnit>;
+  private readonly _cosOrganizationUnitRepository: Repository<CosGeoOrgUnit>;
   @InjectRepository(ComplaintTypeCode)
-  private _complaintTypetRepository: Repository<ComplaintTypeCode>;
+  private readonly _complaintTypetRepository: Repository<ComplaintTypeCode>;
   @InjectRepository(GirTypeCode)
-  private _girTypeCodeRepository: Repository<GirTypeCode>;
+  private readonly _girTypeCodeRepository: Repository<GirTypeCode>;
   @InjectRepository(ReportedByCode)
-  private _reportedByRepository: Repository<ReportedByCode>;
+  private readonly _reportedByRepository: Repository<ReportedByCode>;
   @InjectRepository(TeamCode)
-  private _teamCodeRepository: Repository<TeamCode>;
+  private readonly _teamCodeRepository: Repository<TeamCode>;
   @InjectRepository(CompMthdRecvCdAgcyCdXref)
-  private _compMthdRecvCdAgcyCdXrefRepository: Repository<CompMthdRecvCdAgcyCdXref>;
+  private readonly _compMthdRecvCdAgcyCdXrefRepository: Repository<CompMthdRecvCdAgcyCdXref>;
 
   getCodeTableByName = async (table: string, token?: string): Promise<BaseCodeTable[]> => {
     this.logger.debug("in code table: " + JSON.stringify(table));
@@ -261,20 +262,19 @@ export class CodeTableService {
         return results;
       }
       case "violation": {
-        const data = await this._violationsRepository.find({ order: { display_order: "ASC" } });
-        let results = data.map(
-          ({ violation_code, short_description, long_description, display_order, active_ind, agency_code }) => {
-            let table: Violation = {
-              violation: violation_code,
-              shortDescription: short_description,
-              longDescription: long_description,
-              displayOrder: display_order,
-              isActive: active_ind,
-              agencyCode: agency_code,
-            };
-            return table;
-          },
-        );
+        const data = await this._violationAgencyXrefRepository.find();
+        let results = data.map(({ violation_code, agency_code, active_ind }) => {
+          let table: Violation = {
+            violation: violation_code.violation_code,
+            shortDescription: violation_code.short_description,
+            longDescription: violation_code.long_description,
+            displayOrder: violation_code.display_order,
+            agencyCode: agency_code.agency_code,
+            isActive: active_ind,
+          };
+          return table;
+        });
+        console.log(results);
         return results;
       }
       case "complaint-type": {

--- a/backend/src/v1/code-table/code-table.service.ts
+++ b/backend/src/v1/code-table/code-table.service.ts
@@ -274,7 +274,6 @@ export class CodeTableService {
           };
           return table;
         });
-        console.log(results);
         return results;
       }
       case "complaint-type": {

--- a/backend/src/v1/complaint/complaint.service.spec.ts
+++ b/backend/src/v1/complaint/complaint.service.spec.ts
@@ -27,7 +27,6 @@ import { HwcrComplaintNatureCode } from "../hwcr_complaint_nature_code/entities/
 import { Office } from "../office/entities/office.entity";
 import { Officer } from "../officer/entities/officer.entity";
 import { SpeciesCode } from "../species_code/entities/species_code.entity";
-import { ViolationCode } from "../violation_code/entities/violation_code.entity";
 import { ReportedByCode } from "../reported_by_code/entities/reported_by_code.entity";
 import { PersonComplaintXref } from "../person_complaint_xref/entities/person_complaint_xref.entity";
 import { AttractantHwcrXref } from "../attractant_hwcr_xref/entities/attractant_hwcr_xref.entity";
@@ -87,6 +86,7 @@ import { Team } from "../team/entities/team.entity";
 import { OfficerTeamXrefService } from "../officer_team_xref/officer_team_xref.service";
 import { OfficerTeamXref } from "../officer_team_xref/entities/officer_team_xref.entity";
 import { CacheModule } from "@nestjs/cache-manager";
+import { ViolationAgencyXref } from "../violation_agency_xref/entities/violation_agency_entity_xref";
 
 describe("Testing: Complaint Service", () => {
   let service: ComplaintService;
@@ -205,7 +205,7 @@ describe("Testing: Complaint Service", () => {
           useFactory: MockSpeciesCodeTableRepository,
         },
         {
-          provide: getRepositoryToken(ViolationCode),
+          provide: getRepositoryToken(ViolationAgencyXref),
           useFactory: MockViolationsCodeTableRepository,
         },
         {
@@ -508,7 +508,7 @@ describe("Testing: Complaint Service", () => {
           useFactory: MockSpeciesCodeTableRepository,
         },
         {
-          provide: getRepositoryToken(ViolationCode),
+          provide: getRepositoryToken(ViolationAgencyXref),
           useFactory: MockViolationsCodeTableRepository,
         },
         {

--- a/backend/src/v1/complaint/complaint.service.ts
+++ b/backend/src/v1/complaint/complaint.service.ts
@@ -250,11 +250,13 @@ export class ComplaintService {
           .createQueryBuilder("allegation")
           .leftJoinAndSelect("allegation.complaint_identifier", "complaint")
           .leftJoin("allegation.violation_code", "violation_code")
+          .leftJoin("violation_code.violationAgencyXrefs", "violation_agency_xref")
+          .leftJoin("violation_agency_xref.agency_code", "agency_code")
           .addSelect([
             "violation_code.violation_code",
             "violation_code.short_description",
             "violation_code.long_description",
-            "violation_code.agency_code",
+            "agency_code.agency_code",
           ]);
         break;
       case "GIR":
@@ -1033,7 +1035,7 @@ export class ComplaintService {
 
       //-- return Waste and Pestivide complaints for CEEB users
       if (agencies.includes("EPO") && complaintType === "ERS") {
-        builder.andWhere("violation_code.agency_code = :agency", { agency: "EPO" });
+        builder.andWhere("agency_code.agency_code = :agency", { agency: "EPO" });
       }
 
       // -- filter by complaint identifiers returned by case management if actionTaken filter is present
@@ -1165,7 +1167,7 @@ export class ComplaintService {
 
       //-- return Waste and Pestivide complaints for CEEB users
       if (agencies.includes("EPO") && complaintType === "ERS") {
-        builder.andWhere("violation_code.agency_code = :agency", { agency: "EPO" });
+        builder.andWhere("agency_code.agency_code = :agency", { agency: "EPO" });
       }
 
       // -- filter by complaint identifiers returned by case management if actionTaken filter is present

--- a/backend/src/v1/document/document.controller.spec.ts
+++ b/backend/src/v1/document/document.controller.spec.ts
@@ -58,7 +58,6 @@ import { PersonComplaintXrefService } from "../person_complaint_xref/person_comp
 import { PersonComplaintXrefCode } from "../person_complaint_xref_code/entities/person_complaint_xref_code.entity";
 import { ReportedByCode } from "../reported_by_code/entities/reported_by_code.entity";
 import { SpeciesCode } from "../species_code/entities/species_code.entity";
-import { ViolationCode } from "../violation_code/entities/violation_code.entity";
 import { GirTypeCode } from "../gir_type_code/entities/gir_type_code.entity";
 import { GirComplaint } from "../gir_complaint/entities/gir_complaint.entity";
 import { ActionTaken } from "../complaint/entities/action_taken.entity";
@@ -79,6 +78,7 @@ import { OfficerTeamXref } from "../officer_team_xref/entities/officer_team_xref
 import { TeamService } from "../team/team.service";
 import { OfficerTeamXrefService } from "../officer_team_xref/officer_team_xref.service";
 import { CacheModule } from "@nestjs/cache-manager";
+import { ViolationAgencyXref } from "../violation_agency_xref/entities/violation_agency_entity_xref";
 
 describe("DocumentController", () => {
   let controller: DocumentController;
@@ -149,7 +149,7 @@ describe("DocumentController", () => {
           useFactory: MockSpeciesCodeTableRepository,
         },
         {
-          provide: getRepositoryToken(ViolationCode),
+          provide: getRepositoryToken(ViolationAgencyXref),
           useFactory: MockViolationsCodeTableRepository,
         },
         {

--- a/backend/src/v1/document/document.service.spec.ts
+++ b/backend/src/v1/document/document.service.spec.ts
@@ -55,7 +55,6 @@ import { PersonComplaintXrefService } from "../person_complaint_xref/person_comp
 import { PersonComplaintXrefCode } from "../person_complaint_xref_code/entities/person_complaint_xref_code.entity";
 import { ReportedByCode } from "../reported_by_code/entities/reported_by_code.entity";
 import { SpeciesCode } from "../species_code/entities/species_code.entity";
-import { ViolationCode } from "../violation_code/entities/violation_code.entity";
 import { CdogsService } from "../../external_api/cdogs/cdogs.service";
 import { ConfigurationService } from "../configuration/configuration.service";
 import { Configuration } from "../configuration/entities/configuration.entity";
@@ -78,6 +77,7 @@ import { OfficerTeamXref } from "../officer_team_xref/entities/officer_team_xref
 import { TeamService } from "../team/team.service";
 import { OfficerTeamXrefService } from "../officer_team_xref/officer_team_xref.service";
 import { CacheModule } from "@nestjs/cache-manager";
+import { ViolationAgencyXref } from "../violation_agency_xref/entities/violation_agency_entity_xref";
 
 describe("DocumentService", () => {
   let service: DocumentService;
@@ -147,7 +147,7 @@ describe("DocumentService", () => {
           useFactory: MockSpeciesCodeTableRepository,
         },
         {
-          provide: getRepositoryToken(ViolationCode),
+          provide: getRepositoryToken(ViolationAgencyXref),
           useFactory: MockViolationsCodeTableRepository,
         },
         {

--- a/backend/src/v1/violation_agency_xref/entities/violation_agency_entity_xref.ts
+++ b/backend/src/v1/violation_agency_xref/entities/violation_agency_entity_xref.ts
@@ -1,0 +1,45 @@
+import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
+import { AgencyCode } from "../../agency_code/entities/agency_code.entity";
+import { ViolationCode } from "../../violation_code/entities/violation_code.entity";
+
+@Index("PK_violation_agency_xref_guid", ["violation_agency_xref_guid"], {
+  unique: true,
+})
+@Entity("violation_agency_xref", { schema: "public" })
+export class ViolationAgencyXref {
+  @Column("uuid", {
+    primary: true,
+    name: "violation_agency_xref_guid",
+    default: () => "uuid_generate_v4()",
+  })
+  violation_agency_xref_guid: string;
+
+  @Column("character varying", { name: "create_user_id", length: 32 })
+  create_user_id: string;
+
+  @Column("timestamp without time zone", {
+    name: "create_utc_timestamp",
+    default: () => "now()",
+  })
+  create_utc_timestamp: Date;
+
+  @Column("character varying", { name: "update_user_id", length: 32 })
+  update_user_id: string;
+
+  @Column("timestamp without time zone", {
+    name: "update_utc_timestamp",
+    default: () => "now()",
+  })
+  update_utc_timestamp: Date;
+
+  @Column("boolean", { name: "active_ind", default: () => "true" })
+  active_ind: boolean;
+
+  @ManyToOne(() => AgencyCode, (agencyCode) => agencyCode.violationAgencyXrefs, { eager: true })
+  @JoinColumn([{ name: "agency_code", referencedColumnName: "agency_code" }])
+  agency_code: AgencyCode;
+
+  @ManyToOne(() => ViolationCode, (violationCode) => violationCode.violationAgencyXrefs, { eager: true })
+  @JoinColumn([{ name: "violation_code", referencedColumnName: "violation_code" }])
+  violation_code: ViolationCode;
+}

--- a/backend/src/v1/violation_agency_xref/violation_agency_xref.module.ts
+++ b/backend/src/v1/violation_agency_xref/violation_agency_xref.module.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { ViolationAgencyXref } from "./entities/violation_agency_entity_xref";
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ViolationAgencyXref])],
+})
+export class ViolationAgencyXrefModule {}

--- a/backend/src/v1/violation_code/entities/violation_code.entity.ts
+++ b/backend/src/v1/violation_code/entities/violation_code.entity.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { UUID } from "crypto";
-import { Entity, Column, PrimaryColumn } from "typeorm";
+import { ViolationAgencyXref } from "../../violation_agency_xref/entities/violation_agency_entity_xref";
+import { Entity, Column, PrimaryColumn, OneToMany } from "typeorm";
 
 @Entity()
 export class ViolationCode {
@@ -55,12 +55,8 @@ export class ViolationCode {
   @Column()
   update_utc_timestamp: Date;
 
-  @ApiProperty({
-    example: "COS",
-    description: "The agency code",
-  })
-  @Column({ length: 10 })
-  agency_code: string;
+  @OneToMany(() => ViolationAgencyXref, (violationAgencyXref) => violationAgencyXref.violation_code)
+  violationAgencyXrefs: ViolationAgencyXref[];
 
   constructor(violation_code?: string) {
     this.violation_code = violation_code;

--- a/backend/test/mocks/mock-code-table-repositories.ts
+++ b/backend/test/mocks/mock-code-table-repositories.ts
@@ -348,6 +348,7 @@ const violations = [
     long_description: "Aquatic: Invasive Species",
     display_order: 1,
     active_ind: true,
+    agency_code: { agency_code: "COS" },
   },
   {
     violation_code: "BOATING",
@@ -355,6 +356,7 @@ const violations = [
     long_description: "Boating",
     display_order: 2,
     active_ind: true,
+    agency_code: { agency_code: "COS" },
   },
   {
     violation_code: "DUMPING",
@@ -362,6 +364,7 @@ const violations = [
     long_description: "Dumping",
     display_order: 3,
     active_ind: true,
+    agency_code: { agency_code: "COS" },
   },
   {
     violation_code: "FISHERY",
@@ -369,6 +372,7 @@ const violations = [
     long_description: "Fisheries",
     display_order: 4,
     active_ind: true,
+    agency_code: { agency_code: "COS" },
   },
   {
     violation_code: "ORV",
@@ -376,6 +380,7 @@ const violations = [
     long_description: "Off-road vehicles (ORV)",
     display_order: 5,
     active_ind: true,
+    agency_code: { agency_code: "COS" },
   },
   {
     violation_code: "OPENBURN",
@@ -383,6 +388,7 @@ const violations = [
     long_description: "Open Burning",
     display_order: 6,
     active_ind: true,
+    agency_code: { agency_code: "COS" },
   },
   {
     violation_code: "OTHER",
@@ -390,6 +396,7 @@ const violations = [
     long_description: "Other",
     display_order: 7,
     active_ind: true,
+    agency_code: { agency_code: "COS" },
   },
   {
     violation_code: "PESTICDE",
@@ -397,6 +404,7 @@ const violations = [
     long_description: "Pesticide",
     display_order: 8,
     active_ind: true,
+    agency_code: { agency_code: "COS" },
   },
   {
     violation_code: "RECREATN",
@@ -404,6 +412,7 @@ const violations = [
     long_description: "Recreation sites/ trails",
     display_order: 9,
     active_ind: true,
+    agency_code: { agency_code: "COS" },
   },
 ];
 

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-create.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-create.tsx
@@ -645,7 +645,7 @@ export const CreateComplaint: FC = () => {
 
         <fieldset>
           {/* Complaint Type */}
-          {agency === "COS" && (
+          {(agency === "COS" || agency === "PARKS") && (
             <div
               className="comp-details-form-row"
               id="nature-of-complaint-pair-id"

--- a/migrations/migrations/R__0.24.0_ceeb_violation_types.sql
+++ b/migrations/migrations/R__0.24.0_ceeb_violation_types.sql
@@ -1,3 +1,3 @@
 --
--- No longer required.
+-- Moved to V0.37.1
 --

--- a/migrations/migrations/R__0.24.0_ceeb_violation_types.sql
+++ b/migrations/migrations/R__0.24.0_ceeb_violation_types.sql
@@ -1,2 +1,3 @@
-update violation_code set agency_code = 'EPO'
-where violation_code = 'WASTE' OR violation_code = 'PESTICDE';
+--
+-- No longer required.
+--

--- a/migrations/migrations/R__Create-Test-Data.sql
+++ b/migrations/migrations/R__Create-Test-Data.sql
@@ -3518,33 +3518,6 @@ SELECT
   now() ON CONFLICT
 DO NOTHING;
 
----------------
--- insert new BCPARK agency
----------------
-INSERT INTO
-  agency_code (
-    agency_code,
-    short_description,
-    long_description,
-    display_order,
-    active_ind,
-    create_user_id,
-    create_utc_timestamp,
-    update_user_id,
-    update_utc_timestamp
-  )
-SELECT
-  'PARKS',
-  'BC Parks',
-  'BC Parks',
-  1,
-  'Y',
-  user,
-  now(),
-  user,
-  now() ON CONFLICT
-DO NOTHING;
-
 ------------------------------
 -- update agency table with updated EPO -> CEEB short description and display order
 ------------------------------

--- a/migrations/migrations/V0.37.1__CE-1380.sql
+++ b/migrations/migrations/V0.37.1__CE-1380.sql
@@ -25,13 +25,15 @@ comment on column public.violation_agency_xref.active_ind is 'A boolean indicato
 -- Copy the data
 INSERT into public.violation_agency_xref (violation_code, agency_code, create_user_id, update_user_id, active_ind)
 SELECT violation_code, agency_code, 'FLYWAY', 'FLYWAY', TRUE
-from public.violation_code;
+from public.violation_code
+on conflict do nothing;
 
 -- Insert new data for PARKS (clone of COS)
 INSERT into public.violation_agency_xref (violation_code, agency_code, create_user_id, update_user_id, active_ind)
 SELECT violation_code, 'PARKS', 'FLYWAY', 'FLYWAY', TRUE
 from violation_code
-where agency_code = 'COS';
+where agency_code = 'COS'
+on conflict do nothing;
 
 -- Drop the old column
 ALTER TABLE public.violation_code

--- a/migrations/migrations/V0.37.1__CE-1380.sql
+++ b/migrations/migrations/V0.37.1__CE-1380.sql
@@ -22,6 +22,34 @@ comment on column public.violation_agency_xref.update_user_id is 'The id of the 
 comment on column public.violation_agency_xref.update_utc_timestamp is 'The timestamp when the relationship between an agency and a violation code was updated.  The timestamp is stored in UTC with no Offset.';
 comment on column public.violation_agency_xref.active_ind is 'A boolean indicator to determine if the relationship type between an agency and a violation code is active.';
 
+---------------
+-- insert new BCPARK agency
+-- This was moved from the repeatable script as it might not be there in the dev environment.
+---------------
+INSERT INTO
+  agency_code (
+    agency_code,
+    short_description,
+    long_description,
+    display_order,
+    active_ind,
+    create_user_id,
+    create_utc_timestamp,
+    update_user_id,
+    update_utc_timestamp
+  )
+SELECT
+  'PARKS',
+  'BC Parks',
+  'BC Parks',
+  1,
+  'Y',
+  user,
+  now(),
+  user,
+  now() ON CONFLICT
+DO NOTHING;
+
 -- Copy the data
 INSERT into public.violation_agency_xref (violation_code, agency_code, create_user_id, update_user_id, active_ind)
 SELECT violation_code, agency_code, 'FLYWAY', 'FLYWAY', TRUE

--- a/migrations/migrations/V0.37.1__CE-1380.sql
+++ b/migrations/migrations/V0.37.1__CE-1380.sql
@@ -23,6 +23,13 @@ comment on column public.violation_agency_xref.update_utc_timestamp is 'The time
 comment on column public.violation_agency_xref.active_ind is 'A boolean indicator to determine if the relationship type between an agency and a violation code is active.';
 
 ---------------
+-- Update CEEB types
+-- This was moved from the repeatable script as it might not be there in the dev environment.
+---------------
+update violation_code set agency_code = 'EPO'
+where violation_code = 'WASTE' OR violation_code = 'PESTICDE';
+
+---------------
 -- insert new BCPARK agency
 -- This was moved from the repeatable script as it might not be there in the dev environment.
 ---------------

--- a/migrations/migrations/V0.37.1__CE-1380.sql
+++ b/migrations/migrations/V0.37.1__CE-1380.sql
@@ -1,0 +1,39 @@
+CREATE TABLE public.violation_agency_xref (
+	violation_agency_xref_guid uuid NOT NULL DEFAULT uuid_generate_v4(),
+	violation_code varchar(10) NOT NULL,
+  agency_code varchar(10) NOT NULL,
+  create_user_id varchar(32) NOT NULL,
+  create_utc_timestamp timestamp NOT NULL DEFAULT now(),
+  update_user_id varchar(32) NOT NULL,
+  update_utc_timestamp timestamp NOT NULL DEFAULT now(),
+  active_ind bool NOT NULL DEFAULT TRUE,
+  CONSTRAINT "PK_violation_agency_xref_guid" PRIMARY KEY (violation_agency_xref_guid),
+  CONSTRAINT "FK_violation_agency_xref__violation_code" FOREIGN KEY (violation_code) REFERENCES public.violation_code(violation_code),
+  CONSTRAINT "FK_violation_agency_xref__agency_code" FOREIGN KEY (agency_code) REFERENCES public.agency_code(agency_code)
+);
+
+comment on table public.violation_agency_xref is 'Used to track the relationship type between an agency and a violation code.  For example: violation code ''WASTE'' is only used by EPO (CEEB) but ''WILDLIFE'' is used by both COS and PARKS';
+comment on column public.violation_agency_xref.violation_agency_xref_guid is 'A human readable code used to identify a relationship type between an agency and a violation code.';
+comment on column public.violation_agency_xref.violation_code is 'A human readable code used to identify a violation.';
+comment on column public.violation_agency_xref.agency_code is 'A human readable code used to identify an agency.';
+comment on column public.violation_agency_xref.create_user_id is 'The id of the user that created the relationship between an agency and a violation code.';
+comment on column public.violation_agency_xref.create_utc_timestamp is 'The timestamp when the relationship between an agency and a violation code was created.  The timestamp is stored in UTC with no Offset.';
+comment on column public.violation_agency_xref.update_user_id is 'The id of the user that updated the relationship between an agency and a violation code.';
+comment on column public.violation_agency_xref.update_utc_timestamp is 'The timestamp when the relationship between an agency and a violation code was updated.  The timestamp is stored in UTC with no Offset.';
+comment on column public.violation_agency_xref.active_ind is 'A boolean indicator to determine if the relationship type between an agency and a violation code is active.';
+
+-- Copy the data
+INSERT into public.violation_agency_xref (violation_code, agency_code, create_user_id, update_user_id, active_ind)
+SELECT violation_code, agency_code, 'FLYWAY', 'FLYWAY', TRUE
+from public.violation_code;
+
+-- Insert new data for PARKS (clone of COS)
+INSERT into public.violation_agency_xref (violation_code, agency_code, create_user_id, update_user_id, active_ind)
+SELECT violation_code, 'PARKS', 'FLYWAY', 'FLYWAY', TRUE
+from violation_code
+where agency_code = 'COS';
+
+-- Drop the old column
+ALTER TABLE public.violation_code
+DROP COLUMN agency_code;
+


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Please provide a summary of the change and the issue fixed. Please include relevant context. List dependency changes.

- Provide support for Parks users to be able to create a complaint
- Refactor violation_code and agency_code relationship to be a many-to-many as Parks and COS may share complaint types

Fixes # (issue) CE-1380

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Create HWCR Complaint
- [ ] Create ERS Complaint
- [ ] Create GIR Complaint (?) dependent on parallel PR


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-939-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-939-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)