### PR TITLE
fix: CE-1664-BC-Parks-Area-Filter-not-appearing-as-a-pill-in-the-applied-filters

### DIFF
--- a/frontend/src/app/components/containers/complaints/complaint-filter-bar.tsx
+++ b/frontend/src/app/components/containers/complaints/complaint-filter-bar.tsx
@@ -32,6 +32,7 @@ export const ComplaintFilterBar: FC<Props> = ({
     region,
     zone,
     community,
+    area,
     park,
     officer,
     startDate,
@@ -304,6 +305,14 @@ export const ComplaintFilterBar: FC<Props> = ({
             id="comp-complaint-method-filter"
             label={equipmentTypes?.map((type) => type.label).join(", ")}
             name="equipmentTypes"
+            clear={removeFilter}
+          />
+        )}
+        {hasFilter("area") && (
+          <FilterButton
+            id="comp-complaint-method-filter"
+            label={area?.label}
+            name="area"
             clear={removeFilter}
           />
         )}


### PR DESCRIPTION

# Description

This PR is to fix an issue of missing pill for BC Parks area in the complaint filters. 

Fixes # (CE-1664)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Filter complaint list by an area. Check if a pill for the chosen area appears in the filter header.


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
