### PR TITLE
feat: CE-1556 Allow collaborators to add notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,6 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# Scratch folder
+.scratch

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nr-compliance-enforcement",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "BCGov devops quickstart. For reference, testing and new projects.",
   "main": "index.js",
   "scripts": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nr-compliance-enforcement",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "BCGov devops quickstart. For reference, testing and new projects.",
   "main": "index.js",
   "scripts": {

--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 
+version: 1.8.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 
+appVersion: 1.8.1
 
 dependencies:
   - name: postgresql

--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.8.2
+version: 1.8.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 1.8.2
+appVersion: 1.8.3
 
 dependencies:
   - name: postgresql

--- a/frontend/cypress/e2e/complaint-collaborators.cy.ts
+++ b/frontend/cypress/e2e/complaint-collaborators.cy.ts
@@ -33,6 +33,7 @@ describe("Complaint collaborators have the correct permissions", () => {
     cy.visit(`${Cypress.config().baseUrl}/complaint/HWCR/${COMPLAINT_ID}`);
     cy.contains("COS added you to this complaint as a collaborator").should("exist");
     cy.get("#details-screen-update-status-button").should("be.disabled");
+    cy.get("#outcome-report-add-note").should("not.be.disabled");
   });
 });
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nr-sample-natcomplaints",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "private": true,
   "dependencies": {
     "@craco/craco": "^7.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nr-sample-natcomplaints",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "private": true,
   "dependencies": {
     "@craco/craco": "^7.1.0",

--- a/frontend/src/app/components/containers/complaints/outcomes/notes.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/notes.tsx
@@ -5,13 +5,17 @@ import { selectIsInEdit, selectNotes } from "@store/reducers/case-selectors";
 import { ComplaintParams } from "@components/containers/complaints/details/complaint-details-edit";
 import { Note } from "./notes/note";
 import { useAppSelector } from "@/app/hooks/hooks";
-import { selectComplaintViewMode } from "@/app/store/reducers/complaints";
+import { selectComplaintViewMode, selectComplaintCollaborators } from "@/app/store/reducers/complaints";
+import { personGuid } from "@/app/store/reducers/app";
 
 export const Notes: FC = () => {
   const { id = "", complaintType = "" } = useParams<ComplaintParams>();
   const isInEdit = useAppSelector(selectIsInEdit);
   const isReadOnly = useAppSelector(selectComplaintViewMode);
   const notes = useAppSelector(selectNotes);
+  const collaborators = useAppSelector(selectComplaintCollaborators);
+  const userPersonGuid = useAppSelector(personGuid);
+  const [userIsCollaborator, setUserIsCollaborator] = useState<boolean>(false);
 
   const [showAddNote, setShowAddNote] = useState(false);
 
@@ -20,6 +24,10 @@ export const Notes: FC = () => {
       setShowAddNote(false);
     }
   }, [isInEdit.notes]);
+
+  useEffect(() => {
+    setUserIsCollaborator(collaborators.some((c) => c.personGuid === userPersonGuid));
+  }, [collaborators, userPersonGuid]);
 
   return (
     <section
@@ -49,7 +57,7 @@ export const Notes: FC = () => {
           id="outcome-report-add-note"
           title="Add additional notes"
           onClick={(e) => setShowAddNote(true)}
-          disabled={isReadOnly}
+          disabled={isReadOnly && !userIsCollaborator}
         >
           <i className="bi bi-plus-circle"></i>
           <span>Add note</span>

--- a/frontend/src/app/components/containers/complaints/outcomes/notes.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/notes.tsx
@@ -5,7 +5,11 @@ import { selectIsInEdit, selectNotes } from "@store/reducers/case-selectors";
 import { ComplaintParams } from "@components/containers/complaints/details/complaint-details-edit";
 import { Note } from "./notes/note";
 import { useAppSelector } from "@/app/hooks/hooks";
-import { selectComplaintViewMode, selectComplaintCollaborators } from "@/app/store/reducers/complaints";
+import {
+  selectComplaintViewMode,
+  selectComplaintCollaborators,
+  selectComplaint,
+} from "@/app/store/reducers/complaints";
 import { personGuid } from "@/app/store/reducers/app";
 
 export const Notes: FC = () => {
@@ -16,6 +20,14 @@ export const Notes: FC = () => {
   const collaborators = useAppSelector(selectComplaintCollaborators);
   const userPersonGuid = useAppSelector(personGuid);
   const [userIsCollaborator, setUserIsCollaborator] = useState<boolean>(false);
+  const complaint = useAppSelector(selectComplaint);
+  const [status, setStatus] = useState("CLOSED");
+
+  useEffect(() => {
+    if (complaint) {
+      setStatus(complaint.status);
+    }
+  }, [complaint]);
 
   const [showAddNote, setShowAddNote] = useState(false);
 
@@ -57,7 +69,7 @@ export const Notes: FC = () => {
           id="outcome-report-add-note"
           title="Add additional notes"
           onClick={(e) => setShowAddNote(true)}
-          disabled={isReadOnly && !userIsCollaborator}
+          disabled={(isReadOnly && !userIsCollaborator) || status === "CLOSED"}
         >
           <i className="bi bi-plus-circle"></i>
           <span>Add note</span>

--- a/webeoc/package.json
+++ b/webeoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webeoc",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "",
   "author": "",
   "private": true,

--- a/webeoc/package.json
+++ b/webeoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webeoc",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "",
   "author": "",
   "private": true,


### PR DESCRIPTION
Allow collaborators to add notes

# Description

Users need the ability to add notes to complaints that they have been added as a collaborator on. This PR adds a check to the Notes component to check if the user is a collaborator, and prevents disabling of the functionality if they are.

Fixes # 1556
https://env-ceds.atlassian.net/jira/software/c/projects/CE/boards/4?selectedIssue=CE-1556

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Collaborator cypress test verifies the button is active for collaborator
- [ ] Manually tested adding a note as a collaborator, and verified it shows up for the owning agency as well.


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-1032-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-1032-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)