### PR TITLE
feat: CE-1937 bucket versioning for attachments

### DIFF
--- a/frontend/src/app/store/reducers/attachments.ts
+++ b/frontend/src/app/store/reducers/attachments.ts
@@ -211,6 +211,14 @@ export const saveAttachments =
       return;
     }
 
+    const params = generateApiParameters(`${config.COMS_URL}/object?bucketId=${config.COMS_BUCKET}`);
+
+    let historicalComplaintAttachments = await get<Array<COMSObject>>(dispatch, params, {
+      "x-amz-meta-complaint-id": complaint_identifier,
+      "x-amz-meta-is-thumb": "N",
+      "x-amz-meta-attachment-type": attachmentType,
+    });
+
     for (const attachment of attachments) {
       const header = {
         "x-amz-meta-complaint-id": complaint_identifier,
@@ -223,7 +231,10 @@ export const saveAttachments =
       };
 
       try {
-        const parameters = generateApiParameters(`${config.COMS_URL}/object?bucketId=${config.COMS_BUCKET}`);
+        const existingAttachment = historicalComplaintAttachments.find((item) => item.name === attachment.name);
+        const parameters = existingAttachment
+          ? generateApiParameters(`${config.COMS_URL}/object/${existingAttachment.id}`)
+          : generateApiParameters(`${config.COMS_URL}/object?bucketId=${config.COMS_BUCKET}`);
         const response = await putFile<COMSObject>(dispatch, parameters, header, attachment);
         switch (attachmentType) {
           case AttachmentEnum.COMPLAINT_ATTACHMENT:

--- a/frontend/src/app/store/reducers/attachments.ts
+++ b/frontend/src/app/store/reducers/attachments.ts
@@ -220,18 +220,19 @@ export const saveAttachments =
     });
 
     for (const attachment of attachments) {
+      const attachmentName = encodeURIComponent(
+        injectComplaintIdentifierToFilename(attachment.name, complaint_identifier, attachmentType),
+      );
+      const existingAttachment = historicalComplaintAttachments.find((item) => item.name === attachmentName);
       const header = {
         "x-amz-meta-complaint-id": complaint_identifier,
         "x-amz-meta-is-thumb": "N",
         "x-amz-meta-attachment-type": attachmentType,
-        "Content-Disposition": `attachment; filename="${encodeURIComponent(
-          injectComplaintIdentifierToFilename(attachment.name, complaint_identifier, attachmentType),
-        )}"`,
+        "Content-Disposition": `attachment; filename="${attachmentName}"`,
         "Content-Type": attachment?.type,
       };
 
       try {
-        const existingAttachment = historicalComplaintAttachments.find((item) => item.name === attachment.name);
         const parameters = existingAttachment
           ? generateApiParameters(`${config.COMS_URL}/object/${existingAttachment.id}`)
           : generateApiParameters(`${config.COMS_URL}/object?bucketId=${config.COMS_BUCKET}`);

--- a/frontend/src/app/store/reducers/attachments.ts
+++ b/frontend/src/app/store/reducers/attachments.ts
@@ -114,7 +114,8 @@ export const getAttachments =
   (complaint_identifier: string, attachmentType: AttachmentEnum): AppThunk =>
   async (dispatch) => {
     try {
-      const parameters = generateApiParameters(`${config.COMS_URL}/object?bucketId=${config.COMS_BUCKET}`);
+      const parameters = generateApiParameters(`${config.COMS_URL}/object?bucketId=${config.COMS_BUCKET}&latest=true`);
+
       let response = await get<Array<COMSObject>>(dispatch, parameters, {
         "x-amz-meta-complaint-id": complaint_identifier,
         "x-amz-meta-is-thumb": "N",


### PR DESCRIPTION
Handle bucket versioning being enabled on attachment bucket

# Description

This PR contains the changes needed to handle S3 bucket versioning being enabled on our COMS buckets for attachments. Without specifying to only get the latest versions of objects when versioning is enabled, deleted objects are returned resulting in ghosts in the UI. This functionality checks to see if an attachment with the same name already exists on this complaint, and if it does, treats it as an update rather than a create. Without this, the call errors. 

With this PR and versioning enabled, if you were to add a file to the complaint with the same name as an existing attachment, it will overwrite that attachment.

Fixes # [(issue)](https://env-ceds.atlassian.net/jira/software/c/projects/CE/boards/4?selectedIssue=CE-1937)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
