### PR TITLE
fix: Refresh officer list when user admin updates user

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nr-compliance-enforcement",
-  "version": "1.7.17",
+  "version": "1.9.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nr-compliance-enforcement",
-      "version": "1.7.17",
+      "version": "1.9.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@automapper/classes": "^8.8.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nr-compliance-enforcement",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "BCGov devops quickstart. For reference, testing and new projects.",
   "main": "index.js",
   "scripts": {

--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.9.2
+version: 1.9.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 1.9.2
+appVersion: 1.9.3
 
 dependencies:
   - name: postgresql

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nr-sample-natcomplaints",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "private": true,
   "dependencies": {
     "@craco/craco": "^7.1.0",

--- a/frontend/src/app/components/containers/admin/user-management/edit-user.tsx
+++ b/frontend/src/app/components/containers/admin/user-management/edit-user.tsx
@@ -307,6 +307,7 @@ export const EditUser: FC<EditUserProps> = ({
           );
 
           if (res?.team && res?.roles) {
+            dispatch(getOfficers()); //refresh the officer list to get the latest changes
             ToggleSuccess("Officer updated successfully");
           } else {
             ToggleError("Unable to update");
@@ -328,7 +329,7 @@ export const EditUser: FC<EditUserProps> = ({
         );
 
         if (res?.roles) {
-          dispatch(getOfficers());
+          dispatch(getOfficers()); //refresh the officer list to get the latest changes
           ToggleSuccess("Officer updated successfully");
         } else {
           ToggleError("Unable to update");

--- a/webeoc/package.json
+++ b/webeoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webeoc",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "",
   "author": "",
   "private": true,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Please provide a summary of the change and the issue fixed. Please include relevant context. List dependency changes.

The issue here is that when a user changes a CEEB officer, the refreshed roles aren't pulled into Redux so it looks like the change did not take place unless the app is refreshed.   The fix was to pull the refreshed officer list after the change had been made.

Fixes # CE-1639

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-1057-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-1057-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)