### PR TITLE
chore: Temporarily disable commit in workflow

### DIFF
--- a/.github/workflows/pr-version-bump.yml
+++ b/.github/workflows/pr-version-bump.yml
@@ -45,7 +45,28 @@ jobs:
           git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
           git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
 
-      - name: Update package.json versions
+      # - name: Update package.json versions
+      #   id: increment_version
+      #   # The old and new versions are currently being read from the frontend package.json
+      #   # since all three packages are being kept in sync.
+      #   run: |
+      #     cd frontend
+      #     echo "::set-output name=old_version::$(npm pkg get version | tr -d '"')"
+      #     npm version patch --no-git-tag-version
+      #     echo "::set-output name=new_version::$(npm pkg get version | tr -d '"')"
+      #     new_v=$(npm pkg get version | tr -d '"')
+      #     echo "Frontend package.json version updated to $new_v"
+
+      #     cd ../backend
+      #     npm version $new_v --no-git-tag-version
+      #     echo "Backend package.json version updated to $new_v"
+
+      #     cd ../webeoc
+      #     npm version $new_v --no-git-tag-version
+      #     echo "WebEOC package.json version updated to $new_v"
+
+      #     cd ..
+      - name: Temporary new version setter
         id: increment_version
         # The old and new versions are currently being read from the frontend package.json
         # since all three packages are being kept in sync.
@@ -54,26 +75,15 @@ jobs:
           echo "::set-output name=old_version::$(npm pkg get version | tr -d '"')"
           npm version patch --no-git-tag-version
           echo "::set-output name=new_version::$(npm pkg get version | tr -d '"')"
-          new_v=$(npm pkg get version | tr -d '"')
-          echo "Frontend package.json version updated to $new_v"
+          git restore .
 
-          cd ../backend
-          npm version $new_v --no-git-tag-version
-          echo "Backend package.json version updated to $new_v"
-
-          cd ../webeoc
-          npm version $new_v --no-git-tag-version
-          echo "WebEOC package.json version updated to $new_v"
-
-          cd ..
-
-      - name: Commit and Push Version Update
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          git add frontend/package.json backend/package.json webeoc/package.json
-          git commit -m "chore: bump version to ${{ steps.increment_version.outputs.new_version }}"
-          git push origin HEAD:${{ github.ref }}
+      # - name: Commit and Push Version Update
+      #   env:
+      #     GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      #   run: |
+      #     git add frontend/package.json backend/package.json webeoc/package.json
+      #     git commit -m "chore: bump version to ${{ steps.increment_version.outputs.new_version }}"
+      #     git push origin HEAD:${{ github.ref }}
 
       - name: Create Git Tag and Delete Old Tag
         env:

--- a/.github/workflows/pr-version-bump.yml
+++ b/.github/workflows/pr-version-bump.yml
@@ -66,16 +66,6 @@ jobs:
       #     echo "WebEOC package.json version updated to $new_v"
 
       #     cd ..
-      - name: Temporary new version setter
-        id: increment_version
-        # The old and new versions are currently being read from the frontend package.json
-        # since all three packages are being kept in sync.
-        run: |
-          cd frontend
-          echo "::set-output name=old_version::$(npm pkg get version | tr -d '"')"
-          npm version patch --no-git-tag-version
-          echo "::set-output name=new_version::$(npm pkg get version | tr -d '"')"
-          git restore .
 
       # - name: Commit and Push Version Update
       #   env:
@@ -85,10 +75,10 @@ jobs:
       #     git commit -m "chore: bump version to ${{ steps.increment_version.outputs.new_version }}"
       #     git push origin HEAD:${{ github.ref }}
 
-      - name: Create Git Tag and Delete Old Tag
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          git tag "v${{ steps.increment_version.outputs.new_version }}"
-          git push origin v${{ steps.increment_version.outputs.new_version }}
-          git push --delete origin "v${{ steps.increment_version.outputs.old_version }}"
+      # - name: Create Git Tag and Delete Old Tag
+      #   env:
+      #     GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      #   run: |
+      #     git tag "v${{ steps.increment_version.outputs.new_version }}"
+      #     git push origin v${{ steps.increment_version.outputs.new_version }}
+      #     git push --delete origin "v${{ steps.increment_version.outputs.old_version }}"

