### PR TITLE
fix:CE-1734 update community mapping for New Westminster

### DIFF
--- a/migrations/migrations/R__Create-Test-Data.sql
+++ b/migrations/migrations/R__Create-Test-Data.sql
@@ -11380,6 +11380,11 @@ values ('REFEMAIL','DFO','N',user,now(),user,now()),
 ('REFEMAIL','OTH','N',user,now(),user,now())
 ON CONFLICT DO NOTHING;
 
+-------------------------
+-- Move New Westminster in Location Hierarchy
+-------------------------
+UPDATE geo_org_unit_structure SET parent_geo_org_unit_code = 'SQMSHWHS' WHERE child_geo_org_unit_code  = 'NEWWEST';
+
 --------------------------
 -- New Changes above this line
 -------------------------


### PR DESCRIPTION
# Description

This PR is to fix OS office/zone mapping of New Westminster community in NatCom to match Webeoc

Fixes # (CE-1734)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Filter COS complaint list by "New Westminster"  community. Open any of the filtered complaints.  Check if the zone, and office are shown correctly.  
              Office: Squamish/Whistler
              Zone: Sea to Sky
   
## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
