### PR TITLE
fix: CE-1765 refer button hidden in modal on smaller screen sizes

### DIFF
--- a/frontend/src/app/components/modal/instances/refer-complaint-modal.tsx
+++ b/frontend/src/app/components/modal/instances/refer-complaint-modal.tsx
@@ -222,10 +222,10 @@ export const ReferComplaintModal: FC<ReferComplaintModalProps> = ({ close, submi
   }, [assignableOfficers, currentOfficer]);
 
   return (
-    <div style={{ maxHeight: "90vh", overflow: "hidden" }}>
+    <div style={{ maxHeight: "90vh", overflow: "hidden", display: "flex", flexDirection: "column" }}>
       {title && (
         <Modal.Header
-          style={{ paddingBottom: 0, marginBottom: -10 }}
+          style={{ paddingBottom: 0, marginBottom: 0 }}
           closeButton={true}
         >
           <Modal.Title as="h3">


### PR DESCRIPTION
# Description

This PR is to ensure that the modal footer that contains Refer and  Cancel buttons is not hidden on the devices with small screen size.

Fixes # (CE-1765)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Reduce the window size on your monitor or laptop to be smaller than normal. Attempt to refer a complaint. Check if Refer button is visible

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-1170-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-1170-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)