### PR TITLE
fix: CE-1936 Fix unauthorized redirects

### DIFF
--- a/frontend/src/app/common/api.ts
+++ b/frontend/src/app/common/api.ts
@@ -62,6 +62,10 @@ axios.interceptors.response.use(
   (error: AxiosError) => {
     const { response } = error;
 
+    if (response && response.status === STATUS_CODES.Unauthorized) {
+      window.location.href = "/not-authorized";
+    }
+
     if (response && response.status === STATUS_CODES.Forbiden) {
       ToggleError("User is not authorized to perform this action");
     }

--- a/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
+++ b/frontend/src/app/components/containers/complaints/details/complaint-details-edit.tsx
@@ -95,6 +95,10 @@ export const ComplaintDetailsEdit: FC = () => {
     dispatch(getCaseFile(id));
   }, [id, dispatch, allOfficers]);
 
+  useEffect(() => {
+    dispatch(getComplaintById(id, complaintType));
+  }, [id, complaintType, dispatch]);
+
   //-- selectors
   const data = useAppSelector(selectComplaint);
   const privacyDropdown = useAppSelector(selectPrivacyDropdown);
@@ -225,12 +229,6 @@ export const ComplaintDetailsEdit: FC = () => {
       dispatch(setLinkedComplaints([]));
     };
   }, [dispatch]);
-
-  useEffect(() => {
-    if (id && (!data || data.id !== id)) {
-      dispatch(getComplaintById(id, complaintType));
-    }
-  }, [id, parkGuid, complaintType, data, dispatch]);
 
   useEffect(() => {
     const incidentDateTimeObject = incidentDateTime ? new Date(incidentDateTime) : null;

--- a/frontend/src/app/store/reducers/complaint-outcome-thunks.ts
+++ b/frontend/src/app/store/reducers/complaint-outcome-thunks.ts
@@ -64,8 +64,7 @@ export const findCase =
       const response = await get<ComplaintOutcomeDto>(dispatch, parameters);
       return response?.complaintOutcomeGuid;
     } catch (error) {
-      console.warn("Unauthorized resource request", error);
-      window.location.href = "/not-authorized";
+      console.warn(`Something went wrong requesting outcome identifier for ${complaintIdentifier}`, error);
     }
   };
 
@@ -93,8 +92,7 @@ export const getCaseFile =
         dispatch(setPreventions([]));
       }
     } catch (error) {
-      console.warn("Unauthorized resource request", error);
-      window.location.href = "/not-authorized";
+      console.warn(`Something went wrong requesting outcome for ${complaintIdentifier}`, error);
     }
   };
 

--- a/frontend/src/app/store/reducers/complaints.ts
+++ b/frontend/src/app/store/reducers/complaints.ts
@@ -695,7 +695,6 @@ export const getComplaintById =
       dispatch(setComplaint({ ...response }));
     } catch (error) {
       dispatch(setComplaint(null));
-      window.location.href = "/not-authorized";
     }
   };
 


### PR DESCRIPTION
Handle redirects for unauthorized errors in an axios interceptor

# Description

Redirects to the not authorized page were being handled in a catch all, resulting in incorrect redirects. This moves the handling of 401s to the axios interceptor level.

Fixes # [(issue)](https://env-ceds.atlassian.net/jira/software/c/projects/CE/boards/4?selectedIssue=CE-1936)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Verified COS can still view COS ERS complaints
- [ ] Confirmed non COS users cannot view COS ERS complaints
- [ ] Confirmed sector view behaves the same as before
- [ ] Stopped local CM backend and confirmed that the complaint details page no longer redirects under those circumstances


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
