### PR TITLE
fix: CE-1693 collab can no longer add notes to a complaint

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nr-compliance-enforcement",
-  "version": "1.9.30",
+  "version": "1.9.31",
   "description": "BCGov devops quickstart. For reference, testing and new projects.",
   "main": "index.js",
   "scripts": {

--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.9.30
+version: 1.9.31
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 1.9.30
+appVersion: 1.9.31
 
 dependencies:
   - name: postgresql

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nr-sample-natcomplaints",
-  "version": "1.9.30",
+  "version": "1.9.31",
   "private": true,
   "dependencies": {
     "@craco/craco": "^7.1.0",

--- a/frontend/src/app/components/containers/complaints/outcomes/notes/note-item.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/notes/note-item.tsx
@@ -68,6 +68,10 @@ export const NoteItem: FC<props> = ({ note, actions = [], handleEdit, handleDele
       ))}
     </Tooltip>
   );
+  const isDisabled = () => {
+    const isEnabled = status !== "CLOSED" && (userIsCollaborator || agencyCode === UserService.getUserAgency());
+    return !isEnabled;
+  };
 
   return (
     <Card className="comp-outcome-notes">
@@ -117,9 +121,7 @@ export const NoteItem: FC<props> = ({ note, actions = [], handleEdit, handleDele
               size="sm"
               id="notes-edit-button"
               onClick={() => handleEdit()}
-              disabled={
-                (isReadOnly && !userIsCollaborator) || status === "CLOSED" || agencyCode !== UserService.getUserAgency()
-              }
+              disabled={isDisabled()}
             >
               <i className="bi bi-pencil"></i>
               <span>Edit</span>
@@ -129,9 +131,7 @@ export const NoteItem: FC<props> = ({ note, actions = [], handleEdit, handleDele
               variant="outline-primary"
               id="notes-delete-button"
               onClick={() => handleDelete()}
-              disabled={
-                (isReadOnly && !userIsCollaborator) || status === "CLOSED" || agencyCode !== UserService.getUserAgency()
-              }
+              disabled={isDisabled()}
             >
               <i className="bi bi-trash3"></i>
               <span>Delete</span>

--- a/webeoc/package.json
+++ b/webeoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webeoc",
-  "version": "1.9.30",
+  "version": "1.9.31",
   "description": "",
   "author": "",
   "private": true,


### PR DESCRIPTION

# Description

This PR is to fix a bug when a collaborator is unable to edit notes of the complaint they were invited to collaborate to.

Fixes # (CE-1693)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Add a note to a complaint. Add a collaborator to that complaint. Sign in as this collaborator. Check if you are able to edit the note from the first step. 


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-1094-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-1094-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)