### PR TITLE
feat: CE-1551-View-equipment-on-the-map-on-the-complaint-details

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nr-compliance-enforcement",
-  "version": "1.7.11",
+  "version": "1.7.12",
   "description": "BCGov devops quickstart. For reference, testing and new projects.",
   "main": "index.js",
   "scripts": {

--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.11
+version: 1.7.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 1.7.11
+appVersion: 1.7.12
 
 dependencies:
   - name: postgresql

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nr-sample-natcomplaints",
-  "version": "1.7.5",
+  "version": "1.7.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nr-sample-natcomplaints",
-      "version": "1.7.5",
+      "version": "1.7.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@craco/craco": "^7.1.0",
@@ -90,6 +90,7 @@
         "react-is": "^16.13.1",
         "react-leaflet": "^4.2.1",
         "react-leaflet-cluster": "^2.1.0",
+        "react-leaflet-markercluster": "4.2.1",
         "react-lifecycles-compat": "^3.0.4",
         "react-phone-number-input": "^3.3.6",
         "react-redux": "^8.0.1",
@@ -20693,6 +20694,23 @@
         "leaflet": "^1.8.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
+        "react-leaflet": "^4.0.0"
+      }
+    },
+    "node_modules/react-leaflet-markercluster": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/react-leaflet-markercluster/-/react-leaflet-markercluster-4.2.1.tgz",
+      "integrity": "sha512-lRJwCMGJVKXOKdP/dZIxszfHXjJaf8BpP2E+cNIYx5XxvqFj7NADG1HeK1nouNUgMcXVhqpZejiV6wPxwCibJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-leaflet/core": "^2.0.0",
+        "leaflet": "^1.8.0",
+        "leaflet.markercluster": "^1.5.3",
+        "react-leaflet": "^4.0.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.8.0",
+        "leaflet.markercluster": "^1.5.3",
         "react-leaflet": "^4.0.0"
       }
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -84,6 +84,7 @@
     "react-is": "^16.13.1",
     "react-leaflet": "^4.2.1",
     "react-leaflet-cluster": "^2.1.0",
+    "react-leaflet-markercluster": "4.2.1",
     "react-lifecycles-compat": "^3.0.4",
     "react-phone-number-input": "^3.3.6",
     "react-redux": "^8.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nr-sample-natcomplaints",
