### PR TITLE
fix: Improve assessment cypress tests

### DIFF
--- a/frontend/cypress/e2e/change-complaint-status-details-view.cy.ts
+++ b/frontend/cypress/e2e/change-complaint-status-details-view.cy.ts
@@ -21,9 +21,12 @@ describe("Complaint Change Status spec - Details View", () => {
       actionRequired: "Yes",
       toastText: "Assessment has been saved",
     };
-    // If assessment button exists, click it
-    cy.get("#outcome-assessments").then(($assessmentSection) => {
-      if ($assessmentSection.find("#outcome-report-add-assessment").length) {
+    // If assessment edit button exists, click it
+    cy.get("#outcome-assessments").then(function ($assessments) {
+      if ($assessments.find("#assessment-edit-button").length) {
+        sectionParams.toastText = "Assessment has been updated";
+        cy.get("#assessment-edit-button").click();
+      } else if ($assessments.find("#outcome-report-add-assessment").length) {
         cy.get("#outcome-report-add-assessment").click({ force: true });
       }
     });

--- a/frontend/cypress/e2e/hwcr-outcome-assessment.cy.ts
+++ b/frontend/cypress/e2e/hwcr-outcome-assessment.cy.ts
@@ -43,13 +43,20 @@ describe("HWCR Outcome Assessments", () => {
     //This is required to make the tests re-runnable.  It's not great because it means it will only run the first time.
     //If we ever get the ability to remove an assessment this test suite should be rewritten to remove this conditional
     //and to add a test at the end to delete the assessment.
-    cy.get("#outcome-assessments").then(($assessmentSection) => {
-      if ($assessmentSection.find("#outcome-report-add-assessment").length) {
-        cy.get("#outcome-report-add-assessment").click({ force: true });
+
+    // If assessment edit button exists, skip this test
+    cy.get("#outcome-assessments").then(function ($assessments) {
+      if ($assessments.find("#assessment-edit-button").length) {
+        cy.log("Test was previously run. Skip the Test");
+        this.skip();
       }
     });
-    cy.get(".comp-outcome-report-complaint-assessment").then(function ($assessment) {
-      if ($assessment.find("#outcome-save-button").length) {
+
+    cy.get("#outcome-assessments").then(function ($assessments) {
+      if ($assessments.find("#outcome-report-add-assessment").length) {
+        cy.get("#outcome-report-add-assessment").click({ force: true });
+      }
+      if ($assessments.find("#outcome-save-button").length) {
         cy.validateComplaint("23-033066", "Coyote");
 
         let sectionParams = {
@@ -66,9 +73,6 @@ describe("HWCR Outcome Assessments", () => {
 
           cy.validateHWCSection(sectionParams);
         });
-      } else {
-        cy.log("Test was previously run. Skip the Test");
-        this.skip();
       }
     });
   });
@@ -78,13 +82,8 @@ describe("HWCR Outcome Assessments", () => {
 
     cy.validateComplaint("23-033066", "Coyote");
 
-    cy.get("#outcome-assessments").then(($assessmentSection) => {
-      if ($assessmentSection.find("#outcome-report-add-assessment").length) {
-        cy.get("#outcome-report-add-assessment").click({ force: true });
-      }
-    });
-    cy.get(".comp-outcome-report-complaint-assessment").then(function ($assessment) {
-      if ($assessment.find("#assessment-edit-button").length) {
+    cy.get("#outcome-assessments").then(($assessments) => {
+      if ($assessments.find("#assessment-edit-button").length) {
         cy.get("#assessment-edit-button").click();
 
         cy.get("#action-required-div")
@@ -108,9 +107,6 @@ describe("HWCR Outcome Assessments", () => {
               });
             }
           });
-      } else {
-        cy.log("Assessment Not Found, did a previous test fail? Skip the Test");
-        this.skip();
       }
     });
   });

--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-assessment/hwcr-assessment-item.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-assessment/hwcr-assessment-item.tsx
@@ -205,7 +205,7 @@ export const HWCRAssessmentItem: FC<Props> = ({ assessment, handleEdit }) => {
             <Button
               variant="outline-primary"
               size="sm"
-              id="notes-edit-button"
+              id="assessment-edit-button"
               onClick={() => handleEdit()}
               disabled={isReadOnly}
             >


### PR DESCRIPTION
Fix a couple bugs in the tests related to assessments, as well as prevent the creation of infinite numbers of assessments by editing instead of creating an assessment if one already exists.