### PR TITLE
fix: add version support via vite

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
+import fs from "fs";
+import packageJson from "./package.json";
 import { fileURLToPath } from "url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -24,6 +26,25 @@ export default defineConfig({
             },
           ],
         };
+      },
+    },
+    {
+      name: "update-manifest-version", // Custom plugin to update the manifest version
+      apply: "build",
+      writeBundle() {
+        const manifestPath = path.resolve(__dirname, "dist/manifest.json");
+
+        const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
+
+        // If the version property doesn't exist, initialize it
+        if (!manifest.version) {
+          manifest.version = `${packageJson.version}.${Date.now()}`;
+        } else {
+          // If the version exists, just update it
+          manifest.version = `${packageJson.version}.${Date.now()}`;
+        }
+        // Write the updated version back to the manifest file
+        fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
       },
     },
   ],


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Please provide a summary of the change and the issue fixed. Please include relevant context. List dependency changes.

Fixes # CE-1870

When migrating from CRA to Vite, the functionality that updates the version number in the manifest.json file was lost.   This restores this functionality.

Unlike CRA Vite uses hot reloading in local development.   This means that the entire bundling (which sets the version number) won't be run locally (at least not without a unique process to the update the manifest file that is only used in development) - this could be done in the future if required.  

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
