### PR TITLE
feat: CE-1624 Lead agency of a complaint cannot edit data provided by other agency

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nr-compliance-enforcement",
-  "version": "1.9.28",
+  "version": "1.9.29",
   "description": "BCGov devops quickstart. For reference, testing and new projects.",
   "main": "index.js",
   "scripts": {

--- a/backend/src/external_api/shared_data.ts
+++ b/backend/src/external_api/shared_data.ts
@@ -77,6 +77,7 @@ export const caseFileQueryFields: string = `
   notes {
     id
     note 
+    agencyCode
     actions { 
       actor
       actionCode

--- a/backend/src/v1/shared_data/case_file/case_file.service.ts
+++ b/backend/src/v1/shared_data/case_file/case_file.service.ts
@@ -457,7 +457,7 @@ export class CaseFileService {
       query: `mutation CreateNote($input: CreateNoteInput!) {
         createNote(input: $input) {
           caseIdentifier
-          notes { note, actions { actor, date, actionCode, actionId } }
+          notes { note, agencyCode, actions { actor, date, actionCode, actionId } }
         }
       }`,
       variables: { input: model },

--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.9.28
+version: 1.9.29
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 1.9.28
+appVersion: 1.9.29
 
 dependencies:
   - name: postgresql

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nr-sample-natcomplaints",
-  "version": "1.9.28",
+  "version": "1.9.29",
   "private": true,
   "dependencies": {
     "@craco/craco": "^7.1.0",

--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-assessment/hwcr-assessment-form.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-assessment/hwcr-assessment-form.tsx
@@ -45,6 +45,7 @@ import { Officer } from "@/app/types/person/person";
 import { RootState } from "@/app/store/store";
 import { useSelector } from "react-redux";
 import KeyValuePair from "@/app/types/app/key-value-pair";
+import UserService from "@/app/service/user-service";
 
 type Props = {
   id: string;
@@ -311,6 +312,7 @@ export const HWCRAssessmentForm: FC<Props> = ({
       selectedActionRequired?.label === OptionLabels.OPTION_NO || !isLargeCarnivore
         ? []
         : mapOptions(selectedAssessmentCat1Types),
+    agency: UserService.getUserAgency(),
   });
 
   // save to redux if no errors.  Otherwise, display error message(s).

--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-assessment/hwcr-assessment-item.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-assessment/hwcr-assessment-item.tsx
@@ -12,6 +12,7 @@ import { Assessment } from "@apptypes/outcomes/assessment";
 import { Badge, Button, Card } from "react-bootstrap";
 
 import "@assets/sass/hwcr-assessment.scss";
+import UserService from "@/app/service/user-service";
 
 type Props = {
   assessment: Assessment;
@@ -207,7 +208,7 @@ export const HWCRAssessmentItem: FC<Props> = ({ assessment, handleEdit }) => {
               size="sm"
               id="assessment-edit-button"
               onClick={() => handleEdit()}
-              disabled={isReadOnly}
+              disabled={isReadOnly || assessment.agency !== UserService.getUserAgency()}
             >
               <i className="bi bi-pencil"></i>
               <span>Edit</span>

--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-assessment/hwcr-assessment-item.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-assessment/hwcr-assessment-item.tsx
@@ -208,7 +208,7 @@ export const HWCRAssessmentItem: FC<Props> = ({ assessment, handleEdit }) => {
               size="sm"
               id="assessment-edit-button"
               onClick={() => handleEdit()}
-              disabled={isReadOnly || assessment.agency !== UserService.getUserAgency()}
+              disabled={isReadOnly === true || assessment.agency !== UserService.getUserAgency()}
             >
               <i className="bi bi-pencil"></i>
               <span>Edit</span>

--- a/frontend/src/app/components/containers/complaints/outcomes/notes/note-form.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/notes/note-form.tsx
@@ -12,6 +12,7 @@ import { upsertNote, getCaseFile } from "@store/reducers/case-thunks";
 import { BsExclamationCircleFill } from "react-icons/bs";
 import { ToggleError } from "@common/toast";
 import { Note } from "@/app/types/outcomes/note";
+import UserService from "@/app/service/user-service";
 
 type props = {
   id: string;
@@ -70,7 +71,7 @@ export const NoteForm: FC<props> = ({ id, complaintType, note, currentOfficer, m
 
   const handleSaveNotes = () => {
     if (validateInput()) {
-      dispatch(upsertNote(id, complaintType, currentNote, note?.id)).then((result) => {
+      dispatch(upsertNote(id, complaintType, currentNote, UserService.getUserAgency(), note?.id)).then((result) => {
         if (result === "success") {
           dispatch(getCaseFile(id));
           handleCancel();

--- a/frontend/src/app/components/containers/complaints/outcomes/notes/note-item.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/notes/note-item.tsx
@@ -11,12 +11,14 @@ import {
 } from "@/app/store/reducers/complaints";
 import { selectOfficers } from "@/app/store/reducers/officer";
 import { personGuid } from "@/app/store/reducers/app";
+import UserService from "@/app/service/user-service";
 
 type props = {
   note: string;
   actions?: CaseAction[];
   handleEdit: Function;
   handleDelete: Function;
+  agencyCode: string;
 };
 
 const getActorDisplayName = (actor: string, officers: any) => {
@@ -26,7 +28,7 @@ const getActorDisplayName = (actor: string, officers: any) => {
 
 const longNoteLength = 300;
 
-export const NoteItem: FC<props> = ({ note, actions = [], handleEdit, handleDelete }) => {
+export const NoteItem: FC<props> = ({ note, actions = [], handleEdit, handleDelete, agencyCode }) => {
   const officers = useAppSelector(selectOfficers);
   const isReadOnly = useAppSelector(selectComplaintViewMode);
   const collaborators = useAppSelector(selectComplaintCollaborators);
@@ -115,7 +117,9 @@ export const NoteItem: FC<props> = ({ note, actions = [], handleEdit, handleDele
               size="sm"
               id="notes-edit-button"
               onClick={() => handleEdit()}
-              disabled={(isReadOnly && !userIsCollaborator) || status === "CLOSED"}
+              disabled={
+                (isReadOnly && !userIsCollaborator) || status === "CLOSED" || agencyCode !== UserService.getUserAgency()
+              }
             >
               <i className="bi bi-pencil"></i>
               <span>Edit</span>
@@ -125,7 +129,9 @@ export const NoteItem: FC<props> = ({ note, actions = [], handleEdit, handleDele
               variant="outline-primary"
               id="notes-delete-button"
               onClick={() => handleDelete()}
-              disabled={(isReadOnly && !userIsCollaborator) || status === "CLOSED"}
+              disabled={
+                (isReadOnly && !userIsCollaborator) || status === "CLOSED" || agencyCode !== UserService.getUserAgency()
+              }
             >
               <i className="bi bi-trash3"></i>
               <span>Delete</span>

--- a/frontend/src/app/components/containers/complaints/outcomes/notes/note.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/notes/note.tsx
@@ -63,6 +63,7 @@ export const Note: FC<props> = ({ id = "", complaintType = "", note }) => {
             actions={note.actions}
             handleEdit={() => setShowInput(true)}
             handleDelete={openDeleteNoteModal}
+            agencyCode={note.agencyCode}
           />
         )
       )}

--- a/frontend/src/app/store/reducers/case-thunks.ts
+++ b/frontend/src/app/store/reducers/case-thunks.ts
@@ -133,7 +133,7 @@ const addAssessment =
       leadIdentifier: complaintIdentifier,
       caseIdentifier: caseIdentifier,
       createUserId: profile.idir_username,
-      agencyCode: "COS",
+      agencyCode: assessment.agency,
       caseCode: "HWCR",
       assessment: {
         actionNotRequired: assessment.action_required === "No",
@@ -585,6 +585,7 @@ export const upsertNote =
     leadIdentifier: string,
     complaintType: string,
     note: string,
+    agencyCode: string,
     id?: UUID,
   ): ThunkAction<Promise<string | undefined>, RootState, unknown, Action<string>> =>
   async (dispatch, getState) => {
@@ -602,12 +603,13 @@ export const upsertNote =
         note: string,
         actor: string,
         userId: string,
+        agencyCode: string,
       ): ThunkAction<Promise<CaseFileDto>, RootState, unknown, Action<string>> =>
       async (dispatch) => {
         const input: CreateNoteInput = {
           note,
           leadIdentifier: leadIdentifier,
-          agencyCode: getUserAgency(),
+          agencyCode: agencyCode,
           caseCode: complaintType,
           actor,
           createUserId: userId,
@@ -644,7 +646,9 @@ export const upsertNote =
 
     let result;
     if (!id) {
-      result = await dispatch(_createNote(leadIdentifier, note, officer ? officer.auth_user_guid : "", idir));
+      result = await dispatch(
+        _createNote(leadIdentifier, note, officer ? officer.auth_user_guid : "", idir, agencyCode),
+      );
 
       if (result !== null) {
         dispatch(setCaseId(result.caseIdentifier)); //ideally check if caseId exists first, if not then do this function.

--- a/frontend/src/app/types/outcomes/note.ts
+++ b/frontend/src/app/types/outcomes/note.ts
@@ -4,5 +4,6 @@ import { CaseAction } from "./case-action";
 export interface Note {
   id: UUID;
   note: string;
+  agencyCode: string;
   actions?: CaseAction[];
 }

--- a/webeoc/package.json
+++ b/webeoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webeoc",
-  "version": "1.9.28",
+  "version": "1.9.29",
   "description": "",
   "author": "",
   "private": true,


### PR DESCRIPTION
# Description

This PR is to allow editing notes, assessment and prevention/education only by the agency which added them.

Fixes # (CE-1624)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Add assessment, prevention/education and a note to a complaint. Refer it to another agency. Log in as a user from that agency. Check if editing is disabled for the items you added at the first step 


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-1093-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-1093-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)