### PR TITLE
chore: CE-1476 fix tagging and versioning

### DIFF
--- a/.github/workflows/pr-version-bump.yml
+++ b/.github/workflows/pr-version-bump.yml
@@ -17,41 +17,25 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - name: Fetch all tags
-        run: git fetch --tags --force
-
-      - name: Fetch tags from main
-        id: get_latest_tag
-        run: |
-          git fetch origin main --tags --force
-          latest_tag=$(git tag --list --sort=-v:refname --merged | head -n 1)
-          echo "::set-output name=latest_tag::$latest_tag"
-          echo "Latest tag: $latest_tag"
-
-      - name: Increment Patch Version
-        id: increment_version
-        run: |
-          latest_tag=${{ steps.get_latest_tag.outputs.latest_tag }}
-          version_array=(${latest_tag//./ })
-          patch_version=${version_array[2]}
-          new_patch_version=$((patch_version + 1))
-          new_version="${version_array[0]}.${version_array[1]}.${new_patch_version}"
-          echo "::set-output name=new_version::$new_version"
-          echo "New version: $new_version"
-
       - name: Update package.json versions
+        id: increment_version
+        # The old and new versions are currently being read from the frontend package.json
+        # since all three packages are being kept in sync.
         run: |
           cd frontend
-          npm version ${{ steps.increment_version.outputs.new_version }} --no-git-tag-version
-          echo "Frontend package.json version updated to ${{ steps.increment_version.outputs.new_version }}"
+          echo "::set-output name=old_version::$(npm pkg get version | tr -d '"')"
+          npm version patch --no-git-tag-version
+          echo "::set-output name=new_version::$(npm pkg get version | tr -d '"')"
+          new_v=$(npm pkg get version | tr -d '"')
+          echo "Frontend package.json version updated to $new_v"
 
           cd ../backend
-          npm version ${{ steps.increment_version.outputs.new_version }} --no-git-tag-version
-          echo "Backend package.json version updated to ${{ steps.increment_version.outputs.new_version }}"
+          npm version $new_v --no-git-tag-version
+          echo "Backend package.json version updated to $new_v"
 
           cd ../webeoc
-          npm version ${{ steps.increment_version.outputs.new_version }} --no-git-tag-version
-          echo "WebEOC package.json version updated to ${{ steps.increment_version.outputs.new_version }}"
+          npm version $new_v --no-git-tag-version
+          echo "WebEOC package.json version updated to $new_v"
 
           cd ..
 
@@ -61,9 +45,10 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git add frontend/package.json backend/package.json webeoc/package.json
           git commit -m "chore: bump version to ${{ steps.increment_version.outputs.new_version }}"
-          git push origin HEAD:refs/heads/${{ github.head_ref }}
+          git push origin HEAD:${{ github.ref }}
 
-      - name: Create Git Tag
+      - name: Create Git Tag and Delete Old Tag
         run: |
-          git tag "${{ steps.increment_version.outputs.new_version }}"
-          git push origin "${{ steps.increment_version.outputs.new_version }}"
+          git push --delete origin "v${{ steps.increment_version.outputs.old_version }}"
+          git tag "v${{ steps.increment_version.outputs.new_version }}"
+          git push origin v${{ steps.increment_version.outputs.new_version }}

--- a/.github/workflows/release-branch-creation.yml
+++ b/.github/workflows/release-branch-creation.yml
@@ -8,7 +8,7 @@ jobs:
     name: Bump Minor Version and Create New Tag
     runs-on: ubuntu-22.04
     # Only trigger for main release branches
-    if: startsWith(github.ref, 'refs/heads/release/') && !contains(github.ref, '/')
+    if: startsWith(github.ref, 'refs/heads/release/')
     steps:
       - uses: actions/checkout@v4
         with:
@@ -19,36 +19,36 @@ jobs:
       - name: Install npm
         run: sudo apt-get install -y npm
 
-      # Fetch the latest tag (sort by creation date)
-      - name: Fetch latest tag
-        id: latest_tag
-        run: |
-          git fetch --tags --force
-          latest_tag=$(git tag --list --sort=-v:refname --merged | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
-          if [ -z "$latest_tag" ]; then
-            echo "No previous tags found, starting with v0.1.0"
-            latest_tag="v0.0.0"
-          fi
-          echo "::set-output name=latest_tag::$latest_tag"
-          echo "Latest tag: $latest_tag"
-
-      # Bump the minor version and reset the patch to 0
+      # Bump the minor version (which resets the patch to 0)
       - name: Bump minor version
         id: bump_version
         run: |
-          latest_tag="${{ steps.latest_tag.outputs.latest_tag }}"
-          version_array=(${latest_tag//./ })
-          major_version=${version_array[0]//v/}
-          minor_version=${version_array[1]}
-          patch_version=${version_array[2]}
-          new_minor_version=$((minor_version + 1))
-          new_version="v${major_version}.${new_minor_version}.0"
-          echo "::set-output name=new_version::$new_version"
-          echo "New version: $new_version"
+          cd frontend
+          npm version minor
+          echo "::set-output name=new_version::$(npm pkg get version | tr -d '"')"
+          new_v=$(npm pkg get version | tr -d '"')
+          echo "Frontend package.json version updated to $new_v"
+
+          cd ../backend
+          npm version $new_v --no-git-tag-version
+          echo "Backend package.json version updated to $new_v"
+
+          cd ../webeoc
+          npm version $new_v --no-git-tag-version
+          echo "WebEOC package.json version updated to $new_v"
+
+          cd ..
+
+      - name: Commit and Push Version Update
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git add frontend/package.json backend/package.json webeoc/package.json
+          git commit -m 'chore: bump version to ${{ steps.bump_version.outputs.new_version }}'
+          git push origin HEAD:${{ github.ref }}
 
       # Create a new tag with the bumped minor version
       - name: Create and push the new tag
         run: |
-          new_version="${{ steps.bump_version.outputs.new_version }}"
-          git tag "$new_version"
-          git push origin "$new_version"
+          git tag "v${{ steps.bump_version.outputs.new_version }}"
+          git push origin "v${{ steps.bump_version.outputs.new_version }}"

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -48,7 +48,8 @@ jobs:
         id: tag
         run: |
           git fetch --tags
-          latest_tag=$(git describe --tags --abbrev=0 --match "v*.*.*")
+          git fetch origin ${{ github.event.inputs.release_branch }}:${{ github.event.inputs.release_branch }}
+          latest_tag=$(git tag --points-at ${{ github.event.inputs.release_branch }} "v*.*.*")
           echo "::set-output name=latest_tag::$latest_tag"
           echo "Latest tag: $latest_tag"
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nr-compliance-enforcement",
-  "version": "0.28.1",
+  "version": "1.4.9",
   "description": "BCGov devops quickstart. For reference, testing and new projects.",
   "main": "index.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nr-sample-natcomplaints",
-  "version": "0.28.2",
+  "version": "1.4.9",
   "private": true,
   "dependencies": {
     "@craco/craco": "^7.1.0",

--- a/webeoc/package.json
+++ b/webeoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webeoc",
-  "version": "0.28.1",
+  "version": "1.4.9",
   "description": "",
   "author": "",
   "private": true,


### PR DESCRIPTION
Fix the automated tagging and versioning in the pipeline.

# Description

This PR implements the following changes:
- Versioning will be switched to a three digit semantic versioning pattern x.y.z
- Upon creation of a release branch, the current version will be taken from the package.json in the frontend (all 3 are being kept in sync, there's nothing special about the frontend), and have the minor (`y`) version bumped using `npm version minor`
- The version is set to this new version in the frontend, backend and webeoc package.json files, and a new git tag is created on the release branch
- When branches are merged into the release branch, the same process is applied only using a patch (`z`) level bump rather than a minor. The new tag is pointed at the merge commit of the feature branch into the release branch
- When the release branch is merged into main, the `release-main.yml` workflow can be run using the release branches name. This (if successful) will create a new github release using the version that the release branch is tagged with. For example, if that last branch merged into the release before the release was merged to main bumper the version to `v1.4.12` then the release that is created will be `v1.4.12`.

Fixes # 1476
https://env-ceds.atlassian.net/jira/software/c/projects/CE/boards/4?selectedIssue=CE-1476

# How Has This Been Tested?

This was tested in a separate repository using copies of the action/workflows from this repo to allow for iterations without breaking the dev environment for other developers. The testing process was:
- Create a new release branch off of main, e.g. `release/1.2.0` and verify that once the `release-branch-creation` workflow has run, the new release branch is tagged with `v1.2.0`
- Create a new branch off of the release branch, make a change in it, and merge it to the release branch
- Once the `pr-version-bump` action has run successfully, verify that the release branch is now tagged with v1.2.1 and the v1.2.0 tag is deleted
- Create a PR for the release branch and merge it to main
- Run the `release-main` workflow manually, passing in the release branch `release/1.2.0`
- Once the workflow is complete, verify that the new release was created with the correct version `v1.2.1` (this should match the latest patch version that the release branch was tagged with)


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Further comments

Since this was tested in a separate repo, extra caution should be taken when reviewing/merging to check that this logic does not impact the image creation and pulling. It has not been tested in this repo.


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-957-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-957-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)