### PR TITLE
fix: CE-1606-and-CE-1607

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nr-compliance-enforcement",
-  "version": "1.7.13",
+  "version": "1.7.14",
   "description": "BCGov devops quickstart. For reference, testing and new projects.",
   "main": "index.js",
   "scripts": {

--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.13
+version: 1.7.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 1.7.13
+appVersion: 1.7.14
 
 dependencies:
   - name: postgresql

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nr-sample-natcomplaints",
-  "version": "1.7.13",
+  "version": "1.7.14",
   "private": true,
   "dependencies": {
     "@craco/craco": "^7.1.0",

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
@@ -208,6 +208,7 @@ export const ComplaintDetailsEdit: FC = () => {
   const parentCoordinates = useMemo(() => ({ lat: +latitude, lng: +longitude }), [latitude, longitude]);
 
   const [complaintAttachmentCount, setComplaintAttachmentCount] = useState<number>(0);
+  const [mapElements, setMapElements] = useState<MapElement[]>([]);
 
   const handleSlideCountChange = useCallback(
     (count: number) => {
@@ -746,7 +747,7 @@ export const ComplaintDetailsEdit: FC = () => {
     setCoordinateErrorsInd(hasError);
   };
 
-  const getMapElements = (includeEquipment: boolean): MapElement[] => {
+  useEffect(() => {
     let mapElements: MapElement[] = [];
     mapElements.push({
       objectType: MapObjectType.Complaint,
@@ -758,7 +759,7 @@ export const ComplaintDetailsEdit: FC = () => {
         lng: parentCoordinates.lng,
       },
     } as MapElement);
-    if (includeEquipment && equipmentList && equipmentList.length > 0) {
+    if (equipmentList && equipmentList.length > 0) {
       let equipmentMapElements: MapElement[] = equipmentList
         .filter((equipment) => equipment.activeIndicator === true)
         .map((equipment) => {
@@ -767,7 +768,9 @@ export const ComplaintDetailsEdit: FC = () => {
             objectType: MapObjectType.Equipment,
             name: equipmentItem.typeDescription,
             description: "",
-            isActive: equipment.actions?.filter((action) => action.actionCode === "REMEQUIPMT")?.length === 0,
+            isActive:
+              equipment.actions?.filter((action) => action.actionCode === "REMEQUIPMT")?.length === 0 &&
+              !["K9UNT", "LLTHL"].includes(equipmentItem.typeCode),
             location: {
               lat: +equipment.yCoordinate,
               lng: +equipment.xCoordinate,
@@ -776,8 +779,8 @@ export const ComplaintDetailsEdit: FC = () => {
         });
       mapElements = [...mapElements, ...equipmentMapElements];
     }
-    return mapElements;
-  };
+    setMapElements(mapElements);
+  }, [equipmentList, parentCoordinates]);
   return (
     <div className="comp-complaint-details">
       <ToastContainer />
@@ -851,7 +854,7 @@ export const ComplaintDetailsEdit: FC = () => {
               complaintType={complaintType}
               draggable={false}
               editComponent={true}
-              mapElements={getMapElements(true)}
+              mapElements={mapElements}
             />
           )}
         </div>

--- a/frontend/src/app/components/mapping/leaflet-map-with-point.tsx
+++ b/frontend/src/app/components/mapping/leaflet-map-with-point.tsx
@@ -13,6 +13,7 @@ import NonDismissibleAlert from "@components/common/non-dismissible-alert";
 import { MapGestureHandler } from "./map-gesture-handler";
 import { Card } from "react-bootstrap";
 import { MapElement, MapObjectType } from "@/app/types/maps/map-element";
+import { nanoid } from "nanoid";
 
 type Props = {
   coordinates?: { lat: number; lng: number };
@@ -99,7 +100,10 @@ const LeafletMapWithPoint: FC<Props> = ({ draggable, onMarkerMove, mapElements, 
   }, []);
 
   const getEquipmentStatus = (locationItem: MapElement): string => {
-    if (locationItem.objectType === MapObjectType.Complaint) {
+    if (
+      locationItem.objectType === MapObjectType.Complaint ||
+      (locationItem.objectType === MapObjectType.Equipment && ["Less lethal", "K9 unit"].includes(locationItem.name))
+    ) {
       return "";
     } else {
       return locationItem.isActive ? "Active" : "Inactive";
@@ -129,11 +133,11 @@ const LeafletMapWithPoint: FC<Props> = ({ draggable, onMarkerMove, mapElements, 
             />
           </LayersControl.Overlay>
         </LayersControl>
-        <MarkerClusterGroup>
+        <MarkerClusterGroup key={nanoid()}>
           {mapElements.map((item, index) => {
             return (
               <Marker
-                key={item.name}
+                key={index}
                 data-testid="complaint-location-marker"
                 position={item.location}
                 icon={getMarkerIcon(item.objectType, item.isActive)}

--- a/frontend/src/app/components/mapping/leaflet-map-with-point.tsx
+++ b/frontend/src/app/components/mapping/leaflet-map-with-point.tsx
@@ -137,7 +137,7 @@ const LeafletMapWithPoint: FC<Props> = ({ draggable, onMarkerMove, mapElements, 
           {mapElements.map((item, index) => {
             return (
               <Marker
-                key={index}
+                key={nanoid()}
                 data-testid="complaint-location-marker"
                 position={item.location}
                 icon={getMarkerIcon(item.objectType, item.isActive)}

--- a/webeoc/package.json
+++ b/webeoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webeoc",
-  "version": "1.7.13",
+  "version": "1.7.14",
   "description": "",
   "author": "",
   "private": true,


### PR DESCRIPTION
# Description

This PR is to fix two issues. One is when equipment pin appears on map for complaints without equipment after viewing a complaint with equipment. Another one is when K9 Unit and Less Lethal equipment appear as Active on the map.

Fixes # (CE-1606, CE-1607)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Add equipment with coordinates to a complaint. Check that the map displays a pin that correspond to this equipment.  Open another complaint that does not have any equipment from the list view. Check that the map does not show a pin from the previous complaint.
- [ ] Add K9 Unit or Less Lethal equipment to a complaint. Check that the corresponding map pin is not shown as Active. 


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes




---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-1025-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-1025-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)