### PR TITLE
chore: Use github app to commit to release branch

### DIFF
--- a/.github/workflows/pr-version-bump.yml
+++ b/.github/workflows/pr-version-bump.yml
@@ -63,8 +63,6 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions[bot]"
           git add frontend/package.json backend/package.json webeoc/package.json
           git commit -m "chore: bump version to ${{ steps.increment_version.outputs.new_version }}"
           git push origin HEAD:${{ github.ref }}

--- a/.github/workflows/pr-version-bump.yml
+++ b/.github/workflows/pr-version-bump.yml
@@ -5,17 +5,37 @@ on:
     types: [closed]
     branches:
       - release/**
+
 jobs:
   handle_pr:
     name: Handle Merged PR
     runs-on: ubuntu-22.04
+    permissions:
+      contents: "write"
+      packages: "write"
+      actions: "read"
     if: github.event.pull_request.merged == true
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.VERSION_BUMPER_APPID }}
+          private-key: ${{ secrets.VERSION_BUMPER_SECRET }}
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
           fetch-tags: true
+          token: ${{ steps.app-token.outputs.token }}
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      - run: |
+          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
 
       - name: Update package.json versions
         id: increment_version
@@ -40,6 +60,8 @@ jobs:
           cd ..
 
       - name: Commit and Push Version Update
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
@@ -48,6 +70,8 @@ jobs:
           git push origin HEAD:${{ github.ref }}
 
       - name: Create Git Tag and Delete Old Tag
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git push --delete origin "v${{ steps.increment_version.outputs.old_version }}"
           git tag "v${{ steps.increment_version.outputs.new_version }}"


### PR DESCRIPTION
Use the GitHub app to commit in the action.

# Description

A BCGov wide GitHub app was made for our repo(s). We can use it to make commits in our actions / workflows. The app needs to be added to the bypass list for branch protection rules in order to commit directly to `release/` branches.

Fixes # (issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-972-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-972-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)