### PR TITLE
chore: CE-1825 run playwright before cypress

### DIFF
--- a/.github/workflows/.tests.yml
+++ b/.github/workflows/.tests.yml
@@ -70,40 +70,6 @@ jobs:
           else
             echo "No high risk issues found."
           fi
-  cypress-tests:
-    env:
-      DOMAIN: apps.silver.devops.gov.bc.ca
-      PREFIX: ${{ github.event.repository.name }}-${{ inputs.target }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout GitCode
-        uses: actions/checkout@v3
-
-      - name: Debug secrets
-        run: |
-          echo "Checking secrets..."
-          echo "auth_base_url: ${{ vars.KEYCLOAK_URL_DEV }}"
-          echo "auth_realm: ${{ vars.KEYCLOAK_REALM }}"
-          echo "keycloak_user: ${{ vars.KEYCLOAK_USER }}"
-          echo "keycloak_client_id: ${{ vars.KEYCLOAK_CLIENT_ID }}"
-
-        env:
-          KEYCLOAK_PASSWORD: ${{ secrets.KEYCLOAK_PASSWORD }}
-
-      - name: Run Cypress Test
-        uses: cypress-io/github-action@v5
-        with:
-          working-directory: ./frontend
-          command: npx cypress run --browser electron --config baseUrl=https://${{ env.PREFIX }}-frontend.${{ env.DOMAIN }} --env auth_base_url=${{ vars.KEYCLOAK_URL_DEV }},auth_realm=${{ vars.KEYCLOAK_REALM }},auth_client_id=${{ vars.KEYCLOAK_CLIENT_ID }},keycloak_user=${{ vars.KEYCLOAK_USER }},keycloak_user_02=${{ vars.KEYCLOAK_USER_02 }},keycloak_user_03=${{ vars.KEYCLOAK_USER_03 }},keycloak_password=${{ secrets.KEYCLOAK_PASSWORD }}
-
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: cypress-artifacts
-          path: |-
-            /home/runner/work/nr-compliance-enforcement/nr-compliance-enforcement/frontend/cypress/videos/
-            /home/runner/work/nr-compliance-enforcement/nr-compliance-enforcement/frontend/cypress/screenshots/
   playwright-tests:
     name: "Playwright Tests"
     timeout-minutes: 60
@@ -150,3 +116,39 @@ jobs:
         with:
           name: playwright-report
           path: /home/runner/work/nr-compliance-enforcement/nr-compliance-enforcement/frontend/playwright-report
+
+  cypress-tests:
+    needs: playwright-tests
+    env:
+      DOMAIN: apps.silver.devops.gov.bc.ca
+      PREFIX: ${{ github.event.repository.name }}-${{ inputs.target }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout GitCode
+        uses: actions/checkout@v3
+
+      - name: Debug secrets
+        run: |
+          echo "Checking secrets..."
+          echo "auth_base_url: ${{ vars.KEYCLOAK_URL_DEV }}"
+          echo "auth_realm: ${{ vars.KEYCLOAK_REALM }}"
+          echo "keycloak_user: ${{ vars.KEYCLOAK_USER }}"
+          echo "keycloak_client_id: ${{ vars.KEYCLOAK_CLIENT_ID }}"
+
+        env:
+          KEYCLOAK_PASSWORD: ${{ secrets.KEYCLOAK_PASSWORD }}
+
+      - name: Run Cypress Test
+        uses: cypress-io/github-action@v5
+        with:
+          working-directory: ./frontend
+          command: npx cypress run --browser electron --config baseUrl=https://${{ env.PREFIX }}-frontend.${{ env.DOMAIN }} --env auth_base_url=${{ vars.KEYCLOAK_URL_DEV }},auth_realm=${{ vars.KEYCLOAK_REALM }},auth_client_id=${{ vars.KEYCLOAK_CLIENT_ID }},keycloak_user=${{ vars.KEYCLOAK_USER }},keycloak_user_02=${{ vars.KEYCLOAK_USER_02 }},keycloak_user_03=${{ vars.KEYCLOAK_USER_03 }},keycloak_password=${{ secrets.KEYCLOAK_PASSWORD }}
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: cypress-artifacts
+          path: |-
+            /home/runner/work/nr-compliance-enforcement/nr-compliance-enforcement/frontend/cypress/videos/
+            /home/runner/work/nr-compliance-enforcement/nr-compliance-enforcement/frontend/cypress/screenshots/


### PR DESCRIPTION
Run Playwright before Cypress to prevent data clashes.

# Description

both e2e test suites work on common data points in a common database, causing clashes in the tests. Running them sequentially aims to solve this issue. Since the intent is to complete the Cypress -> Playwright migration, the loss in CI runtime gains will eventually be re-realized.

Fixes # CE-1825

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-1177-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-1177-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)