### PR TITLE
fix: CE-1719 Tweaks

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nr-compliance-enforcement",
-  "version": "2.0.62",
+  "version": "2.0.63",
   "description": "BCGov devops quickstart. For reference, testing and new projects.",
   "main": "index.js",
   "scripts": {

--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -17,14 +17,14 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 2.0.62
+version: 2.0.63
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes
 
-appVersion: 2.0.62
+appVersion: 2.0.63
 
 dependencies:
   - name: postgresql

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nr-sample-natcomplaints",
-  "version": "2.0.43",
+  "version": "2.0.61",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nr-sample-natcomplaints",
-      "version": "2.0.43",
+      "version": "2.0.61",
       "license": "Apache-2.0",
       "dependencies": {
         "@faker-js/faker": "^8.0.2",
@@ -92,7 +92,7 @@
         "pure-react-carousel": "^1.30.1",
         "react": "^18.2.0",
         "react-bootstrap": "^2.7.4",
-        "react-bootstrap-typeahead": "^6.3.4",
+        "react-bootstrap-typeahead": "^6.4.1",
         "react-chartjs-2": "^5.2.0",
         "react-collapsed": "^4.0.2",
         "react-collapsible": "^2.10.0",
@@ -18727,7 +18727,6 @@
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/react-bootstrap-typeahead/-/react-bootstrap-typeahead-6.4.1.tgz",
       "integrity": "sha512-Uw3vB4H5WGmnOHdQvqVKkOyzzxZ5NUrsd/HKhGnbta5+bEI99xyghr9Y0tVLcMoQZ9Wxpe4g/LJl75L/FsHq/A==",
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.14.6",
         "@floating-ui/react-dom": "^2.1.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -87,7 +87,7 @@
     "pure-react-carousel": "^1.30.1",
     "react": "^18.2.0",
     "react-bootstrap": "^2.7.4",
-    "react-bootstrap-typeahead": "^6.3.4",
+    "react-bootstrap-typeahead": "^6.4.1",
     "react-chartjs-2": "^5.2.0",
     "react-collapsed": "^4.0.2",
     "react-collapsible": "^2.10.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nr-sample-natcomplaints",
   "type": "module",
-  "version": "2.0.62",
+  "version": "2.0.63",
   "private": true,
   "dependencies": {
     "@faker-js/faker": "^8.0.2",

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
@@ -245,10 +245,7 @@ export const ComplaintDetailsEdit: FC = () => {
   }, [coordinates]);
 
   useEffect(() => {
-    //getLinkedComplaints api only applies for hwcr, for now
-    if (complaintType === "HWCR") {
-      dispatch(getLinkedComplaints(id));
-    }
+    dispatch(getLinkedComplaints(id));
   }, [dispatch, id, complaintType, details]);
 
   //-- events
@@ -798,7 +795,6 @@ export const ComplaintDetailsEdit: FC = () => {
           <LinkedComplaintList
             id={id}
             linkedComplaintData={linkedComplaintData}
-            canUnlink={status !== "Closed"}
           />
         )}
         {readOnly && <WebEOCComplaintUpdateList complaintIdentifier={id} />}

--- a/frontend/src/app/components/containers/complaints/details/complaint-header.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-header.tsx
@@ -257,7 +257,6 @@ export const ComplaintHeader: FC<ComplaintHeaderProps> = ({
         as="button"
         id="link-complaint-button"
         onClick={openLinkComplaintModal}
-        disabled={status === "Closed"}
       >
         <i className="bi bi-link-45deg"></i>
         <span>Link complaint</span>

--- a/frontend/src/app/components/containers/complaints/details/linked-complaint-list.tsx
+++ b/frontend/src/app/components/containers/complaints/details/linked-complaint-list.tsx
@@ -22,7 +22,7 @@ type Props = {
   canUnlink?: boolean;
 };
 
-export const LinkedComplaintList: FC<Props> = ({ linkedComplaintData, id, canUnlink }) => {
+export const LinkedComplaintList: FC<Props> = ({ linkedComplaintData, id, canUnlink = true }) => {
   const dispatch = useAppDispatch();
   const [expandedComplaints, setExpandedComplaints] = useState<Record<string, boolean>>({});
   const [viewMoreDuplicates, setViewMoreDuplicates] = useState<boolean>(false);

--- a/frontend/src/app/components/containers/complaints/list-items/complaint-action-items.tsx
+++ b/frontend/src/app/components/containers/complaints/list-items/complaint-action-items.tsx
@@ -153,10 +153,7 @@ export const ComplaintActionItems: FC<Props> = ({
             Quick close
           </Dropdown.Item>
         )}
-        <Dropdown.Item
-          onClick={openLinkComplaintModal}
-          disabled={complaint_status === "CLOSED"}
-        >
+        <Dropdown.Item onClick={openLinkComplaintModal}>
           <i
             className="bi bi-link-45deg"
             id="link-complaint-icon"

--- a/frontend/src/app/components/containers/complaints/outcomes/hwcr-assessment/hwcr-assessment-form.tsx
+++ b/frontend/src/app/components/containers/complaints/outcomes/hwcr-assessment/hwcr-assessment-form.tsx
@@ -409,15 +409,11 @@ export const HWCRAssessmentForm: FC<Props> = ({
         );
         return true;
       }
-
-      const duplicateComplaints =
-        linkedComplaintData?.filter((complaint: any) => complaint.link_type === "DUPLICATE") || [];
-
       if (
         selectedActionRequired?.value === "No" &&
         selectedJustification?.value === "DUPLICATE" &&
-        duplicateComplaints.length > 0 &&
-        !duplicateComplaints[0].parent
+        linkedComplaintData?.length > 0 &&
+        !linkedComplaintData[0].parent
       ) {
         setJustificationRequiredErrorMessage(
           "Other complaints are linked to this complaint. This complaint cannot be closed as a duplicate.",

--- a/frontend/src/app/components/modal/instances/link-complaint-modal.tsx
+++ b/frontend/src/app/components/modal/instances/link-complaint-modal.tsx
@@ -103,6 +103,9 @@ export const LinkComplaintModal: FC<LinkComplaintModalProps> = ({ close, submit 
     if (text.length > 0) {
       setHintText("");
     }
+    if (text.length >= 2) {
+      handleSearch(text);
+    }
   };
 
   const handleSearch = async (query: string) => {
@@ -193,10 +196,11 @@ export const LinkComplaintModal: FC<LinkComplaintModalProps> = ({ close, submit 
                 labelKey="id"
                 minLength={2}
                 onInputChange={handleInputChange}
-                onSearch={handleSearch}
+                onSearch={() => {}}
                 onChange={handleComplaintSelect}
                 onFocus={() => setIsFocused(true)}
                 onBlur={() => setIsFocused(false)}
+                useCache={false}
                 selected={selectedComplaint ? [selectedComplaint] : []}
                 filterBy={() => true}
                 isLoading={isLoading}

--- a/webeoc/package.json
+++ b/webeoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webeoc",
-  "version": "2.0.62",
+  "version": "2.0.63",
   "description": "",
   "author": "",
   "private": true,


### PR DESCRIPTION
- Allows linking actions on closed complaints
- Fixes search component not searching on copy/paste if a complaint has already been selected
- Fixes linked complaints not being fetched for complaint types other than HWCR
- Fixes warning not showing when linking to a complaint that is already linked

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-compliance-enforcement-1223-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-compliance-enforcement-1223-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-compliance-enforcement/actions/workflows/merge.yml)