### PR TITLE
fix: CE-1709 Officers GUIDS not translated in some sections when direct linking to a complaint

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nr-compliance-enforcement",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "description": "BCGov devops quickstart. For reference, testing and new projects.",
   "main": "index.js",
   "scripts": {

--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.14
+version: 2.0.15
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 2.0.14
+appVersion: 2.0.15
 
 dependencies:
   - name: postgresql

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nr-sample-natcomplaints",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "private": true,
   "dependencies": {
     "@craco/craco": "^7.1.0",

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
@@ -35,7 +35,7 @@ import { Officer } from "@apptypes/person/person";
 import Option from "@apptypes/app/option";
 import COMPLAINT_TYPES from "@apptypes/app/complaint-types";
 import { ComplaintSuspectWitness } from "@apptypes/complaints/details/complaint-suspect-witness-details";
-import { selectOfficersByAgency } from "@store/reducers/officer";
+import { selectOfficersByAgency, selectOfficers } from "@store/reducers/officer";
 import { ComplaintLocation } from "./complaint-location";
 import { ValidationTextArea } from "@common/validation-textarea";
 import { ValidationMultiSelect } from "@common/validation-multiselect";
@@ -92,10 +92,11 @@ export const ComplaintDetailsEdit: FC = () => {
   const dispatch = useAppDispatch();
 
   const { id = "", complaintType = "" } = useParams<ComplaintParams>();
+  const allOfficers = useSelector((state: RootState) => selectOfficers(state));
 
   useEffect(() => {
     dispatch(getCaseFile(id));
-  }, [id, dispatch]);
+  }, [id, dispatch, allOfficers]);
 
   //-- selectors
   const data = useAppSelector(selectComplaint);

--- a/webeoc/package.json
+++ b/webeoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webeoc",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "description": "",
   "author": "",
   "private": true,


### PR DESCRIPTION
# Description

This PR is to fix an issue when officer GUIDS are displayed instead of names in the outcome assessment and prevention/education sections when direct linking to a complaint

Fixes # (CE-1709)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Fill in the Assessment and Prevention and Education sections. Copy the URL of the complaint. 
In an incognito window access the complaint directly. Check if officer names are displayed in a view mode of the assessment and prevention/education sections.


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-1119-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-1119-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)