### PR TITLE
fix: Sector View - Use code table instead of type for agency description

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nr-compliance-enforcement",
-  "version": "2.0.24",
+  "version": "2.0.25",
   "description": "BCGov devops quickstart. For reference, testing and new projects.",
   "main": "index.js",
   "scripts": {

--- a/backend/src/v1/complaint_referral/complaint_referral.service.ts
+++ b/backend/src/v1/complaint_referral/complaint_referral.service.ts
@@ -81,14 +81,10 @@ export class ComplaintReferralService {
     this._personService.clearAssignedOfficer(createComplaintReferralDto.complaint_identifier);
 
     if (sendEmail) {
-      const recipientList = await this._emailService.sendReferralEmail(
-        createComplaintReferralDto,
-        user,
-        complaintExport,
-      );
+      await this._emailService.sendReferralEmail(createComplaintReferralDto, user, complaintExport);
 
-      // Log the email recipients
-      const createPromises = recipientList.map((emailAddress) => {
+      // Log the additional emails
+      const createPromises = createComplaintReferralDto.additionalEmailRecipients.map((emailAddress) => {
         const emailReferralLog: CreateComplaintReferralEmailLogDto = {
           complaint_referral_email_log_guid: uuidv4(),
           email_address: emailAddress,

--- a/backend/src/v1/complaint_referral/complaint_referral.service.ts
+++ b/backend/src/v1/complaint_referral/complaint_referral.service.ts
@@ -81,10 +81,14 @@ export class ComplaintReferralService {
     this._personService.clearAssignedOfficer(createComplaintReferralDto.complaint_identifier);
 
     if (sendEmail) {
-      await this._emailService.sendReferralEmail(createComplaintReferralDto, user, complaintExport);
+      const recipientList = await this._emailService.sendReferralEmail(
+        createComplaintReferralDto,
+        user,
+        complaintExport,
+      );
 
-      // Log the additional emails
-      const createPromises = createComplaintReferralDto.additionalEmailRecipients.map((emailAddress) => {
+      // Log the email recipients
+      const createPromises = recipientList.map((emailAddress) => {
         const emailReferralLog: CreateComplaintReferralEmailLogDto = {
           complaint_referral_email_log_guid: uuidv4(),
           email_address: emailAddress,

--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.24
+version: 2.0.25
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 2.0.24
+appVersion: 2.0.25
 
 dependencies:
   - name: postgresql

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nr-sample-natcomplaints",
-  "version": "2.0.24",
+  "version": "2.0.25",
   "private": true,
   "dependencies": {
     "@craco/craco": "^7.1.0",

--- a/frontend/src/app/components/containers/complaints/complaint-list.tsx
+++ b/frontend/src/app/components/containers/complaints/complaint-list.tsx
@@ -176,7 +176,7 @@ export const ComplaintList: FC<Props> = ({ type, searchQuery }) => {
   useEffect(() => {
     //-- when the component unmounts clear the complaint from redux
     return () => {
-      dispatch(setComplaints({ type: { type }, data: [] }));
+      dispatch(setComplaints({ type: type, data: [] }));
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/frontend/src/app/components/containers/complaints/list-items/sector-complaint-list-item.tsx
+++ b/frontend/src/app/components/containers/complaints/list-items/sector-complaint-list-item.tsx
@@ -8,7 +8,6 @@ import { getUserAgency } from "@/app/service/user-service";
 import { FeatureFlag } from "@/app/components/common/feature-flag";
 import { FEATURE_TYPES } from "@/app/constants/feature-flag-types";
 import { complaintTypeToName } from "@apptypes/app/complaint-types";
-import { AgencyNames } from "@/app/types/app/agency-types";
 
 type Props = {
   complaint: any;
@@ -20,6 +19,7 @@ export const SectorComplaintListItem: FC<Props> = ({ complaint }) => {
   const natureOfComplaints = useAppSelector(selectCodeTable(CODE_TABLE_TYPES.NATURE_OF_COMPLAINT));
   const girTypeCodes = useAppSelector(selectCodeTable(CODE_TABLE_TYPES.GIR_TYPE));
   const violationCodes = useAppSelector(selectCodeTable(CODE_TABLE_TYPES.VIOLATIONS));
+  const agencies = useAppSelector(selectCodeTable(CODE_TABLE_TYPES.AGENCY));
 
   const [isExpanded, setIsExpanded] = useState(false);
   const [isRowHovered, setIsRowHovered] = useState(false);
@@ -125,7 +125,7 @@ export const SectorComplaintListItem: FC<Props> = ({ complaint }) => {
           className={`${isExpandedClass}`}
           onClick={toggleExpand}
         >
-          {AgencyNames[ownedBy as keyof typeof AgencyNames].long}
+          {agencies?.length > 0 && agencies.filter((agency: any) => agency.agency === ownedBy)[0]?.longDescription}
         </td>
         <td
           className={`${isExpandedClass}`}

--- a/webeoc/package.json
+++ b/webeoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webeoc",
-  "version": "2.0.24",
+  "version": "2.0.25",
   "description": "",
   "author": "",
   "private": true,


### PR DESCRIPTION
- Refer a complaint to an external agency, then verify the sector list does not error.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-1147-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-1147-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)