--- a/.github/workflows/pr-version-bump.yml
+++ b/.github/workflows/pr-version-bump.yml
@@ -75,10 +75,15 @@ jobs:
       #     git commit -m "chore: bump version to ${{ steps.increment_version.outputs.new_version }}"
       #     git push origin HEAD:${{ github.ref }}
 
-      # - name: Create Git Tag and Delete Old Tag
-      #   env:
-      #     GH_TOKEN: ${{ steps.app-token.outputs.token }}
-      #   run: |
-      #     git tag "v${{ steps.increment_version.outputs.new_version }}"
-      #     git push origin v${{ steps.increment_version.outputs.new_version }}
-      #     git push --delete origin "v${{ steps.increment_version.outputs.old_version }}"
+      - name: Create Git Tag and Delete Old Tag
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          cd frontend
+          npm version patch --no-git-tag-version
+          new_v=$(npm pkg get version | tr -d '"')
+          git restore package.json
+          cd ..
+          git tag "v${{ steps.increment_version.outputs.new_version }}"
+          git push origin v${{ steps.increment_version.outputs.new_version }}
+          git push --delete origin "v${{ steps.increment_version.outputs.old_version }}"

--- a/.github/workflows/pr-version-bump.yml
+++ b/.github/workflows/pr-version-bump.yml
@@ -56,17 +56,13 @@ jobs:
       #     echo "::set-output name=new_version::$(npm pkg get version | tr -d '"')"
       #     new_v=$(npm pkg get version | tr -d '"')
       #     echo "Frontend package.json version updated to $new_v"
-
       #     cd ../backend
       #     npm version $new_v --no-git-tag-version
       #     echo "Backend package.json version updated to $new_v"
-
       #     cd ../webeoc
       #     npm version $new_v --no-git-tag-version
       #     echo "WebEOC package.json version updated to $new_v"
-
       #     cd ..
-
       # - name: Commit and Push Version Update
       #   env:
       #     GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -74,16 +70,19 @@ jobs:
       #     git add frontend/package.json backend/package.json webeoc/package.json
       #     git commit -m "chore: bump version to ${{ steps.increment_version.outputs.new_version }}"
       #     git push origin HEAD:${{ github.ref }}
-
       - name: Create Git Tag and Delete Old Tag
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           cd frontend
+          OLD_V=$(npm pkg get version | tr -d '"')
           npm version patch --no-git-tag-version
-          new_v=$(npm pkg get version | tr -d '"')
+          NEW_V=$(npm pkg get version | tr -d '"')
           git restore package.json
           cd ..
-          git tag "v${{ steps.increment_version.outputs.new_version }}"
-          git push origin v${{ steps.increment_version.outputs.new_version }}
-          git push --delete origin "v${{ steps.increment_version.outputs.old_version }}"
+          git tag "v$NEW_V"
+          git push origin v$NEW_V
+          git push --delete origin "v$OLD_V"
+        # git tag "v${{ steps.increment_version.outputs.new_version }}"
+        # git push origin v${{ steps.increment_version.outputs.new_version }}
+        # git push --delete origin "v${{ steps.increment_version.outputs.old_version }}"

--- a/.github/workflows/release-branch-creation.yml
+++ b/.github/workflows/release-branch-creation.yml
@@ -70,8 +70,6 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions[bot]"
           git add frontend/package.json backend/package.json webeoc/package.json
           git commit -m 'chore: bump version to ${{ steps.bump_version.outputs.new_version }}'
           git push origin HEAD:${{ github.ref }}

--- a/frontend/src/app/components/common/attachment-upload.tsx
+++ b/frontend/src/app/components/common/attachment-upload.tsx
@@ -7,6 +7,7 @@ type Props = {
 };
 
 export const AttachmentUpload: FC<Props> = ({ onFileSelect, disabled }) => {
+  // Function to handle files being dropped onto the component
   const onDrop = useCallback(
     (acceptedFiles: File[]) => {
       const dataTransfer = new DataTransfer();


### PR DESCRIPTION
Temporarily disable the commit to release in workflow.

# Description
The commit directly to the release branch is causing the get latest PR number action to return null for the latest PR. This breaks the merge-release workflow. This temporarily removes the commit from the workflow to unblock the pipeline while the proper workaround is found.

Fixes # (issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-981-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-981-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)