### PR TITLE
feature: CE-1803 Create Party of interest

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -36,6 +36,7 @@ import { FEATURE_TYPES } from "@/app/constants/feature-flag-types";
 import { PartyView } from "./components/containers/parties/view";
 import Redirect from "./components/containers/pages/redirect";
 import config from "@/config";
+import PartyEdit from "./components/containers/parties/edit/party-edit";
 
 const App: FC = () => {
   const dispatch = useAppDispatch();
@@ -103,6 +104,14 @@ const App: FC = () => {
                 <Route
                   path="/party/:id"
                   element={<PartyView />}
+                />
+                <Route
+                  path="/party/create"
+                  element={<PartyEdit />}
+                />
+                <Route
+                  path="/party/:id/edit"
+                  element={<PartyEdit />}
                 />
                 {investigationsActive && (
                   <Route

--- a/frontend/src/app/components/containers/parties/edit/party-edit-header.tsx
+++ b/frontend/src/app/components/containers/parties/edit/party-edit-header.tsx
@@ -1,0 +1,76 @@
+import { FC } from "react";
+import { Button } from "react-bootstrap";
+import { Link } from "react-router-dom";
+
+interface PartyEditHeaderProps {
+  isEditMode?: boolean;
+  cancelButtonClick: () => void;
+  partyIdentifier?: string;
+  saveButtonClick: () => void;
+}
+
+export const PartyEditHeader: FC<PartyEditHeaderProps> = ({
+  cancelButtonClick,
+  saveButtonClick,
+  isEditMode = false,
+  partyIdentifier,
+}) => {
+  return (
+    <div className="comp-details-header">
+      <div className="comp-container">
+        {/* <!-- breadcrumb start --> */}
+        <div className="comp-complaint-breadcrumb">
+          <nav aria-label="breadcrumb">
+            <ol className="breadcrumb">
+              <li className="breadcrumb-item comp-nav-item-name-inverted">
+                <Link
+                  to=""
+                  onClick={() => window.alert("Navigating to the list of parties")}
+                >
+                  Parties
+                </Link>
+              </li>
+              <li
+                className="breadcrumb-item"
+                aria-current="page"
+              >
+                {isEditMode ? "Edit party" : "Create party"}
+              </li>
+            </ol>
+          </nav>
+        </div>
+        {/* <!-- breadcrumb end --> */}
+
+        <div className="comp-details-title-container">
+          <div className="comp-details-title-info">
+            <h1 className="comp-box-complaint-id">
+              {isEditMode && partyIdentifier ? (
+                <span>Party of interest #{partyIdentifier}</span>
+              ) : (
+                <span>{isEditMode ? "Edit party" : "Create party"} </span>
+              )}
+            </h1>
+          </div>
+          <div className="comp-header-actions">
+            <Button
+              id="details-screen-cancel-edit-button-top"
+              title={isEditMode ? "Cancel Edit Party" : "Cancel Create Party"}
+              variant="outline-light"
+              onClick={cancelButtonClick}
+            >
+              Cancel
+            </Button>
+            <Button
+              id="details-screen-save-button-top"
+              title="Save Party"
+              variant="outline-light"
+              onClick={saveButtonClick}
+            >
+              Save Changes
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/app/components/containers/parties/edit/party-edit.tsx
+++ b/frontend/src/app/components/containers/parties/edit/party-edit.tsx
@@ -1,0 +1,340 @@
+import { FC, useCallback, useMemo } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { useForm, useStore } from "@tanstack/react-form";
+import { z } from "zod";
+import { gql } from "graphql-request";
+import { PartyEditHeader } from "./party-edit-header";
+import { CompSelect } from "@components/common/comp-select";
+import { FormField } from "@components/common/form-field";
+import { useAppDispatch } from "@hooks/hooks";
+import { useGraphQLQuery } from "@graphql/hooks/useGraphQLQuery";
+import { useGraphQLMutation } from "@graphql/hooks/useGraphQLMutation";
+import { ToggleError, ToggleSuccess } from "@common/toast";
+import { openModal } from "@store/reducers/app";
+import { CANCEL_CONFIRM } from "@apptypes/modal/modal-types";
+import { PartyCreateInput, PartyUpdateInput } from "@/generated/graphql";
+import { CompInput } from "@/app/components/common/comp-input";
+
+const GET_PARTY = gql`
+  query GetParty($partyIdentifier: String!) {
+    party(partyIdentifier: $partyIdentifier) {
+      __typename
+      partyIdentifier
+      partyTypeCode
+      shortDescription
+      longDescription
+      createdDateTime
+      person {
+        personGuid
+        firstName
+        lastName
+      }
+      business {
+        businessGuid
+        name
+      }
+    }
+  }
+`;
+
+const GET_PARTY_TYPE_CODES = gql`
+  query GetPartyTypeCodes {
+    partyTypeCodes {
+      partyTypeCode
+      shortDescription
+      longDescription
+      displayOrder
+      activeIndicator
+    }
+  }
+`;
+
+const UPDATE_PARTY_MUTATION = gql`
+  mutation UpdateParty($partyIdentifier: String!, $input: PartyUpdateInput!) {
+    updateParty(partyIdentifier: $partyIdentifier, input: $input) {
+      partyIdentifier
+      partyTypeCode
+      shortDescription
+      longDescription
+      createdDateTime
+      person {
+        personGuid
+        firstName
+        lastName
+      }
+      business {
+        businessGuid
+        name
+      }
+    }
+  }
+`;
+
+const CREATE_PARTY_MUTATION = gql`
+  mutation CreateParty($input: PartyCreateInput!) {
+    createParty(input: $input) {
+      partyIdentifier
+      partyTypeCode
+      shortDescription
+      longDescription
+      createdDateTime
+      person {
+        personGuid
+        firstName
+        lastName
+      }
+      business {
+        businessGuid
+        name
+      }
+    }
+  }
+`;
+const PartyEdit: FC = () => {
+  const { id } = useParams<{ id?: string }>();
+  const navigate = useNavigate();
+  const isEditMode = !!id;
+  const dispatch = useAppDispatch();
+
+  const { data: partyData, isLoading } = useGraphQLQuery(GET_PARTY, {
+    queryKey: ["party", id],
+    variables: { partyIdentifier: id },
+    enabled: isEditMode,
+  });
+
+  const { data } = useGraphQLQuery(GET_PARTY_TYPE_CODES, {
+    queryKey: ["partyTypeCodes"],
+    enabled: true,
+  });
+
+  const partyTypeCodes = data?.partyTypeCodes
+    ?.sort((left: any, right: any) => left.displayOrder - right.displayOrder)
+    .map((code: any) => {
+      return {
+        value: code.partyTypeCode,
+        label: code.shortDescription,
+      };
+    });
+
+  const createPartyMutation = useGraphQLMutation(CREATE_PARTY_MUTATION, {
+    invalidateQueries: ["searchParties"],
+    onError: (error: any) => {
+      console.error("Error creating party:", error);
+      ToggleError("Failed to create party");
+    },
+    onSuccess: (data: any) => {
+      ToggleSuccess("Party created successfully");
+      navigate(`/party/${data.createParty.partyIdentifier}`);
+    },
+  });
+
+  const updatePartyMutation = useGraphQLMutation(UPDATE_PARTY_MUTATION, {
+    invalidateQueries: [["party", id], "searchParties"],
+    onSuccess: (data: any) => {
+      ToggleSuccess("Party updated successfully");
+      navigate(`/party/${id}`);
+    },
+    onError: (error: any) => {
+      console.error("Error updating party:", error);
+      ToggleError("Failed to update party");
+    },
+  });
+
+  const defaultValues = useMemo(() => {
+    if (isEditMode && partyData?.party) {
+      return {
+        partyType: partyData.party.partyTypeCode || "",
+        firstName: partyData.party.person?.firstName || "",
+        lastName: partyData.party.person?.lastName || "",
+        businessName: partyData.party.business?.name || "",
+      };
+    }
+    return {
+      partyType: null,
+      firstName: "",
+      lastName: "",
+      businessName: "",
+    };
+  }, [isEditMode, partyData]);
+
+  const form = useForm({
+    defaultValues,
+    onSubmit: async ({ value }) => {
+      if (isEditMode) {
+        const updateInput: PartyUpdateInput = {
+          partyTypeCode: value.partyType,
+          business: value.partyType === "CMP" ? { name: value.businessName } : null,
+          person: value.partyType === "PRS" ? { firstName: value.firstName, lastName: value.lastName } : null,
+        };
+
+        updatePartyMutation.mutate({
+          partyIdentifier: id,
+          input: updateInput,
+        });
+      } else {
+        const createInput: PartyCreateInput = {
+          partyTypeCode: value.partyType,
+          business: value.partyType === "CMP" ? { name: value.businessName } : null,
+          person: value.partyType === "PRS" ? { firstName: value.firstName, lastName: value.lastName } : null,
+        };
+
+        createPartyMutation.mutate({ input: createInput });
+      }
+    },
+  });
+
+  const partyTypeValue = useStore(form.store, (state) => state.values.partyType);
+
+  const navigateToPartyList = () => {
+    window.alert("Navigating to the party list view");
+  };
+
+  const confirmCancelChanges = useCallback(() => {
+    form.reset();
+
+    if (isEditMode && id) {
+      navigate(`/party/${id}`);
+    } else {
+      navigateToPartyList();
+    }
+  }, [navigate, isEditMode, id, form]);
+
+  const cancelButtonClick = useCallback(() => {
+    dispatch(
+      openModal({
+        modalSize: "md",
+        modalType: CANCEL_CONFIRM,
+        data: {
+          title: "Cancel changes?",
+          description: "Your changes will be lost.",
+          cancelConfirmed: confirmCancelChanges,
+        },
+      }),
+    );
+  }, [dispatch, confirmCancelChanges]);
+
+  const saveButtonClick = useCallback(() => {
+    form.handleSubmit();
+  }, [form]);
+
+  const isSubmitting = createPartyMutation.isPending || updatePartyMutation.isPending;
+  const isDisabled = isSubmitting || isLoading;
+
+  return (
+    <div className="comp-complaint-details">
+      <PartyEditHeader
+        cancelButtonClick={cancelButtonClick}
+        saveButtonClick={saveButtonClick}
+        isEditMode={isEditMode}
+        partyIdentifier={id}
+      />
+
+      <section className="comp-details-body comp-details-form comp-container">
+        <div className="comp-details-section-header">
+          <h2>Party Details</h2>
+        </div>
+
+        <form onSubmit={form.handleSubmit}>
+          <fieldset disabled={isDisabled}>
+            <FormField
+              form={form}
+              name="partyType"
+              label="Party Type"
+              required
+              validators={{ onChange: z.string().min(1, "Party type is required") }}
+              render={(field) => (
+                <CompSelect
+                  id="party-type-select"
+                  classNamePrefix="comp-select"
+                  className="comp-details-input"
+                  options={partyTypeCodes}
+                  value={partyTypeCodes?.find((opt: any) => opt.value === field.state.value)}
+                  onChange={(option) => field.handleChange(option?.value || "")}
+                  placeholder="Select party type"
+                  isClearable={true}
+                  showInactive={false}
+                  enableValidation={true}
+                  errorMessage={field.state.meta.errors?.[0]?.message || ""}
+                  isDisabled={isDisabled || isEditMode}
+                />
+              )}
+            />
+            {partyTypeValue === "PRS" && (
+              <>
+                <FormField
+                  form={form}
+                  name="firstName"
+                  label="First name"
+                  required
+                  validators={{ onChange: z.string().min(1, "First name is required") }}
+                  render={(field) => (
+                    <CompInput
+                      id="FirstName"
+                      divid=""
+                      type="input"
+                      inputClass="comp-form-control comp-details-input"
+                      defaultValue={field.state.value}
+                      error={field.state.meta.errors?.[0]?.message || ""}
+                      maxLength={10}
+                      onChange={(evt: any) => field.handleChange(evt?.target?.value || "")}
+                      placeholder="Enter first name..."
+                      disabled={isDisabled}
+                    />
+                  )}
+                />
+                <FormField
+                  form={form}
+                  name="lastName"
+                  label="Last name"
+                  required
+                  validators={{ onChange: z.string().min(1, "Last name is required") }}
+                  render={(field) => (
+                    <CompInput
+                      id="LastName"
+                      divid=""
+                      type="input"
+                      inputClass="comp-form-control comp-details-input"
+                      defaultValue={field.state.value}
+                      error={field.state.meta.errors?.[0]?.message || ""}
+                      maxLength={10}
+                      onChange={(evt: any) => field.handleChange(evt?.target?.value || "")}
+                      placeholder="Enter last name..."
+                      disabled={isDisabled}
+                    />
+                  )}
+                />
+              </>
+            )}
+            {partyTypeValue === "CMP" && (
+              <FormField
+                form={form}
+                name="businessName"
+                label="Name"
+                required
+                validators={{
+                  onChange: z.string().min(1, "Name is required"),
+                }}
+                render={(field) => (
+                  <CompInput
+                    id="businessName"
+                    divid=""
+                    type="input"
+                    inputClass="comp-form-control comp-details-input"
+                    value={field.state.value}
+                    error={field.state.meta.errors?.[0]?.message || ""}
+                    maxLength={50}
+                    onChange={(evt: any) => field.handleChange(evt?.target?.value || "")}
+                    placeholder="Enter name..."
+                    disabled={isDisabled}
+                  />
+                )}
+              />
+            )}
+          </fieldset>
+        </form>
+      </section>
+    </div>
+  );
+};
+
+export default PartyEdit;

--- a/frontend/src/app/components/containers/parties/view/party-view.tsx
+++ b/frontend/src/app/components/containers/parties/view/party-view.tsx
@@ -1,5 +1,5 @@
 import { FC } from "react";
-import { useParams } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import { PartyHeader } from "./party-header";
 import { useGraphQLQuery } from "@graphql/hooks";
 import { gql } from "graphql-request";
@@ -34,6 +34,7 @@ export type PartyParams = {
 
 export const PartyView: FC = () => {
   const { id = "" } = useParams<PartyParams>();
+  const navigate = useNavigate();
 
   const { data, isLoading } = useGraphQLQuery<{ party: Party }>(GET_PARTY, {
     queryKey: ["party", id],
@@ -44,7 +45,7 @@ export const PartyView: FC = () => {
   const partyData = data?.party;
 
   const editButtonClick = () => {
-    window.alert("Navigating to the party edit view");
+    navigate(`/party/${id}/edit`);
   };
 
   const displayName = () => {

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -84,6 +84,10 @@ export type Business = {
   name?: Maybe<Scalars['String']['output']>;
 };
 
+export type BusinessInput = {
+  name: Scalars['String']['input'];
+};
+
 export type CaseActivity = {
   __typename?: 'CaseActivity';
   activityType?: Maybe<CaseActivityTypeCode>;
@@ -555,6 +559,7 @@ export type Mutation = {
   createNote: ComplaintOutcome;
   createPark: Park;
   createParkArea: ParkArea;
+  createParty: Party;
   createPerson: Person;
   createPrevention: ComplaintOutcome;
   createReview: ComplaintOutcome;
@@ -575,6 +580,7 @@ export type Mutation = {
   updateNote: ComplaintOutcome;
   updatePark: Park;
   updateParkArea: ParkArea;
+  updateParty: Party;
   updatePerson: Person;
   updatePrevention: ComplaintOutcome;
   updateReview: ComplaintOutcome;
@@ -619,6 +625,11 @@ export type MutationcreateParkArgs = {
 
 export type MutationcreateParkAreaArgs = {
   input: ParkAreaInput;
+};
+
+
+export type MutationcreatePartyArgs = {
+  input: PartyCreateInput;
 };
 
 
@@ -725,6 +736,12 @@ export type MutationupdateParkAreaArgs = {
 };
 
 
+export type MutationupdatePartyArgs = {
+  input: PartyUpdateInput;
+  partyIdentifier: Scalars['String']['input'];
+};
+
+
 export type MutationupdatePersonArgs = {
   input: PersonInput;
   personGuid: Scalars['String']['input'];
@@ -817,6 +834,22 @@ export type Party = {
   partyTypeCode?: Maybe<Scalars['String']['output']>;
   person?: Maybe<Person>;
   shortDescription?: Maybe<Scalars['String']['output']>;
+};
+
+export type PartyCreateInput = {
+  business?: InputMaybe<BusinessInput>;
+  longDescription?: InputMaybe<Scalars['String']['input']>;
+  partyTypeCode: Scalars['String']['input'];
+  person?: InputMaybe<PersonInput>;
+  shortDescription?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type PartyUpdateInput = {
+  business?: InputMaybe<BusinessInput>;
+  longDescription?: InputMaybe<Scalars['String']['input']>;
+  partyTypeCode: Scalars['String']['input'];
+  person?: InputMaybe<PersonInput>;
+  shortDescription?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type PermitSite = {


### PR DESCRIPTION
# Description

This PR is the frontend code to allow a user to add a new party of interest and edit it

Fixes # (CE-1803)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Navigate to the party create view at:
- [ ] Select a party type: Person or Company and populate required input fields
- [ ] Click Save
- [ ] Check if party is saved successfully
- [ ] Repeat it for another party type
- [ ] On the party view page click Edit button
- [ ] Check if you can edit the party and save data
- [ ] Check if validation that prevent saving party when not all required fields are populated works.


## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
