### PR TITLE
chore: Refeetch workload and pod list after polling

### DIFF
--- a/.github/scripts/rollout_healthcheck.sh
+++ b/.github/scripts/rollout_healthcheck.sh
@@ -386,6 +386,8 @@ main() {
         sleep $POLL_INTERVAL_SECONDS
     done
     echo_yellow "Polling finished..."
+    workload_list=$(get_workload_list $LABEL_SELECTOR)
+    pod_list=$(oc get pods --field-selector=status.phase!=Succeeded,status.phase!=Failed,status.phase!=Unknown -n $OC_NAMESPACE -l $LABEL_SELECTOR -oname)
     replicaset_list=$(echo -e "$workload_list" | grep "replicaset")
     statefulset_list=$(echo -e "$workload_list" | grep "statefulset")
     triage_rollout "$deployment_list" "$pod_list" "$replicaset_list" "$statefulset_list"


### PR DESCRIPTION
Refetching the workloads and pods after the polling has finished.

# Description

By refetching the lists before passing them to the triage function, this should give the deployment time to finish and only get the list of relevant pods and workloads.

Fixes # CE-1310

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-962-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-962-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)