-  "version": "1.7.11",
+  "version": "1.7.12",
   "private": true,
   "dependencies": {
     "@craco/craco": "^7.1.0",

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
@@ -762,9 +762,10 @@ export const ComplaintDetailsEdit: FC = () => {
       let equipmentMapElements: MapElement[] = equipmentList
         .filter((equipment) => equipment.activeIndicator === true)
         .map((equipment) => {
+          let equipmentItem: any = equipment;
           return {
             objectType: MapObjectType.Equipment,
-            name: (equipment as any).typeDescription,
+            name: equipmentItem.typeDescription,
             description: "",
             isActive: equipment.actions?.filter((action) => action.actionCode === "REMEQUIPMT")?.length === 0,
             location: {

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
@@ -80,6 +80,8 @@ import { GIROutcomeReport } from "@/app/components/containers/complaints/outcome
 import { RootState } from "@/app/store/store";
 import { Roles } from "@/app/types/app/roles";
 import { Park } from "@/app/components/common/park";
+import { MapElement, MapObjectType } from "@/app/types/maps/map-element";
+import { selectEquipment } from "@/app/store/reducers/case-selectors";
 
 export type ComplaintParams = {
   id: string;
@@ -172,6 +174,8 @@ export const ComplaintDetailsEdit: FC = () => {
   ) as ComplaintSuspectWitness;
 
   const linkedComplaintData = useAppSelector(selectLinkedComplaints);
+
+  const equipmentList = useAppSelector(selectEquipment);
 
   //-- state
   const [readOnly, setReadOnly] = useState(true);
@@ -742,6 +746,37 @@ export const ComplaintDetailsEdit: FC = () => {
     setCoordinateErrorsInd(hasError);
   };
 
+  const getMapElements = (includeEquipment: boolean): MapElement[] => {
+    let mapElements: MapElement[] = [];
+    mapElements.push({
+      objectType: MapObjectType.Complaint,
+      name: "Complaint",
+      description: "",
+      isActive: true,
+      location: {
+        lat: parentCoordinates.lat,
+        lng: parentCoordinates.lng,
+      },
+    } as MapElement);
+    if (includeEquipment && equipmentList && equipmentList.length > 0) {
+      let equipmentMapElements: MapElement[] = equipmentList
+        .filter((equipment) => equipment.activeIndicator === true)
+        .map((equipment) => {
+          return {
+            objectType: MapObjectType.Equipment,
+            name: (equipment as any).typeDescription,
+            description: "",
+            isActive: equipment.actions?.filter((action) => action.actionCode === "REMEQUIPMT")?.length === 0,
+            location: {
+              lat: +equipment.yCoordinate,
+              lng: +equipment.xCoordinate,
+            },
+          } as MapElement;
+        });
+      mapElements = [...mapElements, ...equipmentMapElements];
+    }
+    return mapElements;
+  };
   return (
     <div className="comp-complaint-details">
       <ToastContainer />
@@ -812,11 +847,10 @@ export const ComplaintDetailsEdit: FC = () => {
           {/* Map */}
           {readOnly && (
             <ComplaintLocation
-              parentCoordinates={parentCoordinates}
               complaintType={complaintType}
               draggable={false}
-              hideMarker={!latitude || !longitude || +latitude === 0 || +longitude === 0}
               editComponent={true}
+              mapElements={getMapElements(true)}
             />
           )}
         </div>
@@ -1441,12 +1475,22 @@ export const ComplaintDetailsEdit: FC = () => {
 
             {/* Location Map */}
             <ComplaintLocation
-              parentCoordinates={parentCoordinates}
               complaintType={complaintType}
               draggable={true}
               onMarkerMove={handleMarkerMove}
-              hideMarker={!latitude || !longitude || +latitude === 0 || +longitude === 0}
               editComponent={true}
+              mapElements={[
+                {
+                  objectType: MapObjectType.Complaint,
+                  name: "Complaint",
+                  description: "Complaint Description",
+                  isActive: true,
+                  location: {
+                    lat: parentCoordinates.lat,
+                    lng: parentCoordinates.lng,
+                  },
+                } as MapElement,
+              ]}
             />
           </div>
         )}

--- a/frontend/src/app/components/mapping/leaflet-map-with-point.tsx
+++ b/frontend/src/app/components/mapping/leaflet-map-with-point.tsx
@@ -74,7 +74,7 @@ const LeafletMapWithPoint: FC<Props> = ({ draggable, onMarkerMove, mapElements, 
   };
 
   const areCoordinatesValid = (location: { lat: number; lng: number } | undefined): boolean => {
-    if (location && location.lat && location.lng && +location.lat !== 0 && +location.lng !== 0) {
+    if (location?.lat && location?.lng && +location.lat !== 0 && +location.lng !== 0) {
       return true;
     } else {
       return false;
@@ -97,6 +97,14 @@ const LeafletMapWithPoint: FC<Props> = ({ draggable, onMarkerMove, mapElements, 
   const parkLayerParams = useMemo(() => {
     return { format: "image/png", layers: "pub:WHSE_TANTALIS.TA_PARK_ECORES_PA_SVW", transparent: true };
   }, []);
+
+  const getEquipmentStatus = (locationItem: MapElement): string => {
+    if (locationItem.objectType === MapObjectType.Complaint) {
+      return "";
+    } else {
+      return locationItem.isActive ? "Active" : "Inactive";
+    }
+  };
 
   return (
     <Card className="comp-map-container">
@@ -137,9 +145,7 @@ const LeafletMapWithPoint: FC<Props> = ({ draggable, onMarkerMove, mapElements, 
                   <p className="leaflet-popup-object-coordinates">
                     {item.location.lat} , {item.location.lng}
                   </p>
-                  <p className="leaflet-popup-object-description">
-                    {item.objectType === MapObjectType.Complaint ? "" : item.isActive ? "Active" : "Inactive"}
-                  </p>
+                  <p className="leaflet-popup-object-description">{getEquipmentStatus(item)}</p>
                 </Popup>
               </Marker>
             );

--- a/frontend/src/app/components/mapping/leaflet-map-with-point.tsx
+++ b/frontend/src/app/components/mapping/leaflet-map-with-point.tsx
@@ -1,6 +1,8 @@
 import { FC, useEffect, useMemo, useState } from "react";
-import { MapContainer, TileLayer, Marker, useMap, LayersControl, WMSTileLayer } from "react-leaflet";
+import { MapContainer, TileLayer, Marker, useMap, LayersControl, WMSTileLayer, Popup } from "react-leaflet";
 import "leaflet/dist/leaflet.css"; // Import Leaflet CSS
+import "react-leaflet-markercluster/styles";
+import MarkerClusterGroup from "react-leaflet-markercluster";
 import "@fortawesome/fontawesome-svg-core/styles.css";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import ReactDOMServer from "react-dom/server";
@@ -10,21 +12,23 @@ import Leaflet from "leaflet";
 import NonDismissibleAlert from "@components/common/non-dismissible-alert";
 import { MapGestureHandler } from "./map-gesture-handler";
 import { Card } from "react-bootstrap";
+import { MapElement, MapObjectType } from "@/app/types/maps/map-element";
 
 type Props = {
   coordinates?: { lat: number; lng: number };
   draggable: boolean;
   onMarkerMove?: (lat: number, lng: number) => void;
-  hideMarker?: boolean;
+  mapElements: MapElement[];
+  geocodedLocation?: { lat: number; lng: number };
 };
 
 /**
  * Renders a map with a marker at the supplied location
  *
  */
-const LeafletMapWithPoint: FC<Props> = ({ coordinates, draggable, onMarkerMove, hideMarker }) => {
+const LeafletMapWithPoint: FC<Props> = ({ draggable, onMarkerMove, mapElements, geocodedLocation }) => {
   const iconHTML = ReactDOMServer.renderToString(<FontAwesomeIcon icon={faMapMarkerAlt} />);
-  const [markerPosition, setMarkerPosition] = useState<{
+  const [mapCenterPosition, setMapCenterPosition] = useState<{
     lat: number;
     lng: number;
   }>({ lat: 0, lng: 0 });
@@ -32,10 +36,14 @@ const LeafletMapWithPoint: FC<Props> = ({ coordinates, draggable, onMarkerMove, 
   // update the marker poisition when the coordinates are updated (occurs when geocoded).
   // but don't update them if the marker position has already been set manually
   useEffect(() => {
-    if (coordinates) {
-      setMarkerPosition(coordinates);
+    let complaintMapElement = mapElements.find((item) => item.objectType === MapObjectType.Complaint);
+    const complaintLocation = complaintMapElement?.location;
+    if (complaintLocation && areCoordinatesValid(complaintLocation)) {
+      setMapCenterPosition(complaintLocation);
+    } else if (geocodedLocation && areCoordinatesValid(geocodedLocation)) {
+      setMapCenterPosition(geocodedLocation);
     }
-  }, [coordinates]);
+  }, [mapElements, geocodedLocation]);
 
   const handleMarkerDragEnd = (e: L.LeafletEvent) => {
     const marker = e.target;
@@ -48,20 +56,38 @@ const LeafletMapWithPoint: FC<Props> = ({ coordinates, draggable, onMarkerMove, 
     }
   };
 
-  const customMarkerIcon = new Leaflet.DivIcon({
-    html: iconHTML,
-    className: "map-marker",
-    iconSize: [40, 0], // Adjust icon size as needed
-    iconAnchor: [20, 40], // Adjust icon anchor point
-  });
+  const getMarkerIcon = (mapElementType: MapObjectType, isActive: boolean) => {
+    let cssClass = "map-marker";
+    if (mapElementType === MapObjectType.Equipment) {
+      if (isActive) {
+        cssClass = "map-marker-equipment-active";
+      } else {
+        cssClass = "map-marker-equipment-inactive";
+      }
+    }
+    return new Leaflet.DivIcon({
+      html: iconHTML,
+      className: cssClass,
+      iconSize: [40, 0],
+      iconAnchor: [20, 40],
+    });
+  };
+
+  const areCoordinatesValid = (location: { lat: number; lng: number } | undefined): boolean => {
+    if (location && location.lat && location.lng && +location.lat !== 0 && +location.lng !== 0) {
+      return true;
+    } else {
+      return false;
+    }
+  };
 
   // recenter the map when the center value is updated
   const Centerer = () => {
     const map = useMap();
 
     useEffect(() => {
-      if (markerPosition) {
-        map.setView(markerPosition);
+      if (mapCenterPosition) {
+        map.setView(mapCenterPosition);
       }
     }, [map]);
 
@@ -74,14 +100,14 @@ const LeafletMapWithPoint: FC<Props> = ({ coordinates, draggable, onMarkerMove, 
 
   return (
     <Card className="comp-map-container">
-      {hideMarker && <NonDismissibleAlert />}
+      {geocodedLocation && areCoordinatesValid(geocodedLocation) && <NonDismissibleAlert />}
 
       <MapContainer
         id="map"
-        center={markerPosition}
+        center={mapCenterPosition}
         zoom={12}
         style={{ height: "400px", width: "100%" }}
-        className="map-container"
+        className="map-container markercluster-map"
       >
         <MapGestureHandler />
         <Centerer />
@@ -95,15 +121,30 @@ const LeafletMapWithPoint: FC<Props> = ({ coordinates, draggable, onMarkerMove, 
             />
           </LayersControl.Overlay>
         </LayersControl>
-        {!hideMarker && (
-          <Marker
-            data-testid="complaint-location-marker"
-            position={markerPosition}
-            icon={customMarkerIcon}
-            draggable={draggable}
-            eventHandlers={{ dragend: handleMarkerDragEnd }}
-          ></Marker>
-        )}
+        <MarkerClusterGroup>
+          {mapElements.map((item, index) => {
+            return (
+              <Marker
+                key={item.name}
+                data-testid="complaint-location-marker"
+                position={item.location}
+                icon={getMarkerIcon(item.objectType, item.isActive)}
+                draggable={draggable}
+                eventHandlers={{ dragend: handleMarkerDragEnd }}
+              >
+                <Popup>
+                  <p className="leaflet-popup-object-description">{item.name} coordinates</p>
+                  <p className="leaflet-popup-object-coordinates">
+                    {item.location.lat} , {item.location.lng}
+                  </p>
+                  <p className="leaflet-popup-object-description">
+                    {item.objectType === MapObjectType.Complaint ? "" : item.isActive ? "Active" : "Inactive"}
+                  </p>
+                </Popup>
+              </Marker>
+            );
+          })}
+        </MarkerClusterGroup>
       </MapContainer>
     </Card>
   );

--- a/frontend/src/app/types/maps/map-element.ts
+++ b/frontend/src/app/types/maps/map-element.ts
@@ -1,0 +1,15 @@
+export interface MapElement {
+  objectType: MapObjectType;
+  name: string;
+  description: string;
+  isActive: boolean;
+  location: {
+    lat: number;
+    lng: number;
+  };
+}
+
+export enum MapObjectType {
+  Complaint = "Complaint",
+  Equipment = "Equipment",
+}

--- a/frontend/src/assets/sass/maps.scss
+++ b/frontend/src/assets/sass/maps.scss
@@ -5,6 +5,15 @@
   line-height: 20px;
 }
 
+.map-marker-equipment-active {
+  @extend .map-marker;
+  color: rgb(16, 124, 65);
+}
+.map-marker-equipment-inactive {
+  @extend .map-marker;
+  color: gray;
+}
+
 .map-container {
   z-index: 1;
 }
@@ -121,13 +130,25 @@
 }
 
 .leaflet-popup-content-wrapper {
-  width: 360px;
+  width: max-content;
 }
 
 .leaflet-popup-content {
   width: auto !important;
   margin: 12px;
   font-size: 1rem;
+}
+
+.leaflet-popup-object-description {
+  color: gray;
+  margin: 5px !important;
+}
+
+.leaflet-popup-object-coordinates {
+  margin: 5px !important;
+}
+.markercluster-map {
+  height: 90vh;
 }
 
 .comp-map-popup-header {

--- a/webeoc/package.json
+++ b/webeoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webeoc",
-  "version": "1.7.11",
+  "version": "1.7.12",
   "description": "",
   "author": "",
   "private": true,


### PR DESCRIPTION
# Description

This PR is to let COS officers view the location of the equipment on the complaint details map so that they can easily see where the equipment is located.

Fixes # (CE-1551)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Add equipment to a complaint. Scroll up to the map view. Check that a pin that correspond to the added equipment is displayed on the map. Click the pin. Check if a popup that shows equipment type, status and coordinates is displayed.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-1023-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-1023-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)