### PR TITLE
chore: CE-839 fix disabled datepicker colors on ipad

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nr-compliance-enforcement",
-  "version": "2.0.38",
+  "version": "2.0.39",
   "description": "BCGov devops quickstart. For reference, testing and new projects.",
   "main": "index.js",
   "scripts": {

--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.38
+version: 2.0.39
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 2.0.38
+appVersion: 2.0.39
 
 dependencies:
   - name: postgresql

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nr-sample-natcomplaints",
   "type": "module",
-  "version": "2.0.38",
+  "version": "2.0.39",
   "private": true,
   "dependencies": {
     "@faker-js/faker": "^8.0.2",

--- a/frontend/src/assets/sass/misc.scss
+++ b/frontend/src/assets/sass/misc.scss
@@ -287,6 +287,7 @@
   background-color: hsl(0, 0%, 95%);
   border-color: hwb(0 90% 10%);
   color: hsl(0, 0%, 60%);
+  opacity: 100%;
 }
 
 .filter-pill-close {

--- a/webeoc/package.json
+++ b/webeoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webeoc",
-  "version": "2.0.38",
+  "version": "2.0.39",
   "description": "",
   "author": "",
   "private": true,


### PR DESCRIPTION
Make disabled datepicker on ipad legible.

# Description

The disabled datepicker on the ipad was getting a reduced opacity making it illegible. This forces it's opacity to 100%.

Fixes # CE-839

# How Has This Been Tested?

Tested on an iPad simulator via XCode on a mac.


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-1173-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-1173-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)